### PR TITLE
Feat: add reload button for template lists in call modal

### DIFF
--- a/apps/user-office-frontend/src/components/call/CallGeneralInfo.tsx
+++ b/apps/user-office-frontend/src/components/call/CallGeneralInfo.tsx
@@ -40,6 +40,10 @@ import {
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
 
 const CallGeneralInfo: React.FC<{
+  reLoadTemplates: () => void;
+  reloadEsi: () => void;
+  reloadPdfTemplates: () => void;
+  reloadProposalWorkflows: () => void;
   templates: GetTemplatesQuery['templates'];
   esiTemplates: GetTemplatesQuery['templates'];
   pdfTemplates: GetTemplatesQuery['templates'];
@@ -53,6 +57,10 @@ const CallGeneralInfo: React.FC<{
   esiTemplates,
   pdfTemplates,
   loadingTemplates,
+  reLoadTemplates,
+  reloadEsi,
+  reloadPdfTemplates,
+  reloadProposalWorkflows,
 }) => {
   const { featuresMap } = useContext(FeatureContext);
   const { format: dateTimeFormat, mask, timezone } = useFormattedDateTime();
@@ -329,6 +337,7 @@ const CallGeneralInfo: React.FC<{
         noOptionsText="No templates"
         items={templateOptions}
         InputProps={{ 'data-cy': 'call-template' }}
+        reload={reLoadTemplates}
         required
       />
       {featuresMap.get(FeatureId.RISK_ASSESSMENT)?.isEnabled && (
@@ -339,6 +348,7 @@ const CallGeneralInfo: React.FC<{
           noOptionsText="No templates"
           items={esiTemplateOptions}
           InputProps={{ 'data-cy': 'call-esi-template' }}
+          reload={reloadEsi}
           required
         />
       )}
@@ -349,6 +359,7 @@ const CallGeneralInfo: React.FC<{
         noOptionsText="No templates"
         items={pdfTemplateOptions}
         InputProps={{ 'data-cy': 'call-pdf-template' }}
+        reload={reloadPdfTemplates}
       />
       <FormikUIAutocomplete
         name="proposalWorkflowId"
@@ -359,6 +370,7 @@ const CallGeneralInfo: React.FC<{
         InputProps={{
           'data-cy': 'call-workflow',
         }}
+        reload={reloadProposalWorkflows}
         required
       />
       <LocalizationProvider dateAdapter={DateAdapter}>

--- a/apps/user-office-frontend/src/components/call/CreateUpdateCall.tsx
+++ b/apps/user-office-frontend/src/components/call/CreateUpdateCall.tsx
@@ -32,23 +32,20 @@ const CreateUpdateCall: React.FC<CreateUpdateCallProps> = ({ call, close }) => {
   const { api } = useDataApiWithFeedback();
   const { timezone } = useFormattedDateTime();
 
-  const { templates: proposalTemplates } = useActiveTemplates(
-    TemplateGroupId.PROPOSAL,
-    call?.templateId
-  );
+  const { templates: proposalTemplates, refreshTemplates: reloadProposal } =
+    useActiveTemplates(TemplateGroupId.PROPOSAL, call?.templateId);
 
-  const { templates: proposalEsiTemplates } = useActiveTemplates(
-    TemplateGroupId.PROPOSAL_ESI,
-    call?.esiTemplateId
-  );
+  const { templates: proposalEsiTemplates, refreshTemplates: reloadEsi } =
+    useActiveTemplates(TemplateGroupId.PROPOSAL_ESI, call?.esiTemplateId);
 
-  const { templates: pdfTemplates } = useActiveTemplates(
-    TemplateGroupId.PDF_TEMPLATE,
-    call?.pdfTemplateId
-  );
+  const { templates: pdfTemplates, refreshTemplates: reloadPdfTemplates } =
+    useActiveTemplates(TemplateGroupId.PDF_TEMPLATE, call?.pdfTemplateId);
 
-  const { proposalWorkflows, loadingProposalWorkflows } =
-    useProposalWorkflowsData();
+  const {
+    proposalWorkflows,
+    loadingProposalWorkflows,
+    refreshProposalWorkflows: reloadProposalWorkflows,
+  } = useProposalWorkflowsData();
 
   const currentDayStart = DateTime.now()
     .setZone(timezone || undefined)
@@ -159,6 +156,10 @@ const CreateUpdateCall: React.FC<CreateUpdateCallProps> = ({ call, close }) => {
           }
         >
           <CallGeneralInfo
+            reLoadTemplates={reloadProposal}
+            reloadEsi={reloadEsi}
+            reloadPdfTemplates={reloadPdfTemplates}
+            reloadProposalWorkflows={reloadProposalWorkflows}
             templates={proposalTemplates}
             esiTemplates={proposalEsiTemplates}
             pdfTemplates={pdfTemplates}

--- a/apps/user-office-frontend/src/components/common/FormikUIAutocomplete.tsx
+++ b/apps/user-office-frontend/src/components/common/FormikUIAutocomplete.tsx
@@ -1,10 +1,12 @@
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { IconButton, InputAdornment } from '@mui/material';
 import { InputProps } from '@mui/material/Input';
 import MuiTextField, {
   TextFieldProps as MUITextFieldProps,
 } from '@mui/material/TextField';
 import { Field } from 'formik';
 import { Autocomplete } from 'formik-mui';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Option } from 'utils/utilTypes';
 
@@ -20,6 +22,7 @@ type FormikUIAutocompleteProps = {
   InputProps?: Partial<InputProps> & { 'data-cy': string };
   multiple?: boolean;
   'data-cy'?: string;
+  reload?: () => void;
 };
 
 const FormikUIAutocomplete: React.FC<FormikUIAutocompleteProps> = ({
@@ -33,8 +36,10 @@ const FormikUIAutocomplete: React.FC<FormikUIAutocompleteProps> = ({
   InputProps,
   TextFieldProps,
   multiple = false,
+  reload,
   ...props
 }) => {
+  const [adornmentVisible, setAdornmentVisible] = useState(false);
   const options = items.map((item) => item.value);
 
   return (
@@ -58,7 +63,30 @@ const FormikUIAutocomplete: React.FC<FormikUIAutocompleteProps> = ({
           label={label}
           required={required}
           disabled={disabled}
-          InputProps={{ ...params.InputProps, ...InputProps }}
+          InputProps={{
+            ...params.InputProps,
+            ...InputProps,
+            endAdornment: (
+              <InputAdornment position="start">
+                {adornmentVisible && reload ? (
+                  <IconButton
+                    edge="end"
+                    title="Refresh"
+                    aria-label="Refresh the list"
+                  >
+                    <RefreshIcon fontSize="small" onClick={reload} />
+                  </IconButton>
+                ) : null}
+                {params.InputProps?.endAdornment}
+              </InputAdornment>
+            ),
+          }}
+          onFocus={() => {
+            setAdornmentVisible(true);
+          }}
+          onBlur={() => {
+            setAdornmentVisible(false);
+          }}
         />
       )}
       ListboxProps={{ 'data-cy': props['data-cy'] + '-options' }}

--- a/apps/user-office-frontend/src/hooks/call/useCallTemplates.ts
+++ b/apps/user-office-frontend/src/hooks/call/useCallTemplates.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 
 import { GetTemplatesQuery, TemplateGroupId } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
@@ -13,11 +13,14 @@ export function useActiveTemplates(
   groupId: TemplateGroupId,
   includeTemplate?: number | null
 ) {
-  const api = useDataApi();
-
+  const [update, forceUpdate] = useReducer((x: number) => x + 1, 0);
   const [templates, setTemplates] = useState<
     GetTemplatesQuery['templates'] | null
   >(null);
+
+  const api = useDataApi();
+
+  const refreshTemplates = () => forceUpdate();
 
   useEffect(() => {
     let unmounted = false;
@@ -56,7 +59,7 @@ export function useActiveTemplates(
     return () => {
       unmounted = true;
     };
-  }, [groupId, includeTemplate, api]);
+  }, [groupId, includeTemplate, api, update]);
 
-  return { templates, setTemplates };
+  return { templates, setTemplates, refreshTemplates };
 }

--- a/apps/user-office-frontend/src/hooks/settings/useProposalWorkflowsData.ts
+++ b/apps/user-office-frontend/src/hooks/settings/useProposalWorkflowsData.ts
@@ -1,4 +1,10 @@
-import { useEffect, useState, SetStateAction, Dispatch } from 'react';
+import {
+  useEffect,
+  useState,
+  SetStateAction,
+  Dispatch,
+  useReducer,
+} from 'react';
 
 import { ProposalWorkflow } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
@@ -7,7 +13,9 @@ export function useProposalWorkflowsData(): {
   loadingProposalWorkflows: boolean;
   proposalWorkflows: ProposalWorkflow[];
   setProposalWorkflowsWithLoading: Dispatch<SetStateAction<ProposalWorkflow[]>>;
+  refreshProposalWorkflows: () => void;
 } {
+  const [update, forceUpdate] = useReducer((x: number) => x + 1, 0);
   const [proposalWorkflows, setProposalWorkflows] = useState<
     ProposalWorkflow[]
   >([]);
@@ -15,6 +23,8 @@ export function useProposalWorkflowsData(): {
     useState(true);
 
   const api = useDataApi();
+
+  const refreshProposalWorkflows = () => forceUpdate();
 
   const setProposalWorkflowsWithLoading = (
     data: SetStateAction<ProposalWorkflow[]>
@@ -44,11 +54,12 @@ export function useProposalWorkflowsData(): {
     return () => {
       unmounted = true;
     };
-  }, [api]);
+  }, [api, update]);
 
   return {
     loadingProposalWorkflows,
     proposalWorkflows,
     setProposalWorkflowsWithLoading,
+    refreshProposalWorkflows,
   };
 }


### PR DESCRIPTION
## Description

Reload button is added for template lists in call modal. 

## Motivation and Context

While viewing the template list in calls, the sample declaration question window, or subtemplates the dropdown values might have changed since you opened the window. To prevent closing and opening windows and losing entered values there should be a refresh button that reloads the templates

## How Has This Been Tested

* manual


## Changes

apps/user-office-frontend/src/components/call/CallGeneralInfo.tsx
apps/user-office-frontend/src/components/call/CreateUpdateCall.tsx
apps/user-office-frontend/src/components/common/FormikUIAutocomplete.tsx
apps/user-office-frontend/src/hooks/call/useCallTemplates.ts
apps/user-office-frontend/src/hooks/settings/useProposalWorkflowsData.ts


## Tests included/Docs Updated?



- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
