### PR TITLE
refactor: Remove cypress-file-upload package because cy.selectFile was introduced and do some cleanup of duplicate tests

### DIFF
--- a/apps/user-office-frontend-e2e/cypress/integration/shipments.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/shipments.ts
@@ -86,11 +86,14 @@ context('Shipments tests', () => {
 
     cy.get('[data-cy=import-template-button]').click();
 
-    cy.get('input[type="file"]').attachFixture({
-      filePath: shipmentsTemplateFile,
-      fileName: shipmentsTemplateFile,
-      mimeType: 'application/json',
-    });
+    // NOTE: Force is needed because file input is not visible and has display: none
+    cy.get('input[type="file"]').selectFile(
+      {
+        contents: `cypress/fixtures/${shipmentsTemplateFile}`,
+        fileName: shipmentsTemplateFile,
+      },
+      { force: true }
+    );
 
     cy.get('[data-cy="import-template-button"]').click();
 

--- a/apps/user-office-frontend-e2e/cypress/integration/templates_advanced.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/templates_advanced.ts
@@ -486,8 +486,9 @@ context('Template tests', () => {
       }).as('upload');
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${fileName}`,
@@ -795,8 +796,9 @@ context('Template tests', () => {
       }).as('upload');
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${fileName}`,

--- a/apps/user-office-frontend-e2e/cypress/integration/templates_advanced.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/templates_advanced.ts
@@ -485,11 +485,16 @@ context('Template tests', () => {
         url: '/files/upload',
       }).as('upload');
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'image/png',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+          },
+          { force: true }
+        );
 
       // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
       cy.wait('@upload', { requestTimeout: 30000 });
@@ -789,11 +794,16 @@ context('Template tests', () => {
         url: '/files/upload',
       }).as('upload');
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'image/png',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+          },
+          { force: true }
+        );
 
       // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
       cy.wait('@upload', { requestTimeout: 30000 });

