### PR TITLE
fix(auth): logout not working, logs you back in again

### DIFF
--- a/apps/user-office-frontend/src/context/UserContextProvider.tsx
+++ b/apps/user-office-frontend/src/context/UserContextProvider.tsx
@@ -188,9 +188,11 @@ export const UserContextProvider: React.FC = (props): JSX.Element => {
             SettingsId.EXTERNAL_AUTH_LOGOUT_URL
           )?.settingsValue;
           clearSession();
-          dispatch({ type: ActionType.LOGOFFUSER, payload: null });
           if (logoutUrl) {
             window.location.assign(logoutUrl);
+          } else {
+            // if there is no logout url, just clear the user context
+            dispatch({ type: ActionType.LOGOFFUSER, payload: null });
           }
         });
     }


### PR DESCRIPTION
## Description

Clicking logout was logging you back in again. The problem was that even though the app tries to redirect to the logout page, it is interrupted because the state of the user object changed, which interrupts and refreshes the page. There is no need to set the state of the application if there is a logout URL because the state of the app will be lost anyway as soon as the URL is opened.

## Motivation and Context
Logout button should log user out of the system

## Fixes

https://jira.esss.lu.se/browse/SWAP-3018


## Depends on

N/A

