### PR TITLE
Update the logout function calling older in user context

### DIFF
--- a/apps/user-office-frontend/src/context/UserContextProvider.tsx
+++ b/apps/user-office-frontend/src/context/UserContextProvider.tsx
@@ -199,8 +199,8 @@ export const UserContextProvider: React.FC = (props): JSX.Element => {
           const logoutUrl = settingsContext.settingsMap.get(
             SettingsId.EXTERNAL_AUTH_LOGOUT_URL
           )?.settingsValue;
-          dispatch({ type: ActionType.LOGOFFUSER, payload: null });
           clearSession();
+          dispatch({ type: ActionType.LOGOFFUSER, payload: null });
           if (logoutUrl) {
             window.location.assign(logoutUrl);
           }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
When a user logout in stfc the system will still make calls to the backend creating invalid token logs.This is shown by the below screenshot.



## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To get ready of unnecessary log failures. 

## How Has This Been Tested
Manually tested on local dev

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
Fix the following errors from being created.

![Logout log errors](https://user-images.githubusercontent.com/71100224/196719405-2ad7abd1-a45e-42cc-ba70-7b18cfbbb3ce.png)

## Changes
The following file was updated.
apps/user-office-frontend/src/context/UserContextProvider.tsx
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->



## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