--- a/apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts
@@ -1422,8 +1422,9 @@ context('Template tests', () => {
       const fileName = 'file_without_ext';
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${fileName}`,
@@ -1440,8 +1441,9 @@ context('Template tests', () => {
       const fileName = 'file_upload_test.png';
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${fileName}`,
@@ -1463,8 +1465,9 @@ context('Template tests', () => {
       }).as('upload');
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${fileName}`,
@@ -1492,8 +1495,9 @@ context('Template tests', () => {
       }).as('upload');
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${fileName}`,
@@ -1523,8 +1527,9 @@ context('Template tests', () => {
       }).as('upload');
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${validFile}`,
@@ -1553,8 +1558,9 @@ context('Template tests', () => {
       }).as('upload');
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${invalidFile}`,
@@ -1583,8 +1589,9 @@ context('Template tests', () => {
       }).as('upload');
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${fileName}`,
@@ -1613,8 +1620,9 @@ context('Template tests', () => {
       }).as('upload');
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
+      cy.contains(fileQuestion)
+        .parent()
+        .find('input[type="file"]')
         .selectFile(
           {
             contents: `cypress/fixtures/${fileName}`,

--- a/apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts
@@ -1295,15 +1295,13 @@ context('Template tests', () => {
       cy.get('[data-cy=import-template-button]').click();
 
       // NOTE: Force is needed because file input is not visible and has display: none
-      cy.get(`[data-cy="${fileQuestion}"]`)
-        .siblings('input[type="file"]')
-        .selectFile(
-          {
-            contents: `cypress/fixtures/${fileName}`,
-            fileName: fileName,
-          },
-          { force: true }
-        );
+      cy.get('input[type="file"]').selectFile(
+        {
+          contents: `cypress/fixtures/${fileName}`,
+          fileName: fileName,
+        },
+        { force: true }
+      );
 
       cy.get("[data-cy='proposal_basis-accordion']")
         .find('[data-cy=conflict-icon]')

--- a/apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/templates_basic.ts
@@ -1294,11 +1294,16 @@ context('Template tests', () => {
 
       cy.get('[data-cy=import-template-button]').click();
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'image/png',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+          },
+          { force: true }
+        );
 
       cy.get("[data-cy='proposal_basis-accordion']")
         .find('[data-cy=conflict-icon]')
@@ -1381,501 +1386,6 @@ context('Template tests', () => {
     });
   });
 
-  describe('Proposal templates advanced tests', () => {
-    beforeEach(() => {
-      createTopicWithQuestionsAndRelations(true);
-    });
-
-    it('User can create proposal with template', () => {
-      const dateTimeFieldValue = DateTime.fromJSDate(
-        faker.date.past()
-      ).toFormat(initialDBData.getFormats().dateTimeFormat);
-      cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
-        const createdProposal = result.createProposal.proposal;
-        if (createdProposal) {
-          cy.updateProposal({
-            proposalPk: createdProposal.primaryKey,
-            title: proposal.title,
-            abstract: proposal.abstract,
-            proposerId: initialDBData.users.user1.id,
-          });
-        }
-      });
-      cy.login('user1');
-      cy.visit('/');
-
-      cy.contains(proposal.title)
-        .parent()
-        .find('[aria-label="Edit proposal"]')
-        .click();
-
-      cy.contains('save and continue', { matchCase: false }).click();
-      cy.finishedLoading();
-
-      cy.get(`[data-cy="${intervalId}.min"]`).click().type('1');
-      cy.get(`[data-cy="${intervalId}.max"]`).click().type('2');
-      cy.get(`[data-cy="${numberId}.value"]`).click().type('1');
-      cy.get(`#${boolId}`).click();
-      cy.get(`#${textId}`).clear().type('this_word_{enter}should_be_multiline');
-      cy.contains('this_word_should_be_multiline').should('not.exist');
-      cy.get(`#${textId}`).clear().type(textQuestion.answer);
-      cy.contains(`${textQuestion.answer.length}/${textQuestion.maxChars}`);
-      cy.get(`[data-cy='${dateId}.value'] button`).click();
-      cy.contains('15').click();
-      cy.get(`[data-cy='${timeId}.value'] input`)
-        .clear()
-        .type(dateTimeFieldValue);
-
-      cy.get(`#${multipleChoiceId}`).click();
-      cy.contains(multipleChoiceQuestion.answers[0]).click();
-      cy.contains(multipleChoiceQuestion.answers[2]).click();
-      cy.get('body').type('{esc}');
-
-      cy.window().then((win) => {
-        return new Cypress.Promise((resolve) => {
-          win.tinyMCE.editors[richTextInputId].setContent(
-            richTextInputQuestion.answer
-          );
-          win.tinyMCE.editors[richTextInputId].fire('blur');
-
-          resolve();
-        });
-      });
-
-      cy.get(`#${richTextInputId}_ifr`)
-        .its('0.contentDocument.body')
-        .should('not.be.empty')
-        .contains(richTextInputQuestion.answer);
-
-      cy.get('[data-cy="rich-text-char-count"]').then((element) => {
-        expect(element.text()).to.be.equal(
-          `Characters: ${richTextInputQuestion.answer.length} / ${richTextInputQuestion.maxChars}`
-        );
-      });
-
-      cy.contains('Save and continue').click();
-
-      cy.contains('Submit').click();
-
-      cy.contains('OK').click();
-
-      cy.contains(proposal.title);
-      cy.contains(proposal.abstract);
-      cy.contains(textQuestion.answer);
-      cy.contains(multipleChoiceQuestion.answers[0]);
-      cy.contains(multipleChoiceQuestion.answers[1]).should('not.exist');
-      cy.contains(multipleChoiceQuestion.answers[2]);
-      cy.contains(dateTimeFieldValue);
-
-      cy.contains(richTextInputQuestion.title);
-      cy.get(`[data-cy="${richTextInputId}_open"]`).click();
-      cy.get('[role="dialog"]').contains(richTextInputQuestion.title);
-      cy.get('[role="dialog"]').contains(richTextInputQuestion.answer);
-      cy.get('[role="dialog"]').contains('Close').click();
-
-      cy.contains('Dashboard').click();
-      cy.contains(proposal.title);
-      cy.contains('submitted');
-    });
-
-    it('File Upload field could be set as required', () => {
-      const fileName = 'file_upload_test.png';
-
-      cy.login('officer');
-      cy.visit('/');
-
-      cy.navigateToTemplatesSubmenu('Proposal');
-
-      cy.contains(initialDBData.template.name)
-        .parent()
-        .find("[aria-label='Edit']")
-        .first()
-        .click();
-
-      cy.contains(fileQuestion).click();
-
-      cy.get('[role="presentation"]').contains('image/*').click();
-
-      cy.get('body').type('{esc}');
-
-      cy.contains('Is required').click();
-
-      cy.contains('Update').click();
-
-      cy.logout();
-
-      cy.login('user1');
-      cy.visit('/');
-
-      cy.contains('New Proposal').click();
-      cy.get('[data-cy=call-list]').find('li:first-child').click();
-
-      cy.get('[data-cy=title] input').type(faker.lorem.words(2));
-      cy.get('[data-cy=abstract] textarea').first().type(faker.lorem.words(2));
-      cy.contains('Save and continue').click();
-
-      cy.contains(fileQuestion);
-      cy.contains('Save and continue').click();
-      cy.contains(fileQuestion)
-        .parent()
-        .contains('field must have at least 1 items');
-
-      cy.intercept({
-        method: 'POST',
-        url: '/files/upload',
-      }).as('upload');
-
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'image/png',
-      });
-
-      // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
-      cy.wait('@upload', { requestTimeout: 30000 });
-
-      cy.contains(fileName);
-
-      cy.contains(fileQuestion)
-        .parent()
-        .should('not.contain.text', 'field must have at least 1 items');
-
-      cy.logout();
-    });
-
-    it('File Upload max files should be required', () => {
-      cy.login('officer');
-      cy.visit('/');
-
-      cy.navigateToTemplatesSubmenu('Proposal');
-
-      cy.contains(initialDBData.template.name)
-        .parent()
-        .find("[aria-label='Edit']")
-        .first()
-        .click();
-
-      cy.contains(fileQuestion).click();
-
-      cy.get('[role="presentation"]').contains('image/*').click();
-
-      cy.get('body').type('{esc}');
-
-      cy.get('[data-cy="max_files"] input').clear().type('-1');
-
-      cy.contains('Update').should('be.disabled');
-
-      cy.get('[data-cy="max_files"] input').clear();
-
-      cy.get('[data-cy="max_files"] input').should('be.focused');
-      cy.get('[data-cy="max_files"] input:invalid').should('have.length', 1);
-
-      cy.get('[data-cy="max_files"] input').clear().type('1');
-
-      cy.contains('Update').click();
-
-      cy.get('[data-cy="question-relation-dialogue"]').should('not.exist');
-
-      cy.logout();
-    });
-
-    it('Officer can delete proposal questions', () => {
-      cy.login('officer');
-      cy.visit('/');
-
-      cy.navigateToTemplatesSubmenu('Proposal');
-
-      cy.contains(initialDBData.template.name)
-        .parent()
-        .find("[aria-label='Edit']")
-        .first()
-        .click();
-
-      cy.contains(textQuestion.title).click();
-      cy.get("[data-cy='remove-from-template']").click();
-
-      cy.contains(booleanQuestion).click();
-      cy.get("[data-cy='remove-from-template']").click();
-
-      cy.contains(dateQuestion.title).click();
-      cy.get("[data-cy='remove-from-template']").click();
-
-      cy.contains(fileQuestion).click();
-      cy.get("[data-cy='remove-from-template']").click();
-    });
-
-    it('User officer can add multiple dependencies on a question', () => {
-      cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
-        const createdProposal = result.createProposal.proposal;
-        if (createdProposal) {
-          cy.updateProposal({
-            proposalPk: createdProposal.primaryKey,
-            title: proposal.title,
-            abstract: proposal.abstract,
-            proposerId: initialDBData.users.user1.id,
-          });
-        }
-      });
-      cy.login('officer');
-      cy.visit('/');
-
-      cy.navigateToTemplatesSubmenu('Proposal');
-
-      cy.contains(initialDBData.template.name)
-        .parent()
-        .find("[aria-label='Edit']")
-        .first()
-        .click();
-
-      cy.createTextQuestion(templateDependencies.questions.textQuestion.title);
-
-      cy.contains(templateDependencies.questions.textQuestion.title).click();
-
-      cy.get('[data-cy="add-dependency-button"]').click();
-
-      cy.get('[id="dependency-id"]').click();
-
-      cy.get('[role="presentation"]')
-        .contains(multipleChoiceQuestion.title)
-        .click();
-
-      cy.get('[id="dependencyValue"]').click();
-
-      cy.contains(multipleChoiceQuestion.answers[1]).click();
-
-      cy.get('[data-cy="add-dependency-button"]').click();
-
-      cy.get('[id="dependency-id"]').last().click();
-
-      cy.get('[role="presentation"]').contains(booleanQuestion).click();
-
-      cy.get('[id="dependencyValue"]').last().click();
-
-      cy.contains('true').click();
-
-      cy.get('[data-cy="submit"]').click();
-
-      cy.logout();
-
-      cy.login('user1');
-      cy.visit('/');
-
-      cy.contains(proposal.title)
-        .parent()
-        .find('[aria-label="Edit proposal"]')
-        .click();
-
-      cy.contains('save and continue', { matchCase: false }).click();
-      cy.finishedLoading();
-
-      cy.get('main form').should(
-        'not.contain.text',
-        templateDependencies.questions.textQuestion.title
-      );
-
-      cy.contains(multipleChoiceQuestion.title).parent().click();
-      cy.contains(multipleChoiceQuestion.answers[1]).click();
-      cy.get('body').type('{esc}');
-      cy.get('main form').should(
-        'not.contain.text',
-        templateDependencies.questions.textQuestion.title
-      );
-
-      cy.contains(booleanQuestion).click();
-
-      cy.get('main form').should(
-        'contain.text',
-        templateDependencies.questions.textQuestion.title
-      );
-
-      cy.contains(multipleChoiceQuestion.title).parent().click();
-      cy.get('[role="presentation"]')
-        .contains(multipleChoiceQuestion.answers[1])
-        .click();
-      cy.contains(multipleChoiceQuestion.answers[2]).click();
-      cy.get('body').type('{esc}');
-
-      cy.get('main form').should(
-        'not.contain.text',
-        templateDependencies.questions.textQuestion.title
-      );
-    });
-
-    it('User officer can change dependency logic operator', () => {
-      cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
-        const createdProposal = result.createProposal.proposal;
-        if (createdProposal) {
-          cy.updateProposal({
-            proposalPk: createdProposal.primaryKey,
-            title: proposal.title,
-            abstract: proposal.abstract,
-            proposerId: initialDBData.users.user1.id,
-          });
-        }
-      });
-      cy.login('officer');
-      cy.visit('/');
-
-      cy.navigateToTemplatesSubmenu('Proposal');
-
-      cy.get('[aria-label="Edit"]').last().click();
-
-      cy.contains(textQuestion.title).click();
-
-      cy.get('[data-cy="add-dependency-button"]').click();
-
-      cy.get('[id="dependency-id"]').last().click();
-
-      cy.get('[role="presentation"]')
-        .contains(multipleChoiceQuestion.title)
-        .click();
-
-      cy.get('[id="dependencyValue"]').last().click();
-
-      cy.contains(multipleChoiceQuestion.answers[1]).click();
-
-      cy.get('[data-cy="dependencies-operator"]').click();
-
-      cy.get('[data-value="OR"]').click();
-
-      cy.get('[data-cy="submit"]').click();
-
-      cy.logout();
-
-      cy.login('user1');
-      cy.visit('/');
-
-      cy.contains(proposal.title)
-        .parent()
-        .find('[aria-label="Edit proposal"]')
-        .click();
-
-      cy.contains('save and continue', { matchCase: false }).click();
-      cy.finishedLoading();
-
-      cy.get('main form').should('not.contain.text', textQuestion.title);
-
-      cy.contains(multipleChoiceQuestion.title).parent().click();
-      cy.contains(multipleChoiceQuestion.answers[1]).click();
-      cy.get('body').type('{esc}');
-      cy.contains(textQuestion.title);
-
-      cy.contains(multipleChoiceQuestion.title).parent().click();
-      cy.get('[role="presentation"]')
-        .contains(multipleChoiceQuestion.answers[1])
-        .click();
-      cy.contains(multipleChoiceQuestion.answers[2]).click();
-      cy.get('body').type('{esc}');
-
-      cy.get('main form').should('not.contain.text', textQuestion.title);
-
-      cy.contains(booleanQuestion).click();
-      cy.contains(textQuestion.title);
-    });
-
-    it('Can delete dependee, which will remove the dependency on depender', () => {
-      cy.login('officer');
-      cy.visit('/');
-
-      cy.navigateToTemplatesSubmenu('Proposal');
-
-      cy.contains(initialDBData.template.name)
-        .parent()
-        .find("[aria-label='Edit']")
-        .first()
-        .click();
-
-      cy.contains(textQuestion.title)
-        .closest('[data-cy=question-container]')
-        .find('[data-cy=dependency-list]')
-        .should('exist');
-      cy.contains(booleanQuestion).click();
-      cy.get('[data-cy=remove-from-template]').click();
-      cy.contains(textQuestion.title)
-        .closest('[data-cy=question-container]')
-        .find('[data-cy=dependency-list]')
-        .should('not.exist');
-    });
-
-    it('User can add captions after uploading image/* file', () => {
-      const fileName = 'file_upload_test2.png'; // need to use another file due to bug in cypress, which do not allow the same fixture to be reused
-      cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
-        const createdProposal = result.createProposal.proposal;
-        if (createdProposal) {
-          cy.updateProposal({
-            proposalPk: createdProposal.primaryKey,
-            title: proposal.title,
-            abstract: proposal.abstract,
-            proposerId: initialDBData.users.user1.id,
-          });
-        }
-      });
-
-      cy.login('user1');
-      cy.visit('/');
-
-      cy.contains(proposal.title)
-        .parent()
-        .find('[aria-label="Edit proposal"]')
-        .click();
-      cy.finishedLoading();
-
-      cy.contains('Save and continue').click();
-
-      cy.contains(fileQuestion);
-
-      cy.intercept({
-        method: 'POST',
-        url: '/files/upload',
-      }).as('upload');
-
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'image/png',
-      });
-
-      // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
-      cy.wait('@upload', { requestTimeout: 30000 });
-
-      cy.contains(fileName);
-
-      cy.get('[aria-label="Add image caption"]').click();
-
-      cy.get('[data-cy="image-figure"] input').type('Fig_test');
-      cy.get('[data-cy="image-caption"] input').type('Test caption');
-
-      cy.get('[data-cy="save-button"]').click();
-
-      cy.notification({ variant: 'success', text: 'Saved' });
-
-      cy.finishedLoading();
-
-      cy.get('.MuiStep-root').contains('Review').click();
-
-      cy.contains(proposal.abstract);
-
-      cy.contains(fileName);
-
-      cy.get('[data-cy="questionary-stepper"]')
-        .contains(initialDBData.template.topic.title)
-        .click();
-
-      cy.finishedLoading();
-      cy.contains('Save and continue');
-
-      cy.contains(fileQuestion)
-        .parent()
-        .should('contain.text', fileName)
-        .find('[data-cy="image-caption"] input')
-        .should('have.value', 'Test caption');
-      cy.contains(fileQuestion)
-        .parent()
-        .find('[data-cy="image-figure"] input')
-        .should('have.value', 'Fig_test');
-    });
-  });
-
   describe('File upload tests', () => {
     beforeEach(() => {
       cy.login('officer');
@@ -1913,11 +1423,17 @@ context('Template tests', () => {
     it('File without extension cannot be uploaded', () => {
       const fileName = 'file_without_ext';
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'application/pdf',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+            mimeType: 'application/pdf',
+          },
+          { force: true }
+        );
 
       cy.contains('Incorrect file type');
     });
@@ -1925,11 +1441,17 @@ context('Template tests', () => {
     it('File with incorrect content header cannot be uploaded', () => {
       const fileName = 'file_upload_test.png';
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'application/octet-stream',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+            mimeType: 'application/octet-stream',
+          },
+          { force: true }
+        );
 
       cy.contains('Incorrect file type');
     });
@@ -1942,11 +1464,16 @@ context('Template tests', () => {
         url: '/files/upload',
       }).as('upload');
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'application/pdf',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+          },
+          { force: true }
+        );
 
       // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
       cy.wait('@upload', { requestTimeout: 30000 });
@@ -1966,11 +1493,17 @@ context('Template tests', () => {
         url: '/files/upload',
       }).as('upload');
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'application/pdf',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+            mimeType: 'application/pdf',
+          },
+          { force: true }
+        );
 
       // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
       cy.wait('@upload', { requestTimeout: 30000 });
