### PR TITLE
Fix call displays correct time remaining test which are failing

### DIFF
--- a/apps/user-office-frontend-e2e/cypress/integration/calls.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/calls.ts
@@ -1034,8 +1034,8 @@ context('Calls tests', () => {
 
       cy.contains(initialDBData.call.shortCode)
         .parent()
-        .contains('remaining')
-        .should('not.exist');
+        .contains('Application deadline')
+        .should('not.have.text', 'remaining');
     });
 
     cy.updateCall({
@@ -1105,8 +1105,8 @@ context('Calls tests', () => {
 
       cy.contains(initialDBData.call.shortCode)
         .parent()
-        .contains('remaining')
-        .should('not.exist');
+        .contains('Application deadline')
+        .should('not.have.text', 'remaining');
     });
   });
 
@@ -1143,8 +1143,8 @@ context('Calls tests', () => {
 
       cy.contains(initialDBData.call.shortCode)
         .parent()
-        .contains('remaining')
-        .should('not.exist');
+        .contains('Internal deadline')
+        .should('not.have.text', 'remaining');
     });
 
     cy.updateCall({
@@ -1219,8 +1219,8 @@ context('Calls tests', () => {
 
       cy.contains(initialDBData.call.shortCode)
         .parent()
-        .contains('remaining')
-        .should('not.exist');
+        .contains('Internal deadline')
+        .should('not.have.text', 'remaining');
     });
   });
 });


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
`Call display correct time test` is failing and needs to be updated because of a new feature which was added to calls.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Fixes
This is part of https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/711

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

Files changed:
apps/user-office-frontend-e2e/cypress/integration/calls.ts

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->



## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
