### PR TITLE
fix: Fix deprecated set-output warning in the actions

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -32,7 +32,7 @@ jobs:
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
 
           # set output variable accessible in the action
-          echo ::set-output name=branch::${BRANCH_NAME}
+          echo "branch=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
       # For debugging capture the selected branch
       - name: Extracted branch

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -45,7 +45,7 @@ jobs:
             FACTORY_TAG="${{ github.head_ref }}"
           fi
 
-          echo ::set-output name=FACTORY_TAG::${FACTORY_TAG}
+          echo "FACTORY_TAG=${FACTORY_TAG}" >> $GITHUB_OUTPUT
 
       - name: Resolved
         run: |


### PR DESCRIPTION
## Description

This PR is just fixing the deprecated set-output warnings in the github actions. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Motivation and Context

![Screenshot_19](https://user-images.githubusercontent.com/6333063/199522640-d4aee44e-0728-4a89-83ef-e7461f602740.png)
