### PR TITLE
Hotfix: Update how stfc  email handler assign email templates

### DIFF
--- a/apps/user-office-backend/src/eventHandlers/email/stfcEmailHandler.ts
+++ b/apps/user-office-backend/src/eventHandlers/email/stfcEmailHandler.ts
@@ -51,24 +51,16 @@ export async function stfcEmailHandler(event: ApplicationEvent) {
 
         return;
       }
-
-      const instrument = instruments[0].name;
-
       let piEmailTemplate: string;
-
-      const isIsis = instrument === 'ISIS';
-
       const isRapidAccess =
-        isIsis && call?.shortCode?.toLowerCase().includes('rapid');
-
-      if (isIsis) {
-        piEmailTemplate = 'isis-proposal-submitted-pi';
-      } else if (isRapidAccess) {
-        piEmailTemplate = 'isis-rapid-proposal-submitted-pi';
+        call?.shortCode?.toLowerCase().includes('rapid') || false;
+      if (instruments[0].name === 'ISIS') {
+        piEmailTemplate = isRapidAccess
+          ? 'isis-rapid-proposal-submitted-pi'
+          : 'isis-proposal-submitted-pi';
       } else {
         piEmailTemplate = 'clf-proposal-submitted-pi';
       }
-
       const principalInvestigator = await userDataSource.getUser(
         event.proposal.proposerId
       );


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Principal Investigator receiving email with wrong details when submitting to ISIS Rapid because call not picking the right proposal submission email template.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Currently users submitting proposals to Rapid call are receiving email created from incorrect template.

## How Has This Been Tested
Manual tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/732

## Changes

<!--- What types of changes does your code introduce? In what place? -->
File updated: apps/user-office-backend/src/eventHandlers/email/stfcEmailHandler.ts

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [`x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
