### PR TITLE
fix: hide average score

### DIFF
--- a/apps/user-office-frontend/src/components/proposal/ProposalTableOfficer.tsx
+++ b/apps/user-office-frontend/src/components/proposal/ProposalTableOfficer.tsx
@@ -145,7 +145,12 @@ const SEPReviewColumns = [
     hidden: true,
   },
   { title: 'Deviation', field: 'reviewDeviation', emptyValue: '-' },
-  { title: 'Average Score', field: 'reviewAverage', emptyValue: '-' },
+  {
+    title: 'Average Score',
+    field: 'reviewAverage',
+    emptyValue: '-',
+    hidden: true,
+  },
   { title: 'Ranking', field: 'rankOrder', emptyValue: '-' },
   { title: 'SEP', field: 'sepCode', emptyValue: '-' },
 ];


### PR DESCRIPTION
## Description

Currently, the proposal table contains the column Average Score.  

This field is used only internally and should not be seen on the table.


## How Has This Been Tested

manual tests

## Fixes

![Screenshot 2022-12-05 at 16 23 48](https://user-images.githubusercontent.com/78078898/205678260-0a140c6b-e0e9-4d4a-ae9f-5c538b81335c.png)


## Changes

apps/user-office-frontend/src/components/proposal/ProposalTableOfficer.tsx

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
