### PR TITLE
feat: Makes selecting a call when making a propsal always required.

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -47,6 +47,9 @@ jobs:
 
       - name: Set environment variables
         run: cp apps/user-office-frontend/example.development.env apps/user-office-frontend/.env
+        
+      - name: Generate SDK
+        run: npm run generate:sdk
 
       - name: Build and push backend
         uses: docker/build-push-action@v3

--- a/apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts
@@ -301,6 +301,8 @@ context('GenericTemplates tests', () => {
       cy.visit('/');
 
       cy.contains('New proposal', { matchCase: false }).click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
+
       cy.get('[data-cy=title] input').type(faker.lorem.words(1));
 
       cy.get('[data-cy=abstract] textarea').first().type(faker.lorem.words(2));
@@ -331,6 +333,7 @@ context('GenericTemplates tests', () => {
       cy.visit('/');
 
       cy.contains('New proposal', { matchCase: false }).click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=title] input').type(proposalTitle[1]);
 
@@ -473,6 +476,7 @@ context('GenericTemplates tests', () => {
       cy.visit('/');
 
       cy.contains('New proposal', { matchCase: false }).click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=title] input').type(proposalTitle[1]);
 

--- a/apps/user-office-frontend-e2e/cypress/integration/proposals.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/proposals.ts
@@ -132,6 +132,19 @@ context('Proposal tests', () => {
         'Carl'
       );
 
+      cy.get('[data-cy=edit-proposer-button]').click();
+
+      cy.finishedLoading();
+
+      cy.get('[data-cy=email]').type('ben@inbox.com');
+
+      cy.get('[data-cy=findUser]').click();
+
+      cy.contains('Benjamin')
+        .parent()
+        .find("[aria-label='Select user']")
+        .click();
+
       cy.contains('Save and continue').click();
 
       cy.contains('Title is required');
@@ -695,6 +708,19 @@ context('Proposal tests', () => {
         'Carl'
       );
 
+      cy.get('[data-cy=edit-proposer-button]').click();
+
+      cy.finishedLoading();
+
+      cy.get('[data-cy=email]').type('ben@inbox.com');
+
+      cy.get('[data-cy=findUser]').click();
+
+      cy.contains('Benjamin')
+        .parent()
+        .find("[aria-label='Select user']")
+        .click();
+
       cy.contains('Save and continue').click();
 
       cy.contains('Title is required');
@@ -801,6 +827,19 @@ context('Proposal tests', () => {
         'contain.value',
         'Carl'
       );
+
+      cy.get('[data-cy=edit-proposer-button]').click();
+
+      cy.finishedLoading();
+
+      cy.get('[data-cy=email]').type('ben@inbox.com');
+
+      cy.get('[data-cy=findUser]').click();
+
+      cy.contains('Benjamin')
+        .parent()
+        .find("[aria-label='Select user']")
+        .click();
 
       cy.contains('Save and continue').click();
 

--- a/apps/user-office-frontend-e2e/cypress/integration/proposals.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/proposals.ts
@@ -125,24 +125,12 @@ context('Proposal tests', () => {
       cy.visit('/');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=principal-investigator] input').should(
         'contain.value',
         'Carl'
       );
-
-      cy.get('[data-cy=edit-proposer-button]').click();
-
-      cy.finishedLoading();
-
-      cy.get('[data-cy=email]').type('ben@inbox.com');
-
-      cy.get('[data-cy=findUser]').click();
-
-      cy.contains('Benjamin')
-        .parent()
-        .find("[aria-label='Select user']")
-        .click();
 
       cy.contains('Save and continue').click();
 
@@ -150,6 +138,7 @@ context('Proposal tests', () => {
       cy.contains('Abstract is required');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=title] input').type(title).should('have.value', title);
 
@@ -157,15 +146,6 @@ context('Proposal tests', () => {
         .first()
         .type(abstract)
         .should('have.value', abstract);
-
-      cy.get('[data-cy=edit-proposer-button]').click();
-      cy.get('[role="presentation"]').as('modal');
-
-      cy.get('@modal')
-        .contains(proposer.firstName)
-        .parent()
-        .find("[aria-label='Select user']")
-        .click();
 
       cy.contains('Save and continue').click();
 
@@ -701,31 +681,19 @@ context('Proposal tests', () => {
       });
     });
 
-    it('Internal user should be able to create and clone  and delete an internal  proposal', function () {
+    it('Internal user should be able to create and clone and delete an internal proposal', function () {
       if (featureFlags.getEnabledFeatures().get(FeatureId.OAUTH)) {
         this.skip();
       }
       cy.login('user1');
       cy.visit('/');
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=principal-investigator] input').should(
         'contain.value',
         'Carl'
       );
-
-      cy.get('[data-cy=edit-proposer-button]').click();
-
-      cy.finishedLoading();
-
-      cy.get('[data-cy=email]').type('ben@inbox.com');
-
-      cy.get('[data-cy=findUser]').click();
-
-      cy.contains('Benjamin')
-        .parent()
-        .find("[aria-label='Select user']")
-        .click();
 
       cy.contains('Save and continue').click();
 
@@ -733,6 +701,7 @@ context('Proposal tests', () => {
       cy.contains('Abstract is required');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=title] input').type(title).should('have.value', title);
 
@@ -740,15 +709,6 @@ context('Proposal tests', () => {
         .first()
         .type(abstract)
         .should('have.value', abstract);
-
-      cy.get('[data-cy=edit-proposer-button]').click();
-      cy.get('[role="presentation"]').as('modal');
-
-      cy.get('@modal')
-        .contains(proposer.firstName)
-        .parent()
-        .find("[aria-label='Select user']")
-        .click();
 
       cy.contains('Save and continue').click();
 
@@ -835,24 +795,12 @@ context('Proposal tests', () => {
       cy.login('user1');
       cy.visit('/');
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=principal-investigator] input').should(
         'contain.value',
         'Carl'
       );
-
-      cy.get('[data-cy=edit-proposer-button]').click();
-
-      cy.finishedLoading();
-
-      cy.get('[data-cy=email]').type('ben@inbox.com');
-
-      cy.get('[data-cy=findUser]').click();
-
-      cy.contains('Benjamin')
-        .parent()
-        .find("[aria-label='Select user']")
-        .click();
 
       cy.contains('Save and continue').click();
 
@@ -860,6 +808,7 @@ context('Proposal tests', () => {
       cy.contains('Abstract is required');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=title] input')
         .type(newProposalTitle)
@@ -869,15 +818,6 @@ context('Proposal tests', () => {
         .first()
         .type(abstract)
         .should('have.value', abstract);
-
-      cy.get('[data-cy=edit-proposer-button]').click();
-      cy.get('[role="presentation"]').as('modal');
-
-      cy.get('@modal')
-        .contains(proposer.firstName)
-        .parent()
-        .find("[aria-label='Select user']")
-        .click();
 
       cy.contains('Save and continue').click();
 

--- a/apps/user-office-frontend-e2e/cypress/integration/samples.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/samples.ts
@@ -241,6 +241,8 @@ context('Samples tests', () => {
       cy.visit('/');
 
       cy.contains('new proposal', { matchCase: false }).click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
+
       cy.get('[data-cy=title] input').type(proposalTitle);
 
       cy.get('[data-cy=abstract] textarea').first().type(proposalTitle);
@@ -312,6 +314,8 @@ context('Samples tests', () => {
       cy.visit('/');
 
       cy.contains('new proposal', { matchCase: false }).click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
+
       cy.get('[data-cy=title] input').type(proposalTitle);
 
       cy.get('[data-cy=abstract] textarea').first().type(proposalTitle);

--- a/apps/user-office-frontend-e2e/cypress/integration/templates_advanced.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/templates_advanced.ts
@@ -468,6 +468,7 @@ context('Template tests', () => {
       cy.visit('/');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=title] input').type(faker.lorem.words(2));
       cy.get('[data-cy=abstract] textarea').first().type(faker.lorem.words(2));

--- a/apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts
@@ -884,6 +884,7 @@ context('Template tests', () => {
       cy.visit('/');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.contains(dateQuestion.title);
       cy.get('body').then(() => {
@@ -975,6 +976,7 @@ context('Template tests', () => {
       cy.visit('/');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       /* Test questions exist */
       for (const question of questions) {
@@ -1468,6 +1470,7 @@ context('Template tests', () => {
       cy.visit('/');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=title] input').type(faker.lorem.words(2));
       cy.get('[data-cy=abstract] textarea').first().type(faker.lorem.words(2));
@@ -1854,6 +1857,7 @@ context('Template tests', () => {
       cy.visit('/');
 
       cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
 
       cy.get('[data-cy=title] input').type('title');
 

--- a/apps/user-office-frontend/src/components/menu/MenuItems.tsx
+++ b/apps/user-office-frontend/src/components/menu/MenuItems.tsx
@@ -154,7 +154,6 @@ const SamplesMenuListItem = () => {
 
 const MenuItems: React.FC<MenuItemsProps> = ({ currentRole, callsData }) => {
   const proposalDisabled = callsData.length === 0;
-  const multipleCalls = callsData.length > 1;
   const context = useContext(FeatureContext);
 
   const isSchedulerEnabled = context.featuresMap.get(
@@ -186,11 +185,7 @@ const MenuItems: React.FC<MenuItemsProps> = ({ currentRole, callsData }) => {
       <Tooltip title="New Proposal">
         <ListItem
           component={NavLink}
-          to={
-            multipleCalls
-              ? '/ProposalSelectType'
-              : `/ProposalCreate/${callsData[0]?.id}/${callsData[0]?.templateId}`
-          }
+          to="/ProposalSelectType"
           button
           disabled={proposalDisabled}
         >


### PR DESCRIPTION
Closes: UserOfficeProject/user-office-project-issue-tracker#726

Currently, when there is only one call open the user is taken straight to the proposal creation page when selecting `New Proposal`. This PR makes selecting the `New Proposal` menu option always take the user to the call selection page even when there is only one call.

With this PR when creating a proposal and there is only one call, selecting `New Proposal` will take the user to the call selection page and their progress will be lost, even if there is only one call open. Currently, when there is only one call open selecting `New Proposal` the user will stay on the proposal creation page, keeping their progress. The behaviour this PR introduces is consistent with when there are multiple calls open.

## Motivation and Context

Users can be be confused and submit the wrong kind of proposal when they aren't prompted to select a call.

## How Has This Been Tested

- manual tests
- e2e tests

## Changes

- `apps/user-office-frontend/src/components/menu/MenuItems.tsx` - removes ternary that decides between directing to call section or proposal creation pages 
- `apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts` - adds step to tests to select call from call selection page
- `apps/user-office-frontend-e2e/cypress/integration/samples.ts` - adds step to tests to select call from call selection page
- `apps/user-office-frontend-e2e/cypress/integration/templates_advanced.ts` - adds step to tests to select call from call selection page
- `apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts` - adds step to tests to select call from call selection page
- `apps/user-office-frontend-e2e/cypress/integration/proposals.ts` - adds step to tests to select call from call selection page; removes steps to change PI


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
