### PR TITLE
Added a new filter to trigger call ended event

### DIFF
--- a/apps/user-office-backend/src/asyncJobs/jobs/checkAllCallsEnded.ts
+++ b/apps/user-office-backend/src/asyncJobs/jobs/checkAllCallsEnded.ts
@@ -9,7 +9,7 @@ const checkCallsEnded = async (dataSource: CallDataSource) => {
   const updatedCalls = [];
   try {
     const notEndedCalls = await dataSource.getCalls({
-      isEnded: false,
+      isCallEndedByEvent: false,
     });
 
     const currentDate = new Date();

--- a/apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
@@ -103,6 +103,12 @@ export default class PostgresCallDataSource implements CallDataSource {
       query.where('call_sep_review_ended', false);
     }
 
+    if (filter?.isCallEndedByEvent === true) {
+      query.where('call_ended', true);
+    } else if (filter?.isCallEndedByEvent === false) {
+      query.where('call_ended', false);
+    }
+
     return query.then((callDB: CallRecord[]) =>
       callDB.map((call) => createCallObject(call))
     );

--- a/apps/user-office-backend/src/resolvers/queries/CallsQuery.ts
+++ b/apps/user-office-backend/src/resolvers/queries/CallsQuery.ts
@@ -28,6 +28,9 @@ export class CallsFilter {
 
   @Field(() => Boolean, { nullable: true })
   public isSEPReviewEnded?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  public isCallEndedByEvent?: boolean;
 }
 
 @Resolver()

--- a/apps/user-office-frontend/src/generated/sdk.ts
+++ b/apps/user-office-frontend/src/generated/sdk.ts
@@ -172,6 +172,7 @@ export type CallResponseWrap = {
 export type CallsFilter = {
   isActive?: InputMaybe<Scalars['Boolean']>;
   isActiveInternal?: InputMaybe<Scalars['Boolean']>;
+  isCallEndedByEvent?: InputMaybe<Scalars['Boolean']>;
   isEnded?: InputMaybe<Scalars['Boolean']>;
   isEndedInternal?: InputMaybe<Scalars['Boolean']>;
   isReviewEnded?: InputMaybe<Scalars['Boolean']>;


### PR DESCRIPTION
Closes: [#714](https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/714)

We added a new filter to replace one that had been modified in another PR. This now correctly updates the call_ended field in postgres.