### PR TITLE
Added navigation link

### DIFF
--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
@@ -4,7 +4,6 @@ import FormControl from '@mui/material/FormControl';
 import Link from '@mui/material/Link';
 import MaterialTextField from '@mui/material/TextField';
 import makeStyles from '@mui/styles/makeStyles';
-// import clsx from 'clsx';
 import { Field } from 'formik';
 import { CheckboxWithLabel, TextField } from 'formik-mui';
 import React, { FC, useState } from 'react';

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
@@ -1,5 +1,10 @@
+import LaunchIcon from '@mui/icons-material/Launch';
 import Autocomplete from '@mui/lab/Autocomplete';
+import FormControl from '@mui/material/FormControl';
+import Link from '@mui/material/Link';
 import MaterialTextField from '@mui/material/TextField';
+import makeStyles from '@mui/styles/makeStyles';
+// import clsx from 'clsx';
 import { Field } from 'formik';
 import { CheckboxWithLabel, TextField } from 'formik-mui';
 import React, { FC, useState } from 'react';
@@ -13,11 +18,19 @@ import { NumberInputConfig, NumberValueConstraint } from 'generated/sdk';
 import { useUnitsData } from 'hooks/settings/useUnitData';
 import { useNaturalKeySchema } from 'utils/userFieldValidationSchema';
 
+const useStyles = makeStyles((theme) => ({
+  iconVerticalAlign: {
+    verticalAlign: 'middle',
+    marginLeft: theme.spacing(0.5),
+  },
+}));
+
 export const QuestionNumberForm: FC<QuestionFormProps> = (props) => {
   const field = props.question;
   const numberConfig = props.question.config as NumberInputConfig;
   const naturalKeySchema = useNaturalKeySchema(field.naturalKey);
   const { units } = useUnitsData();
+  const classes = useStyles();
   const [selectedUnits, setSelectedUnits] = useState(numberConfig.units);
 
   return (
@@ -81,24 +94,37 @@ export const QuestionNumberForm: FC<QuestionFormProps> = (props) => {
               }}
               InputProps={{ 'data-cy': 'required' }}
             />
+            <FormControl fullWidth>
+              <Autocomplete
+                id="config-units"
+                multiple
+                options={units}
+                getOptionLabel={({ unit, symbol, quantity }) =>
+                  `${symbol} (${unit}) - ${quantity}`
+                }
+                renderInput={(params) => (
+                  <MaterialTextField {...params} label="Units" margin="none" />
+                )}
+                onChange={(_event, newValue) => {
+                  setSelectedUnits(newValue);
+                  setFieldValue('config.units', newValue);
+                }}
+                value={selectedUnits ?? undefined}
+                data-cy="units"
+              />
 
-            <Autocomplete
-              id="config-units"
-              multiple
-              options={units}
-              getOptionLabel={({ unit, symbol, quantity }) =>
-                `${symbol} (${unit}) - ${quantity}`
-              }
-              renderInput={(params) => (
-                <MaterialTextField {...params} label="Units" margin="none" />
-              )}
-              onChange={(_event, newValue) => {
-                setSelectedUnits(newValue);
-                setFieldValue('config.units', newValue);
-              }}
-              value={selectedUnits ?? undefined}
-              data-cy="units"
-            />
+              <Link
+                href="/Units/"
+                target="_blank"
+                style={{ textAlign: 'right' }}
+              >
+                View/Edit all units
+                <LaunchIcon
+                  fontSize="small"
+                  className={classes.iconVerticalAlign}
+                />
+              </Link>
+            </FormControl>
 
             <FormikUIAutocomplete
               name="config.numberValueConstraint"

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
@@ -22,6 +22,9 @@ const useStyles = makeStyles((theme) => ({
     verticalAlign: 'middle',
     marginLeft: theme.spacing(0.5),
   },
+  textRightAlign: {
+    textAlign: 'right',
+  },
 }));
 
 export const QuestionNumberForm: FC<QuestionFormProps> = (props) => {
@@ -115,7 +118,7 @@ export const QuestionNumberForm: FC<QuestionFormProps> = (props) => {
               <Link
                 href="/Units/"
                 target="_blank"
-                style={{ textAlign: 'right' }}
+                className={classes.textRightAlign}
               >
                 View/Edit all units
                 <LaunchIcon


### PR DESCRIPTION
## Description

When specifying unit it would be nice to have a quick link so that you can quickly navigate to units page



## How Has This Been Tested

* manual testing

## Fixes

![Screenshot 2022-12-13 at 14 42 48](https://user-images.githubusercontent.com/78078898/207345952-6591349e-6bc6-4593-b7f1-e7ee1d9db14b.png)


## Changes

apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx



## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
