### PR TITLE
fix: close icon is blocked by input field

### DIFF
--- a/apps/user-office-frontend/src/components/proposal/ParticipantModal.tsx
+++ b/apps/user-office-frontend/src/components/proposal/ParticipantModal.tsx
@@ -16,6 +16,7 @@ const useStyles = makeStyles((theme) => ({
     position: 'absolute',
     right: theme.spacing(1),
     top: theme.spacing(1),
+    zIndex: '1',
   },
 }));
 


### PR DESCRIPTION
## Description

Close button is blocked by input field.
![image-2022-12-12-14-32-32-145](https://user-images.githubusercontent.com/78078898/207279006-6eac92c9-0931-4828-849b-abc2188234d4.png)


## Motivation and Context

Close button should not be blocked in any circumstances.

## How Has This Been Tested

* e2e test
*  manual test

## Fixes

![Screenshot 2022-12-13 at 10 23 38](https://user-images.githubusercontent.com/78078898/207279349-1a1a9219-1e4d-4a35-bef4-d3de0dae5fe2.png)


## Changes

apps/user-office-frontend/src/components/proposal/ParticipantModal.tsx


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
