### PR TITLE
fix: exposing getUserByOIDC endpoint

### DIFF
--- a/apps/user-office-backend/src/queries/UserQueries.ts
+++ b/apps/user-office-backend/src/queries/UserQueries.ts
@@ -32,6 +32,11 @@ export default class UserQueries {
     return this.dataSource.getUser(id);
   }
 
+  @Authorized([Roles.USER_OFFICER])
+  async getByOidcSub(agent: UserWithRole | null, oidcSub: string) {
+    return this.dataSource.getByOIDCSub(oidcSub);
+  }
+
   @Authorized()
   async byRef(agent: UserWithRole | null, id: number) {
     return this.dataSource.getUser(id);

--- a/apps/user-office-backend/src/resolvers/queries/UserByOIDCQuery.ts
+++ b/apps/user-office-backend/src/resolvers/queries/UserByOIDCQuery.ts
@@ -1,0 +1,15 @@
+import { Query, Arg, Ctx, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { User } from '../types/User';
+
+@Resolver()
+export class UserByOIDCQueryResolver {
+  @Query(() => User, { nullable: true })
+  userByOIDCSub(
+    @Arg('oidcSub', () => String) oidcSub: string,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.queries.user.getByOidcSub(context.user, oidcSub);
+  }
+}


### PR DESCRIPTION
## Description

Exposing endpoint getUserByOIDC which is only accessible by user officer and API tokens

## Motivation and Context

SciCat service needs such endpoint to be able to look up users



## Fixes

SWAP-2846

