### PR TITLE
fix: Fixing dependabot PRs and branch names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Specify a different separator for branch names
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen because docker hub doesn't want slashes
+      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: "-"


### PR DESCRIPTION
## Description

This PR should fix the failing docker image pushes when dependabot creates PR with branch name containing slash "/". Now it should replace slash "/" separator with hyphen "-".

## Motivation and Context

All dependabot PRs were failing in push action.

## Changes

Adds dependabot.yml file for dependabot configuration.