@@ -1991,11 +1524,16 @@ context('Template tests', () => {
         url: '/files/upload',
       }).as('upload');
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: validFile,
-        fileName: validFile,
-        mimeType: 'image/png',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${validFile}`,
+            fileName: validFile,
+          },
+          { force: true }
+        );
 
       // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
       cy.wait('@upload', { requestTimeout: 30000 });
@@ -2016,11 +1554,17 @@ context('Template tests', () => {
         url: '/files/upload',
       }).as('upload');
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: invalidFile,
-        fileName: invalidFile,
-        mimeType: 'application/pdf',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${invalidFile}`,
+            fileName: invalidFile,
+            mimeType: 'application/pdf',
+          },
+          { force: true }
+        );
 
       // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
       cy.wait('@upload', { requestTimeout: 30000 });
@@ -2040,11 +1584,17 @@ context('Template tests', () => {
         url: '/files/upload',
       }).as('upload');
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'application/pdf',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+            mimeType: 'application/pdf',
+          },
+          { force: true }
+        );
 
       // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
       cy.wait('@upload', { requestTimeout: 30000 });
@@ -2064,11 +1614,17 @@ context('Template tests', () => {
         url: '/files/upload',
       }).as('upload');
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'application/pdf',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get(`[data-cy="${fileQuestion}"]`)
+        .siblings('input[type="file"]')
+        .selectFile(
+          {
+            contents: `cypress/fixtures/${fileName}`,
+            fileName: fileName,
+            mimeType: 'application/pdf',
+          },
+          { force: true }
+        );
 
       // wait for the '/files/upload' request, and leave a 30 seconds delay before throwing an error
       cy.wait('@upload', { requestTimeout: 30000 });

