### PR TITLE
feat: call events must be retriggered when call dates are extended after being previously closed

### DIFF
--- a/apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
@@ -269,10 +269,10 @@ export default class PostgresCallDataSource implements CallDataSource {
               call_ended:
                 preUpdateCall.call_ended &&
                 args.endCall.getTime() < currentDate.getTime(),
-              call_ended_internal:
-                preUpdateCall.call_ended_internal &&
-                args?.endCallInternal &&
-                args.endCallInternal.getTime() < currentDate.getTime(),
+              call_ended_internal: args?.endCallInternal
+                ? preUpdateCall.call_ended_internal &&
+                  args.endCallInternal.getTime() < currentDate.getTime()
+                : args.callEndedInternal,
               call_review_ended: args.callReviewEnded,
               call_sep_review_ended: args.callSEPReviewEnded,
               template_id: args.templateId,

--- a/apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/CallDataSource.ts
@@ -269,7 +269,7 @@ export default class PostgresCallDataSource implements CallDataSource {
               call_ended:
                 preUpdateCall.call_ended &&
                 args.endCall.getTime() < currentDate.getTime(),
-              call_ended_internal: args?.endCallInternal
+              call_ended_internal: args.endCallInternal
                 ? preUpdateCall.call_ended_internal &&
                   args.endCallInternal.getTime() < currentDate.getTime()
                 : args.callEndedInternal,


### PR DESCRIPTION

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
CALL_ENDED or CALL_ENDED_INTERNAL events must be retriggered when either call end date or call end internal dates are updated.

<!--- Describe your changes in detail -->

## Motivation and Context

When the user officer opens a call after it has previously been closed and triggered the CALL_ENDED event. Proposals submitted after the call end date is updated will not have their workflow updated by the CALL_ENDED event because it would have been triggered already and will not be triggered when the new call ended date expires. The same issue also applies to CALL_ENDED_INTERNAL event.
Both CALL_ENDED or CALL_ENDED_INTERNAL event must be retriggered at the new dates after call dates updates.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- manual tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Closes
https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/731
<!--- Does this fix a user story, if so add a reference here -->

## Changes
Files:

- apps/user-office-backend/src/datasources/postgres/CallDataSource.ts

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
