### PR TITLE
fix: add ENVIRONMENT param

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -4,7 +4,9 @@ name: Build && Push
 # events but only for the develop branch
 on:
   push:
-    branches: [develop]
+    branches:
+      - develop
+      - staging
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -97,6 +99,7 @@ jobs:
             -F "variables[RUN_DEPLOY]=1" \
             -F "variables[BRANCH]=${{ steps.extract_branch.outputs.branch }}" \
             -F "variables[REPOSITORY]=${REPOSITORY#UserOfficeProject/}" \
+            -F "variables[ENVIRONMENT]=${{ steps.extract_branch.outputs.branch }}" \
             -o /dev/null \
             --silent \
             --write-out '%{http_code}' \

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -97,9 +97,8 @@ jobs:
             -F token="${{ secrets.GITLAB_TRIGGER_TOKEN }}" \
             -F ref=master \
             -F "variables[RUN_DEPLOY]=1" \
-            -F "variables[BRANCH]=${{ steps.extract_branch.outputs.branch }}" \
-            -F "variables[REPOSITORY]=${REPOSITORY#UserOfficeProject/}" \
             -F "variables[ENVIRONMENT]=${{ steps.extract_branch.outputs.branch }}" \
+            -F "variables[REPOSITORY]=${REPOSITORY#UserOfficeProject/}" \
             -o /dev/null \
             --silent \
             --write-out '%{http_code}' \


### PR DESCRIPTION
## Description

The `branch` param has been replaced with `environment`, as it better describes the purpose.