--- a/apps/user-office-frontend-e2e/cypress/integration/units.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/units.ts
@@ -91,19 +91,24 @@ context('Units tests', () => {
       cy.get('[data-cy=officer-menu-items]').contains('Units').click();
 
       cy.get('[data-cy="import-units-button"]').click();
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'application/json',
-      });
+      // NOTE: Force is needed because file input is not visible and has display: none
+      cy.get('input[type="file"]').selectFile(
+        {
+          contents: `cypress/fixtures/${fileName}`,
+          fileName: fileName,
+        },
+        { force: true }
+      );
 
       cy.get('[data-cy="back-button"]').click();
 
-      cy.get('input[type="file"]').attachFixture({
-        filePath: fileName,
-        fileName: fileName,
-        mimeType: 'application/json',
-      });
+      cy.get('input[type="file"]').selectFile(
+        {
+          contents: `cypress/fixtures/${fileName}`,
+          fileName: fileName,
+        },
+        { force: true }
+      );
 
       cy.get('[data-cy="import-units-button"]').should('be.disabled');
 

--- a/apps/user-office-frontend-e2e/cypress/support/utils.ts
+++ b/apps/user-office-frontend-e2e/cypress/support/utils.ts
@@ -1,4 +1,3 @@
-import 'cypress-file-upload';
 import 'cypress-real-events';
 
 import { faker } from '@faker-js/faker';

