### PR TITLE
fix: trigger Jenkins only on develop

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,7 +1,6 @@
 name: Build && Push
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the develop branch
+# Controls when the action will run
 on:
   push:
     branches:
@@ -10,11 +9,11 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  # List of jobs
   build:
-    # The type of runner that the job will run on
+    # The type of virtual machine that the job will run on
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [16.x]
@@ -59,9 +58,9 @@ jobs:
 
       - name: Install Node.js dependencies
         run: npm ci
-        
+
       - name: Set environment variables
-        run:  cp apps/user-office-frontend/example.development.env apps/user-office-frontend/.env
+        run: cp apps/user-office-frontend/example.development.env apps/user-office-frontend/.env
 
       - name: Generate SDK
         run: npm run generate:sdk
@@ -109,6 +108,7 @@ jobs:
             exit 1
           fi
 
+      # Trigger Jenkins pipeline
       - name: Trigger Jenkins
         if: ${{ steps.extract_branch.outputs.branch == 'develop' }} # Only trigger Jenkins for develop branch
         run: |

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -110,5 +110,6 @@ jobs:
           fi
 
       - name: Trigger Jenkins
+        if: ${{ steps.extract_branch.outputs.branch == 'develop' }} # Only trigger Jenkins for develop branch
         run: |
           curl -k -l -u ${{ secrets.STFC_CI_TRIGGER_USERNAME }}:${{ secrets.STFC_CI_TRIGGER_TOKEN }} "${{ secrets.STFC_CI_TRIGGER_BASE_URL }}/Dev_Deploy_ProposalFrontend.LatestImage/build?token=${{ secrets.STFC_CI_TRIGGER_URL_TOKEN }}"


### PR DESCRIPTION
## Description

Trigger Jenkins only on develop

## Motivation and Context

We don't want Jenkins to be triggered from any other branch than develop


