### PR TITLE
fix:Add user office frontend e2e cypress tests screenshots to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 apps/user-office-frontend/node_modules
 apps/user-office-frontend-e2e/node_modules
+apps/user-office-frontend-e2e/cypress/screenshots
 apps/user-office-backend/node_modules
 apps/user-office-frontend/src/generated


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add user office frontend e2e cypress tests screenshots to gitignore.

## Motivation and Context
When running test on the local environment we don't necessary what git to keep track of cypress screenshots changes.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/749
<!--- Does this fix a user story, if so add a reference here -->

## Changes
Files changed:
 gitignore
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?
Manually tested.
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [x] All relevant doc has been updated