--- a/apps/user-office-frontend-e2e/package-lock.json
+++ b/apps/user-office-frontend-e2e/package-lock.json
@@ -11,7 +11,6 @@
         "@faker-js/faker": "^7.5.0",
         "@types/luxon": "^2.4.0",
         "cypress": "^9.7.0",
-        "cypress-file-upload": "^6.0.0-beta.0",
         "cypress-real-events": "^1.7.4",
         "graphql": "^15.8.0",
         "graphql-request": "^3.7.0",
@@ -994,17 +993,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/cypress-file-upload": {
-      "version": "6.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-6.0.0-beta.0.tgz",
-      "integrity": "sha512-6CDL3TKpLoPl0zme9twxQqfyI/SkzOjryy/Q49ijF4MD6ZXfoos1JZJY0wtWNqNJI9sy1YxH7OrlWVD0AlAigQ==",
-      "engines": {
-        "node": ">=12.18.3"
-      },
-      "peerDependencies": {
-        "cypress": ">=6.0.0"
       }
     },
     "node_modules/cypress-real-events": {
@@ -4578,12 +4566,6 @@
           "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q=="
         }
       }
-    },
-    "cypress-file-upload": {
-      "version": "6.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-6.0.0-beta.0.tgz",
-      "integrity": "sha512-6CDL3TKpLoPl0zme9twxQqfyI/SkzOjryy/Q49ijF4MD6ZXfoos1JZJY0wtWNqNJI9sy1YxH7OrlWVD0AlAigQ==",
-      "requires": {}
     },
     "cypress-real-events": {
       "version": "1.7.4",

--- a/apps/user-office-frontend-e2e/package.json
+++ b/apps/user-office-frontend-e2e/package.json
@@ -7,7 +7,6 @@
     "@faker-js/faker": "^7.5.0",
     "@types/luxon": "^2.4.0",
     "cypress": "^9.7.0",
-    "cypress-file-upload": "^6.0.0-beta.0",
     "cypress-real-events": "^1.7.4",
     "graphql": "^15.8.0",
     "graphql-request": "^3.7.0",

--- a/apps/user-office-frontend-e2e/tsconfig.json
+++ b/apps/user-office-frontend-e2e/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "lib": ["ES6", "dom"],
-    "types": ["node", "cypress", "cypress-file-upload", "./cypress/types"],
+    "types": ["node", "cypress", "./cypress/types"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/apps/user-office-frontend/src/components/common/FileUploadComponent.tsx
+++ b/apps/user-office-frontend/src/components/common/FileUploadComponent.tsx
@@ -211,6 +211,7 @@ export function FileEntry(props: {
 }
 
 export function NewFileEntry(props: {
+  question?: string;
   filetype: string | undefined;
   onUploadComplete: (data: FileMetaData) => void;
 }) {
@@ -312,7 +313,11 @@ export function NewFileEntry(props: {
               multiple={false}
               onChange={onFileSelected}
             />
-            <Button variant="outlined" component="span">
+            <Button
+              variant="outlined"
+              component="span"
+              data-cy={props.question}
+            >
               <AddCircleOutlineIcon className={classes.addIcon} /> Attach file
             </Button>
           </label>
@@ -365,6 +370,7 @@ const useStyles = makeStyles(() => ({
 export function FileUploadComponent(props: {
   maxFiles?: number; // 0 is unlimited
   id?: string;
+  question?: string;
   fileType: string;
   pdfPageLimit: number; // 0 is unlimited
   value: FileIdWithCaptionAndFigure[];
@@ -426,7 +432,11 @@ export function FileUploadComponent(props: {
   let newFileEntry;
   if (files.length < maxFiles || maxFiles === 0) {
     newFileEntry = (
-      <NewFileEntry filetype={fileType} onUploadComplete={onUploadComplete} />
+      <NewFileEntry
+        filetype={fileType}
+        question={props.question}
+        onUploadComplete={onUploadComplete}
+      />
     );
   }
 

--- a/apps/user-office-frontend/src/components/common/FileUploadComponent.tsx
+++ b/apps/user-office-frontend/src/components/common/FileUploadComponent.tsx
@@ -211,7 +211,6 @@ export function FileEntry(props: {
 }
 
 export function NewFileEntry(props: {
-  question?: string;
   filetype: string | undefined;
   onUploadComplete: (data: FileMetaData) => void;
 }) {
@@ -304,24 +303,18 @@ export function NewFileEntry(props: {
       );
     case UPLOAD_STATE.PRISTINE:
       return (
-        <>
-          <label>
-            <input
-              accept={props.filetype}
-              style={{ display: 'none' }}
-              type="file"
-              multiple={false}
-              onChange={onFileSelected}
-            />
-            <Button
-              variant="outlined"
-              component="span"
-              data-cy={props.question}
-            >
-              <AddCircleOutlineIcon className={classes.addIcon} /> Attach file
-            </Button>
-          </label>
-        </>
+        <label>
+          <input
+            accept={props.filetype}
+            style={{ display: 'none' }}
+            type="file"
+            multiple={false}
+            onChange={onFileSelected}
+          />
+          <Button variant="outlined" component="span">
+            <AddCircleOutlineIcon className={classes.addIcon} /> Attach file
+          </Button>
+        </label>
       );
     case UPLOAD_STATE.ABORTED:
       return (
@@ -370,7 +363,6 @@ const useStyles = makeStyles(() => ({
 export function FileUploadComponent(props: {
   maxFiles?: number; // 0 is unlimited
   id?: string;
-  question?: string;
   fileType: string;
   pdfPageLimit: number; // 0 is unlimited
   value: FileIdWithCaptionAndFigure[];
@@ -432,11 +424,7 @@ export function FileUploadComponent(props: {
   let newFileEntry;
   if (files.length < maxFiles || maxFiles === 0) {
     newFileEntry = (
-      <NewFileEntry
-        filetype={fileType}
-        question={props.question}
-        onUploadComplete={onUploadComplete}
-      />
+      <NewFileEntry filetype={fileType} onUploadComplete={onUploadComplete} />
     );
   }
 

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/FileUpload/QuestionaryComponentFileUpload.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/FileUpload/QuestionaryComponentFileUpload.tsx
@@ -49,7 +49,6 @@ export function QuestionaryComponentFileUpload(
       </FormLabel>
       <FileUploadComponent
         id={answer.question.id}
-        question={answer.question.question}
         maxFiles={config.max_files}
         pdfPageLimit={config.pdf_page_limit}
         fileType={config.file_type ? config.file_type.join(',') : ''}

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/FileUpload/QuestionaryComponentFileUpload.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/FileUpload/QuestionaryComponentFileUpload.tsx
@@ -49,6 +49,7 @@ export function QuestionaryComponentFileUpload(
       </FormLabel>
       <FileUploadComponent
         id={answer.question.id}
+        question={answer.question.question}
         maxFiles={config.max_files}
         pdfPageLimit={config.pdf_page_limit}
         fileType={config.file_type ? config.file_type.join(',') : ''}


### PR DESCRIPTION
## Description

This PR aims to improve tests and remove duplicates.

## Motivation and Context

1. In the template tests we had duplicate tests that were left after some splitting in multiple files.
2. Remove `cypress-file-upload` package cause it is not needed after cypress introduced `cy.selectFile` command on their own.
