### PR TITLE
fix: next button not working when updating call

### DIFF
--- a/apps/user-office-backend/src/auth/ProposalAuthorization.ts
+++ b/apps/user-office-backend/src/auth/ProposalAuthorization.ts
@@ -215,8 +215,9 @@ export class ProposalAuthorization {
     )?.shortCode;
     if (
       proposalStatus === ProposalStatusDefaultShortCodes.EDITABLE_SUBMITTED ||
-      proposalStatus ===
-        ProposalStatusDefaultShortCodes.EDITABLE_SUBMITTED_INTERNAL
+      (checkIfInternalEditable &&
+        proposalStatus ===
+          ProposalStatusDefaultShortCodes.EDITABLE_SUBMITTED_INTERNAL)
     ) {
       return true;
     }

--- a/apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
@@ -246,7 +246,7 @@ export default class PostgresCallDataSource implements CallDataSource {
               call_short_code: args.shortCode,
               start_call: args.startCall,
               end_call: args.endCall,
-              end_call_internal: args.endCallInternal || args.endCall,
+              end_call_internal: args.endCallInternal,
               reference_number_format: args.referenceNumberFormat,
               start_review: args.startReview,
               end_review: args.endReview,

--- a/apps/user-office-frontend-e2e/cypress/integration/calls.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/calls.ts
@@ -523,13 +523,13 @@ context('Calls tests', () => {
     });
 
     it('A user-officer should be able to edit a call', () => {
-      const { shortCode, startDate } = updatedCall;
-      const updatedCallStartDate = startDate
-        .plus({ days: 7 })
-        .toFormat(initialDBData.getFormats().dateTimeFormat);
-      const updatedCallEndDate = startDate
-        .plus({ days: 14 })
-        .toFormat(initialDBData.getFormats().dateTimeFormat);
+      const { shortCode, startDate, endDate } = updatedCall;
+      const updatedCallStartDate = startDate.toFormat(
+        initialDBData.getFormats().dateTimeFormat
+      );
+      const updatedCallEndDate = endDate.toFormat(
+        initialDBData.getFormats().dateTimeFormat
+      );
 
       const refNumFormat = '211{digits:5}';
 

--- a/apps/user-office-frontend/src/components/call/CreateUpdateCall.tsx
+++ b/apps/user-office-frontend/src/components/call/CreateUpdateCall.tsx
@@ -13,7 +13,6 @@ import {
   AllocationTimeUnits,
   UpdateCallInput,
   TemplateGroupId,
-  Scalars,
 } from 'generated/sdk';
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
 import { useActiveTemplates } from 'hooks/call/useCallTemplates';
@@ -57,18 +56,6 @@ const CreateUpdateCall: React.FC<CreateUpdateCallProps> = ({ call, close }) => {
   const currentDayEnd = DateTime.now()
     .setZone(timezone || undefined)
     .endOf('day');
-
-  const setInternalCallEnd = (
-    callEndDate: Scalars['DateTime'],
-    callEndInternalDate: Scalars['DateTime']
-  ) => {
-    const endCallDate = new Date(callEndDate);
-    const endCallInternalData = new Date(callEndInternalDate);
-
-    return endCallDate > endCallInternalData
-      ? callEndDate
-      : callEndInternalDate;
-  };
 
   const getDateTimeFromISO = (value: string) =>
     DateTime.fromISO(value, {
@@ -143,10 +130,6 @@ const CreateUpdateCall: React.FC<CreateUpdateCallProps> = ({ call, close }) => {
         initialValues={initialValues}
         onSubmit={async (values) => {
           if (call) {
-            values.endCallInternal = setInternalCallEnd(
-              values.endCall,
-              values.endCallInternal
-            );
             const data = await api({
               toastSuccessMessage: 'Call updated successfully!',
             }).updateCall(values as UpdateCallInput);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

When the user officer update call end date and click next button, the stepper is not moving to the next page.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
During a call user officer wants to be able to update call dates.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- manual tests
- e2e tests

## Fixes
 https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/729
 https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/730

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->
Files changed:

- apps/user-office-frontend/src/components/call/CallGeneralInfo.tsx
- apps/user-office-backend/src/auth/ProposalAuthorization.ts
- apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
- apps/user-office-frontend/src/components/call/CreateUpdateCall.tsx
- apps/user-office-frontend-e2e/cypress/integration/calls.ts

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->



## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
