### PR TITLE
Fix: Some modals missing close modal button

### DIFF
--- a/apps/user-office-frontend/src/components/common/StyledModal.tsx
+++ b/apps/user-office-frontend/src/components/common/StyledModal.tsx
@@ -13,6 +13,8 @@ const boxStyle = {
   border: 'none',
   boxShadow: '4',
   padding: 3,
+  paddingTop: 4,
+  borderRadius: '5px',
   maxHeight: '100%',
   overflowY: 'auto',
 };

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
@@ -4,7 +4,6 @@ import FormControl from '@mui/material/FormControl';
 import Link from '@mui/material/Link';
 import MaterialTextField from '@mui/material/TextField';
 import makeStyles from '@mui/styles/makeStyles';
-// import clsx from 'clsx';
 import { Field } from 'formik';
 import { CheckboxWithLabel, TextField } from 'formik-mui';
 import React, { FC, useState } from 'react';

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
@@ -1,5 +1,10 @@
+import LaunchIcon from '@mui/icons-material/Launch';
 import Autocomplete from '@mui/lab/Autocomplete';
+import FormControl from '@mui/material/FormControl';
+import Link from '@mui/material/Link';
 import MaterialTextField from '@mui/material/TextField';
+import makeStyles from '@mui/styles/makeStyles';
+// import clsx from 'clsx';
 import { Field } from 'formik';
 import { CheckboxWithLabel, TextField } from 'formik-mui';
 import React, { FC, useState } from 'react';
@@ -13,11 +18,19 @@ import { NumberInputConfig, NumberValueConstraint } from 'generated/sdk';
 import { useUnitsData } from 'hooks/settings/useUnitData';
 import { useNaturalKeySchema } from 'utils/userFieldValidationSchema';
 
