### PR TITLE
refactor: Cleanup the react-cookie and cookie-parser. Use only express-jwt in all the requests.

### DIFF
--- a/apps/user-office-backend/docker-compose.yml
+++ b/apps/user-office-backend/docker-compose.yml
@@ -1,18 +1,6 @@
 version: "3.1"
 
 services:
-  # used to proxy the scheduler UI FE and BE requests to the right container
-  # Scheduler FE is accessible on localhost:33000/
-  # API gateway is accessible on localhost:33000/gateway
-  scheduler-proxy:
-    image: traefik:1.7 # The official Traefik docker image
-    command: --api --docker # Enables the web UI and tells Traefik to listen to docker
-    ports:
-      - "33000:80" # The HTTP port
-      - "8080:8080" # The Web UI (enabled by --api)
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-
   duo-cron-job:
     image: dmsc/duo-cron-job:develop
     environment:

--- a/apps/user-office-backend/index.ts
+++ b/apps/user-office-backend/index.ts
@@ -1,5 +1,4 @@
 import { logger } from '@user-office-software/duo-logger';
-import cookieParser from 'cookie-parser';
 import express from 'express';
 import 'reflect-metadata';
 import { container } from 'tsyringe';
@@ -22,7 +21,6 @@ async function bootstrap() {
   const app = express();
 
   app
-    .use(cookieParser())
     .use(authorization())
     .use(files())
     .use(factory())

--- a/apps/user-office-backend/package-lock.json
+++ b/apps/user-office-backend/package-lock.json
@@ -25,7 +25,6 @@
         "bluebird": "^3.7.2",
         "clamscan": "^2.1.2",
         "class-validator": "^0.13.1",
-        "cookie-parser": "^1.4.6",
         "cron": "^1.8.2",
         "dotenv": "^14.3.2",
         "email-templates": "^8.0.9",
@@ -3926,26 +3925,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
-    },
-    "node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-parser": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-      "dependencies": {
-        "cookie": "0.4.1",
-        "cookie-signature": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
@@ -15208,20 +15187,6 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         }
-      }
-    },
-    "cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-    },
-    "cookie-parser": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-      "requires": {
-        "cookie": "0.4.1",
-        "cookie-signature": "1.0.6"
       }
     },
     "cookie-signature": {

--- a/apps/user-office-backend/package.json
+++ b/apps/user-office-backend/package.json
@@ -49,7 +49,6 @@
     "bluebird": "^3.7.2",
     "clamscan": "^2.1.2",
     "class-validator": "^0.13.1",
-    "cookie-parser": "^1.4.6",
     "cron": "^1.8.2",
     "dotenv": "^14.3.2",
     "email-templates": "^8.0.9",

--- a/apps/user-office-backend/src/middlewares/factory.ts
+++ b/apps/user-office-backend/src/middlewares/factory.ts
@@ -3,8 +3,6 @@ import express, { Request, Response, NextFunction } from 'express';
 
 import baseContext from '../buildContext';
 import { DownloadType } from '../factory/service';
-import { AuthJwtPayload } from '../models/User';
-import { verifyToken } from '../utils/jwt';
 import pdfDownload from './factory/pdf';
 import xlsxDownload from './factory/xlsx';
 
@@ -52,7 +50,10 @@ export default function factory() {
   return express.Router().use(
     '/download',
     (req, res, next) => {
-      const decoded = verifyToken<AuthJwtPayload>(req.cookies.token);
+      const decoded = req.user;
+      if (!decoded) {
+        return res.status(401).send('Unauthorized');
+      }
 
       baseContext.queries.user
         .getAgent(decoded.user.id)

--- a/apps/user-office-frontend-e2e/cypress/integration/generalSeps.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/generalSeps.ts
@@ -149,7 +149,15 @@ context('General scientific evaluation panel tests', () => {
     it('Should be able to download SEP as Excel file', () => {
       cy.contains('SEPs').click();
 
-      cy.request('GET', '/download/xlsx/sep/1/call/1').then((response) => {
+      const token = window.localStorage.getItem('token');
+
+      cy.request({
+        url: '/download/xlsx/sep/1/call/1',
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      }).then((response) => {
         expect(response.headers['content-type']).to.be.equal(
           'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
         );

--- a/apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts
@@ -152,16 +152,14 @@ context('GenericTemplates tests', () => {
   };
 
   beforeEach(() => {
-    cy.getAndStoreFeaturesEnabled();
-    cy.resetDB();
-  });
-
-  // NOTE: Stop the web application and clearly separate the end-to-end tests by visiting the blank about page after each test.
-  // This prevents flaky tests with some long-running network requests from one test to finish in the next and unexpectedly update the app.
-  afterEach(() => {
+    // NOTE: Stop the web application and clearly separate the end-to-end tests by visiting the blank about page before each test.
+    // This prevents flaky tests with some long-running network requests from one test to finish in the next and unexpectedly update the app.
     cy.window().then((win) => {
       win.location.href = 'about:blank';
     });
+
+    cy.getAndStoreFeaturesEnabled();
+    cy.resetDB();
   });
 
   describe('Generic templates basic tests', () => {

--- a/apps/user-office-frontend-e2e/cypress/integration/proposal_administration.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/proposal_administration.ts
@@ -286,11 +286,13 @@ context('Proposal administration tests', () => {
       }
       cy.contains('Proposals').click();
 
+      const token = window.localStorage.getItem('token');
+
       cy.request({
         url: '/download/pdf/proposal/1',
         method: 'GET',
         headers: {
-          authorization: `Bearer ${Cypress.env('SVC_ACC_TOKEN')}`,
+          authorization: `Bearer ${token}`,
         },
       }).then((response) => {
         expect(response.headers['content-type']).to.be.equal('application/pdf');

--- a/apps/user-office-frontend-e2e/cypress/integration/samples.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/samples.ts
@@ -139,16 +139,14 @@ context('Samples tests', () => {
   };
 
   beforeEach(() => {
-    cy.getAndStoreFeaturesEnabled();
-    cy.resetDB(true);
-  });
-
-  // NOTE: Stop the web application and clearly separate the end-to-end tests by visiting the blank about page after each test.
-  // This prevents flaky tests with some long-running network requests from one test to finish in the next and unexpectedly update the app.
-  afterEach(() => {
+    // NOTE: Stop the web application and clearly separate the end-to-end tests by visiting the blank about page after each test.
+    // This prevents flaky tests with some long-running network requests from one test to finish in the next and unexpectedly update the app.
     cy.window().then((win) => {
       win.location.href = 'about:blank';
     });
+
+    cy.getAndStoreFeaturesEnabled();
+    cy.resetDB(true);
   });
 
   describe('Samples basic tests', () => {
@@ -429,6 +427,8 @@ context('Samples tests', () => {
           });
         }
       });
+
+      cy.login('officer');
     });
 
     it('Officer should able to delete proposal with sample', () => {
@@ -438,8 +438,6 @@ context('Samples tests', () => {
         questionId: createdSampleQuestionId,
         title: sampleTitle,
       });
-
-      cy.login('officer');
       cy.visit('/');
 
       cy.contains('Proposals').click();
@@ -463,8 +461,6 @@ context('Samples tests', () => {
         questionId: createdSampleQuestionId,
         title: sampleTitle,
       });
-
-      cy.login('officer');
       cy.visit('/');
 
       cy.contains('Proposals').click();
@@ -566,10 +562,7 @@ context('Samples tests', () => {
         questionId: createdSampleQuestionId,
         title: sampleTitle,
       });
-
       cy.submitProposal({ proposalPk: createdProposalPk });
-
-      cy.login('officer');
       cy.visit('/');
 
       cy.contains('Sample safety').click();
@@ -632,7 +625,6 @@ context('Samples tests', () => {
         questionId: createdSampleQuestionId,
         title: sampleTitle,
       });
-      cy.login('officer');
       cy.visit('/');
 
       cy.contains('Sample safety').click();
@@ -660,12 +652,19 @@ context('Samples tests', () => {
         questionId: createdSampleQuestionId,
         title: sampleTitle,
       });
-      cy.login('officer');
       cy.visit('/');
 
       cy.contains('Sample safety').click();
 
-      cy.request('GET', '/download/pdf/sample/1').then((response) => {
+      const token = window.localStorage.getItem('token');
+
+      cy.request({
+        url: '/download/pdf/sample/1',
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      }).then((response) => {
         expect(response.headers['content-type']).to.be.equal('application/pdf');
         expect(response.status).to.be.equal(200);
       });

--- a/apps/user-office-frontend-e2e/cypress/integration/settings.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/settings.ts
@@ -1085,8 +1085,6 @@ context('Settings tests', () => {
 
   describe('API access tokens tests', () => {
     const accessTokenName = faker.lorem.words(2);
-    beforeEach(() => {});
-
     let removedAccessToken: string;
 
     it('User Officer should be able to create api access token', () => {

--- a/apps/user-office-frontend/package-lock.json
+++ b/apps/user-office-frontend/package-lock.json
@@ -46,7 +46,6 @@
         "query-string": "^6.14.0",
         "react": "^17.0.2",
         "react-beautiful-dnd": "^13.1.0",
-        "react-cookie": "^4.1.1",
         "react-dom": "^17.0.2",
         "react-fast-compare": "^3.2.0",
         "react-router": "^5.3.1",
@@ -4697,11 +4696,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
-      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "node_modules/@types/eslint": {
       "version": "8.4.1",
@@ -15858,19 +15852,6 @@
         "react-dom": "^16.8.5 || ^17.0.0"
       }
     },
-    "node_modules/react-cookie": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
-      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.0.1",
-        "hoist-non-react-statics": "^3.0.0",
-        "universal-cookie": "^4.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0"
-      }
-    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -18625,15 +18606,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/universal-cookie": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
-      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
-      "dependencies": {
-        "@types/cookie": "^0.3.3",
-        "cookie": "^0.4.0"
       }
     },
     "node_modules/universalify": {
@@ -22945,11 +22917,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "@types/cookie": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
-      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "@types/eslint": {
       "version": "8.4.1",
@@ -31128,16 +31095,6 @@
         "use-memo-one": "^1.1.1"
       }
     },
-    "react-cookie": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
-      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
-      "requires": {
-        "@types/hoist-non-react-statics": "^3.0.1",
-        "hoist-non-react-statics": "^3.0.0",
-        "universal-cookie": "^4.0.0"
-      }
-    },
     "react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -33210,15 +33167,6 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
         "crypto-random-string": "^2.0.0"
-      }
-    },
-    "universal-cookie": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
-      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
-      "requires": {
-        "@types/cookie": "^0.3.3",
-        "cookie": "^0.4.0"
       }
     },
     "universalify": {

--- a/apps/user-office-frontend/package.json
+++ b/apps/user-office-frontend/package.json
@@ -46,7 +46,6 @@
     "query-string": "^6.14.0",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.1.0",
-    "react-cookie": "^4.1.1",
     "react-dom": "^17.0.2",
     "react-fast-compare": "^3.2.0",
     "react-router": "^5.3.1",

--- a/apps/user-office-frontend/src/context/DownloadContextProvider.tsx
+++ b/apps/user-office-frontend/src/context/DownloadContextProvider.tsx
@@ -208,6 +208,9 @@ export const DownloadContextProvider: React.FC = ({ children }) => {
     const controller = new AbortController();
     const req = crossFetch(generateLink(type, ids), {
       signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     })
       .then(async (response) => {
         await delayInTest();

--- a/apps/user-office-frontend/src/context/UserContextProvider.tsx
+++ b/apps/user-office-frontend/src/context/UserContextProvider.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import jwtDecode from 'jwt-decode';
 import PropTypes from 'prop-types';
-import React, { useCallback, useContext, useEffect } from 'react';
-import { useCookies } from 'react-cookie';
+import React, { useCallback, useContext } from 'react';
 
 import { Role, UserRole, SettingsId, UserJwt } from 'generated/sdk';
 import { useUnauthorizedApi } from 'hooks/common/useDataApi';
@@ -174,19 +173,8 @@ const reducer = (
 
 export const UserContextProvider: React.FC = (props): JSX.Element => {
   const [state, dispatch] = React.useReducer(reducer, initUserData);
-  const [, setCookie] = useCookies();
   const unauthorizedApi = useUnauthorizedApi();
   const settingsContext = useContext(SettingsContext);
-
-  useEffect(() => {
-    if (state.token) {
-      setCookie('token', state.token, {
-        path: '/',
-        secure: false,
-        sameSite: 'lax',
-      });
-    }
-  }, [setCookie, state.token]);
 
   checkLocalStorage(dispatch, state);
 


### PR DESCRIPTION
## Description

In order to use only one way of sending authorization headers I try to remove the use of cookies and parsing them in the backend.

## Motivation and Context

We were sending authorization headers with the jwt token and also including it in the cookies.

## How Has This Been Tested

- manual tests
- e2e tests

## Changes

It is mostly removing the cookies handling on the frontend and backend.

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
