### PR TITLE
fix: make settings update more resilient  

### DIFF
--- a/apps/user-office-backend/src/datasources/AdminDataSource.ts
+++ b/apps/user-office-backend/src/datasources/AdminDataSource.ts
@@ -31,7 +31,7 @@ export interface AdminDataSource {
   setFeatures(features: FeatureId[], value: boolean): Promise<FeatureId[]>;
   updateFeatures(updatedFeaturesInput: UpdateFeaturesInput): Promise<Feature[]>;
   getSettings(): Promise<Settings[]>;
-  getSetting(id: SettingsId): Promise<Settings>;
+  getSetting(id: SettingsId): Promise<Settings | null>;
   createApiAccessToken(
     args: CreateApiAccessTokenInput,
     accessTokenId: string,

--- a/apps/user-office-backend/src/datasources/postgres/AdminDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/AdminDataSource.ts
@@ -378,6 +378,14 @@ export default class PostgresAdminDataSource implements AdminDataSource {
       );
   }
 
+  async createSetting(setting: Settings): Promise<Settings> {
+    return database
+      .insert(setting)
+      .into('settings')
+      .returning('*')
+      .then((settings: SettingsRecord[]) => createSettingsObject(settings[0]));
+  }
+
   async getSettings(): Promise<Settings[]> {
     return database
       .select()
@@ -387,13 +395,15 @@ export default class PostgresAdminDataSource implements AdminDataSource {
       );
   }
 
-  async getSetting(id: SettingsId): Promise<Settings> {
+  async getSetting(id: SettingsId): Promise<Settings | null> {
     return database
       .select()
       .from('settings')
-      .where('setting_id', id)
+      .where('settings_id', id)
       .first()
-      .then((setting: SettingsRecord) => createSettingsObject(setting));
+      .then((setting: SettingsRecord) =>
+        setting ? createSettingsObject(setting) : null
+      );
   }
 
   async getTokenAndPermissionsById(
@@ -493,6 +503,15 @@ export default class PostgresAdminDataSource implements AdminDataSource {
     updatedSettingsInput: UpdateSettingsInput
   ): Promise<Settings> {
     const { settingsId, description, settingsValue } = updatedSettingsInput;
+
+    const setting = await this.getSetting(settingsId);
+    if (!setting) {
+      await this.createSetting({
+        id: settingsId as SettingsId,
+        settingsValue: '',
+        description: '',
+      });
+    }
 
     return database('settings')
       .update({ settings_value: settingsValue, description: description })

--- a/apps/user-office-backend/src/datasources/postgres/AdminDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/AdminDataSource.ts
@@ -380,7 +380,11 @@ export default class PostgresAdminDataSource implements AdminDataSource {
 
   async createSetting(setting: Settings): Promise<Settings> {
     return database
-      .insert(setting)
+      .insert({
+        settings_id: setting.id,
+        settings_value: setting.settingsValue,
+        description: setting.description,
+      })
       .into('settings')
       .returning('*')
       .then((settings: SettingsRecord[]) => createSettingsObject(settings[0]));


### PR DESCRIPTION
## Description

This PR aims to fix the issue where the server will throw an exception if trying to update a setting that does not exist. The more resilient approach is to create the setting in case it does not exist.

## Motivation and Context

This PR makes the backend more resilient

## Fixes

https://jira.esss.lu.se/browse/SWAP-2954