+const useStyles = makeStyles((theme) => ({
+  iconVerticalAlign: {
+    verticalAlign: 'middle',
+    marginLeft: theme.spacing(0.5),
+  },
+}));
+
 export const QuestionNumberForm: FC<QuestionFormProps> = (props) => {
   const field = props.question;
   const numberConfig = props.question.config as NumberInputConfig;
   const naturalKeySchema = useNaturalKeySchema(field.naturalKey);
   const { units } = useUnitsData();
+  const classes = useStyles();
   const [selectedUnits, setSelectedUnits] = useState(numberConfig.units);
 
   return (
@@ -81,24 +94,37 @@ export const QuestionNumberForm: FC<QuestionFormProps> = (props) => {
               }}
               InputProps={{ 'data-cy': 'required' }}
             />
+            <FormControl fullWidth>
+              <Autocomplete
+                id="config-units"
+                multiple
+                options={units}
+                getOptionLabel={({ unit, symbol, quantity }) =>
+                  `${symbol} (${unit}) - ${quantity}`
+                }
+                renderInput={(params) => (
+                  <MaterialTextField {...params} label="Units" margin="none" />
+                )}
+                onChange={(_event, newValue) => {
+                  setSelectedUnits(newValue);
+                  setFieldValue('config.units', newValue);
+                }}
+                value={selectedUnits ?? undefined}
+                data-cy="units"
+              />
 
-            <Autocomplete
-              id="config-units"
-              multiple
-              options={units}
-              getOptionLabel={({ unit, symbol, quantity }) =>
-                `${symbol} (${unit}) - ${quantity}`
-              }
-              renderInput={(params) => (
-                <MaterialTextField {...params} label="Units" margin="none" />
-              )}
-              onChange={(_event, newValue) => {
-                setSelectedUnits(newValue);
-                setFieldValue('config.units', newValue);
-              }}
-              value={selectedUnits ?? undefined}
-              data-cy="units"
-            />
+              <Link
+                href="/Units/"
+                target="_blank"
+                style={{ textAlign: 'right' }}
+              >
+                View/Edit all units
+                <LaunchIcon
+                  fontSize="small"
+                  className={classes.iconVerticalAlign}
+                />
+              </Link>
+            </FormControl>
 
             <FormikUIAutocomplete
               name="config.numberValueConstraint"

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
@@ -22,6 +22,9 @@ const useStyles = makeStyles((theme) => ({
     verticalAlign: 'middle',
     marginLeft: theme.spacing(0.5),
   },
+  textRightAlign: {
+    textAlign: 'right',
+  },
 }));
 
 export const QuestionNumberForm: FC<QuestionFormProps> = (props) => {
@@ -115,7 +118,7 @@ export const QuestionNumberForm: FC<QuestionFormProps> = (props) => {
               <Link
                 href="/Units/"
                 target="_blank"
-                style={{ textAlign: 'right' }}
+                className={classes.textRightAlign}
               >
                 View/Edit all units
                 <LaunchIcon

--- a/apps/user-office-frontend/src/components/template/QuestionEditor.tsx
+++ b/apps/user-office-frontend/src/components/template/QuestionEditor.tsx
@@ -1,3 +1,6 @@
+import CloseIcon from '@mui/icons-material/Close';
+import IconButton from '@mui/material/IconButton';
+import makeStyles from '@mui/styles/makeStyles';
 import React from 'react';
 
 import StyledModal from 'components/common/StyledModal';
@@ -5,34 +8,56 @@ import { createQuestionForm } from 'components/questionary/QuestionaryComponentR
 import { Question, Template } from 'generated/sdk';
 import { Event, EventType } from 'models/questionary/QuestionaryEditorModel';
 
+const useStyles = makeStyles((theme) => ({
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    '& > svg': {
+      color: theme.palette.grey[600],
+    },
+  },
+}));
+
 export default function QuestionEditor(props: {
   field: Question | null;
   dispatch: React.Dispatch<Event>;
   closeMe: () => void;
   template: Template;
 }) {
+  const classes = useStyles();
+
   if (props.field === null) {
     return null;
   }
 
   return (
-    <StyledModal onClose={props.closeMe} open={props.field != null}>
-      {createQuestionForm({
-        question: props.field,
-        onUpdated: (question) => {
-          props.dispatch({
-            type: EventType.QUESTION_UPDATED,
-            payload: question,
-          });
-        },
-        onDeleted: (question) => {
-          props.dispatch({
-            type: EventType.QUESTION_DELETED,
-            payload: question,
-          });
-        },
-        closeMe: props.closeMe,
-      })}
+    <StyledModal open={props.field != null}>
+      <>
+        <IconButton
+          data-cy="close-modal-btn"
+          className={classes.closeButton}
+          onClick={props.closeMe}
+        >
+          <CloseIcon />
+        </IconButton>
+        {createQuestionForm({
+          question: props.field,
+          onUpdated: (question) => {
+            props.dispatch({
+              type: EventType.QUESTION_UPDATED,
+              payload: question,
+            });
+          },
+          onDeleted: (question) => {
+            props.dispatch({
+              type: EventType.QUESTION_DELETED,
+              payload: question,
+            });
+          },
+          closeMe: props.closeMe,
+        })}
+      </>
     </StyledModal>
   );
 }

--- a/apps/user-office-frontend/src/components/template/QuestionTemplateRelationEditor.tsx
+++ b/apps/user-office-frontend/src/components/template/QuestionTemplateRelationEditor.tsx
@@ -1,3 +1,6 @@
+import CloseIcon from '@mui/icons-material/Close';
+import IconButton from '@mui/material/IconButton';
+import makeStyles from '@mui/styles/makeStyles';
 import React from 'react';
 
 import StyledModal from 'components/common/StyledModal';
@@ -5,45 +8,66 @@ import { createQuestionTemplateRelationForm } from 'components/questionary/Quest
 import { QuestionTemplateRelation, Template } from 'generated/sdk';
 import { Event, EventType } from 'models/questionary/QuestionaryEditorModel';
 
+const useStyles = makeStyles((theme) => ({
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    '& > svg': {
+      color: theme.palette.grey[600],
+    },
+  },
+}));
+
 export default function QuestionTemplateRelationEditor(props: {
   field: QuestionTemplateRelation | null;
   dispatch: React.Dispatch<Event>;
   closeMe: () => void;
   template: Template;
 }) {
+  const classes = useStyles();
+
   if (props.field === null) {
     return null;
   }
 
   return (
     <StyledModal
-      onClose={props.closeMe}
       open={props.field != null}
       data-cy="question-relation-dialogue"
     >
-      {createQuestionTemplateRelationForm({
-        questionRel: props.field,
-        onOpenQuestionClicked: (question) => {
-          props.dispatch({
-            type: EventType.OPEN_QUESTION_EDITOR,
-            payload: question,
-          });
-        },
-        onUpdated: (template) => {
-          props.dispatch({
-            type: EventType.QUESTION_REL_UPDATED,
-            payload: template,
-          });
-        },
-        onDeleted: (template) => {
-          props.dispatch({
-            type: EventType.QUESTION_REL_DELETED,
-            payload: template,
-          });
-        },
-        closeMe: props.closeMe,
-        template: props.template,
-      })}
+      <>
+        <IconButton
+          data-cy="close-modal-btn"
+          className={classes.closeButton}
+          onClick={props.closeMe}
+        >
+          <CloseIcon />
+        </IconButton>
+        {createQuestionTemplateRelationForm({
+          questionRel: props.field,
+          onOpenQuestionClicked: (question) => {
+            props.dispatch({
+              type: EventType.OPEN_QUESTION_EDITOR,
+              payload: question,
+            });
+          },
+          onUpdated: (template) => {
+            props.dispatch({
+              type: EventType.QUESTION_REL_UPDATED,
+              payload: template,
+            });
+          },
+          onDeleted: (template) => {
+            props.dispatch({
+              type: EventType.QUESTION_REL_DELETED,
+              payload: template,
+            });
+          },
+          closeMe: props.closeMe,
+          template: props.template,
+        })}
+      </>
     </StyledModal>
   );
 }


### PR DESCRIPTION
## Description

Question template modals are missing close button in the top right corner

## How Has This Been Tested

* manual test

## Fixes

![Screenshot 2022-12-14 at 13 51 45](https://user-images.githubusercontent.com/78078898/207602805-36c56357-5926-457f-850c-0b28578b623b.png)
![Screenshot 2022-12-14 at 13 54 03](https://user-images.githubusercontent.com/78078898/207602818-bf064eb6-ce7c-4fdb-a2a8-27d10731a1d9.png)

## Changes

apps/user-office-frontend/src/components/template/QuestionEditor.tsx
apps/user-office-frontend/src/components/template/QuestionTemplateRelationEditor.tsx

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
