### PR TITLE
fix: improve toast success message when saving submitted proposal

### DIFF
--- a/apps/user-office-frontend/src/components/questionary/QuestionaryStepView.tsx
+++ b/apps/user-office-frontend/src/components/questionary/QuestionaryStepView.tsx
@@ -9,6 +9,7 @@ import { NavigButton } from 'components/common/NavigButton';
 import UOLoader from 'components/common/UOLoader';
 import { Answer, QuestionaryStep, Sdk } from 'generated/sdk';
 import { usePreSubmitActions } from 'hooks/questionary/useSubmitActions';
+import { ProposalSubmissionState } from 'models/questionary/proposal/ProposalSubmissionState';
 import {
   areDependenciesSatisfied,
   getQuestionaryStepByTopicId as getStepByTopicId,
@@ -92,6 +93,10 @@ export default function QuestionaryStepView(props: {
 
   const { state, dispatch } = useContext(QuestionaryContext);
 
+  const [isProposalSubmitted] = useState(
+    () => (state as ProposalSubmissionState)?.proposal?.submitted ?? false
+  );
+
   if (!state || !dispatch) {
     throw new Error(createMissingContextErrorMessage());
   }
@@ -168,7 +173,9 @@ export default function QuestionaryStepView(props: {
     }
 
     const answerTopicResult = await api({
-      toastSuccessMessage: 'Saved',
+      toastSuccessMessage: isProposalSubmitted
+        ? 'Saved and proposal resubmitted'
+        : 'Saved',
     }).answerTopic({
       questionaryId: questionaryId,
       answers: prepareAnswers(activeFields),


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

When a user update their proposal (if it's in a call that allows it), they only get messages that the proposal has been "saved", which isn't clear that it has been re-submitted.

<!--- Describe your changes in detail -->

## Motivation and Context

Make it more clearer to users that each time they press save and continue  on a submitted proposal , their proposal is being resubmitted.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manual test.

## Fixes

Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/764

<!--- Does this fix a user story, if so add a reference here -->

## Changes

Files changed:

- apps/user-office-frontend/src/components/questionary/QuestionaryStepView.tsx

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
