### PR TITLE
 add external logout and fix login with token

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -287,6 +287,7 @@ jobs:
           EMAIL_TEMPLATE_PATH: /config/emails/
           EMAIL_FOOTER_IMAGE_PATH: /config/logos/STFC-Logo-small.png
           EXTERNAL_AUTH_LOGIN_URL: http://localhost:9003/auth/Login.aspx
+          EXTERNAL_AUTH_LOGOUT_URL: http://localhost:9003/auth/Login.aspx
           EXTERNAL_AUTH_SERVICE_URL: http://localhost:1080/ws/UserOfficeWebService?wsdl
           ANTIVIRUS_HOST: clam-antivirus
           ANTIVIRUS_PORT: 3310

--- a/apps/user-office-backend/src/config/stfc/configureSTFCEnvironment.ts
+++ b/apps/user-office-backend/src/config/stfc/configureSTFCEnvironment.ts
@@ -78,6 +78,10 @@ async function enableDefaultStfcFeatures() {
     settingsValue: process.env.EXTERNAL_AUTH_LOGIN_URL,
   });
   await db.updateSettings({
+    settingsId: SettingsId.EXTERNAL_AUTH_LOGOUT_URL,
+    settingsValue: process.env.EXTERNAL_AUTH_LOGOUT_URL,
+  });
+  await db.updateSettings({
     settingsId: SettingsId.PROFILE_PAGE_LINK,
     settingsValue: process.env.PROFILE_PAGE_LINK,
   });

--- a/apps/user-office-frontend/src/components/user/ExternalAuth.tsx
+++ b/apps/user-office-frontend/src/components/user/ExternalAuth.tsx
@@ -146,7 +146,8 @@ function ExternalAuth() {
     setView(<LoadingMessage />);
 
     const errorDescription = urlQueryParams.error_description;
-    const authorizationCode = urlQueryParams.sessionid ?? urlQueryParams.code;
+    const authorizationCode =
+      urlQueryParams.sessionid ?? urlQueryParams.code ?? urlQueryParams.token;
 
     if (errorDescription) {
       handleError(errorDescription);
@@ -163,6 +164,7 @@ function ExternalAuth() {
     urlQueryParams.code,
     urlQueryParams.error_description,
     urlQueryParams.sessionid,
+    urlQueryParams.token,
   ]);
 
   return View;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This will fix current login problem in develop and add external logout url for STFC

## Motivation and Context
The current develop branch don't login when using an external token and also the external logout url must be set for users to be able to successfully logout

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->
.github/workflows/test-build.yml
apps/user-office-backend/src/config/stfc/configureSTFCEnvironment.ts
apps/user-office-frontend/src/components/user/ExternalAuth.tsx

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->
https://github.com/isisbusapps/docker-orchestration/pull/315

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
