### PR TITLE
refactor: make titles multiline, truncate long titles & fix tests

### DIFF
--- a/apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts
@@ -338,7 +338,7 @@ context('GenericTemplates tests', () => {
 
       cy.contains(genericTemplateQuestions[0]);
 
-      cy.get('[data-cy=title-input] input').clear();
+      cy.get('[data-cy=title-input] textarea').first().clear();
 
       cy.get(
         '[data-cy=genericTemplate-declaration-modal] [data-cy=save-and-continue-button]'
@@ -346,10 +346,14 @@ context('GenericTemplates tests', () => {
 
       cy.contains('This is a required field');
 
-      cy.get('[data-cy=title-input] input')
+      const longTitle = faker.lorem.paragraph(5);
+
+      cy.get('[data-cy=title-input] textarea')
+        .first()
         .clear()
-        .type(genericTemplateTitle)
-        .should('have.value', genericTemplateTitle);
+        .type(longTitle)
+        .should('have.value', longTitle)
+        .blur();
 
       cy.get(
         '[data-cy=genericTemplate-declaration-modal] [data-cy=save-and-continue-button]'
@@ -474,7 +478,8 @@ context('GenericTemplates tests', () => {
 
       cy.contains(addButtonLabel[0]).click();
 
-      cy.get('[data-cy=title-input] input')
+      cy.get('[data-cy=title-input] textarea')
+        .first()
         .clear()
         .type(genericTemplateTitle)
         .should('have.value', genericTemplateTitle)

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/GenericTemplate/GenericTemplateContainer.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/GenericTemplate/GenericTemplateContainer.tsx
@@ -15,6 +15,7 @@ import {
   QuestionarySubmissionModel,
 } from 'models/questionary/QuestionarySubmissionState';
 import useEventHandlers from 'models/questionary/useEventHandlers';
+import { truncateString } from 'utils/truncateString';
 
 export interface GenericTemplateContextType extends QuestionaryContextType {
   state: GenericTemplateSubmissionState | null;
@@ -63,7 +64,9 @@ export function GenericTemplateContainer(props: {
 
   return (
     <QuestionaryContext.Provider value={{ state, dispatch }}>
-      <Questionary title={state.genericTemplate.title || props.title} />
+      <Questionary
+        title={truncateString(state.genericTemplate.title || props.title, 30)}
+      />
     </QuestionaryContext.Provider>
   );
 }

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/GenericTemplateBasis/QuestionaryComponentGenericTemplateBasis.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/GenericTemplateBasis/QuestionaryComponentGenericTemplateBasis.tsx
@@ -54,6 +54,7 @@ function QuestionaryComponentGenericTemplateBasis(props: BasicComponentProps) {
           },
         }}
         required
+        multiline
         fullWidth
         component={TextFieldNoSubmit}
         data-cy="title-input"


### PR DESCRIPTION
## Description
Make the publication title field multiline to accommodate for longer titles.
Titles that contain more than 30 characters are truncated, so that it fits within the dialogue box.

<!--- Describe your changes in detail -->

## Motivation and Context
- The field accepts 500 characters, so increasing the character limit was not necessary. Longer titles can fit into the text field by being typed on multiple lines.
- Additionally, Titles that are very long do not fit inside of the dialogue box properly.
- Some tests needed to be fixed as changes made to ensure titles could be typed on multiple lines broke some tests.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- Ensured that the user can type on multiple lines through manual testing.
- Added check to test to ensure that long titles are truncated after entry.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
Part of UserOfficeProject/user-office-project-issue-tracker#239
<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
