### PR TITLE
Fix: click on empty space should not trigger url redirection

### DIFF
--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx
@@ -29,7 +29,8 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: theme.spacing(0.5),
   },
   textRightAlign: {
-    textAlign: 'right',
+    marginLeft: 'auto',
+    marginRight: 0,
   },
   closeButton: {
     position: 'absolute',


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->



<!--- Describe your changes in detail -->

Click empty space should not trigger url redirection

<!--- Why is this change required? What problem does it solve? -->

When user accidentally click empty space right below the input field it triggers View/Edit all units button.


## Changes

apps/user-office-frontend/src/components/questionary/questionaryComponents/NumberInput/QuestionNumberInputForm.tsx

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
