### PR TITLE
fix: Fixing the state cleanup after modal close and cleaning some console warnings

### DIFF
--- a/apps/user-office-frontend-e2e/cypress/integration/settings.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/settings.ts
@@ -1085,8 +1085,6 @@ context('Settings tests', () => {
 
   describe('API access tokens tests', () => {
     const accessTokenName = faker.lorem.words(2);
-    beforeEach(() => {});
-
     let removedAccessToken: string;
 
     it('User Officer should be able to create api access token', () => {
@@ -1144,6 +1142,26 @@ context('Settings tests', () => {
             });
           });
         });
+
+      cy.get('[data-cy="submit"]').contains('Update').click();
+
+      cy.notification({
+        variant: 'success',
+        text: 'Api access token updated successfully!',
+      });
+
+      cy.get(
+        '[data-cy="api-access-tokens-table"] table tbody [aria-label="Edit"]'
+      ).should('have.length', 1);
+
+      cy.contains(accessTokenName).parent().find('[aria-label="Edit"]').click();
+
+      cy.get('[data-cy="close-modal-btn"]').click();
+
+      cy.get('[data-cy="create-new-entry"]').click();
+      cy.finishedLoading();
+
+      cy.get('#name').invoke('val').should('be.empty');
     });
 
     it('User Officer should be able to update api access token', () => {

--- a/apps/user-office-frontend/src/components/common/SuperMaterialTable.tsx
+++ b/apps/user-office-frontend/src/components/common/SuperMaterialTable.tsx
@@ -137,6 +137,8 @@ export function SuperMaterialTable<Entry extends EntryID>({
 
     if (shouldCloseAfterCreation) {
       setShow(false);
+    } else {
+      setEditObject(objectAdded);
     }
   };
 
@@ -152,8 +154,8 @@ export function SuperMaterialTable<Entry extends EntryID>({
     }
 
     if (shouldCloseAfterUpdate) {
-      setShow(false);
       setEditObject(null);
+      setShow(false);
     }
   };
 
@@ -195,14 +197,17 @@ export function SuperMaterialTable<Entry extends EntryID>({
         fullWidth={!!props.createModalSize}
         onClose={(_, reason) => {
           if (reason && reason == 'backdropClick') return;
-          setShow(false);
           setEditObject(null);
+          setShow(false);
         }}
       >
         <IconButton
           data-cy="close-modal-btn"
           className={classes.closeButton}
-          onClick={() => setShow(false)}
+          onClick={() => {
+            setEditObject(null);
+            setShow(false);
+          }}
         >
           <CloseIcon />
         </IconButton>

--- a/apps/user-office-frontend/src/hooks/call/useCallTemplates.ts
+++ b/apps/user-office-frontend/src/hooks/call/useCallTemplates.ts
@@ -20,14 +20,23 @@ export function useActiveTemplates(
   >(null);
 
   useEffect(() => {
+    let unmounted = false;
+
     api()
       .getTemplates({ filter: { group: groupId, isArchived: false } })
       .then((data) => {
+        if (unmounted) {
+          return;
+        }
         // if we need to include an extra template
         if (includeTemplate) {
           api()
             .getTemplate({ templateId: includeTemplate })
             .then(({ template }) => {
+              if (unmounted) {
+                return;
+              }
+
               if (template && data.templates) {
                 const alreadyContainsExtraTemplate = data.templates.find(
                   (t) => t.templateId === template.templateId
@@ -43,6 +52,10 @@ export function useActiveTemplates(
           setTemplates(data.templates);
         }
       });
+
+    return () => {
+      unmounted = true;
+    };
   }, [groupId, includeTemplate, api]);
 
   return { templates, setTemplates };


### PR DESCRIPTION
## Description

The close button on the create/update modal of SuperMaterialTable should also clean up the state of editing object. This wasn't the case and there was a bug after you try to edit some item, close the modal (using close button) and open the create item modal which shows the previously edited item instead of a clean creation state.

## Motivation and Context

In every place we used the SuperMaterialTable this problem with showing the last edited item was present.

## How Has This Been Tested

- manual tests
- e2e tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2879

## Changes

https://user-images.githubusercontent.com/6333063/199449929-d0f4fc56-5055-4825-9e72-9b64296d7419.mp4

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
