### PR TITLE
Amend workflow to allow UO to set internal deadline after grouping st…

### DIFF
--- a/apps/user-office-frontend/src/components/call/CallGeneralInfo.tsx
+++ b/apps/user-office-frontend/src/components/call/CallGeneralInfo.tsx
@@ -134,17 +134,18 @@ const CallGeneralInfo: React.FC<{
       (value) => value.id === proposalWorkflowId
     );
     if (selectedProposalWorkFlow) {
-      selectedProposalWorkFlow.proposalWorkflowConnectionGroups.map(
-        (workGroup) => {
-          const result = workGroup.connections.some((connectionStatus) => {
-            return (
-              connectionStatus.proposalStatus.shortCode ===
-              ProposalStatusDefaultShortCodes.EDITABLE_SUBMITTED_INTERNAL
-            );
-          });
-          setInternalCallDate({ showField: result, isValueSet: true });
-        }
-      );
+      const result =
+        selectedProposalWorkFlow.proposalWorkflowConnectionGroups.some(
+          (workGroup) => {
+            return workGroup.connections.some((connectionStatus) => {
+              return (
+                connectionStatus.proposalStatus.shortCode ===
+                ProposalStatusDefaultShortCodes.EDITABLE_SUBMITTED_INTERNAL
+              );
+            });
+          }
+        );
+      setInternalCallDate({ showField: result, isValueSet: true });
     }
   }, [proposalWorkflowId, proposalWorkflows]);
 


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/820
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Previously, grouping the statuses in the workflow for a call with an internal deadline would not allow the User Officer to set an internal deadline.

![image](https://user-images.githubusercontent.com/69144386/218702709-9e3e5da9-ee62-4ba6-a367-87df81887045.png)

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
These changes allow the User Officer to group statuses within a workflow for a call with an internal deadline.
## How Has This Been Tested
Manually tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->
Amended `CallGeneralInfo.tsx`  to set the internal call date if the workflow has editable submitted internal.
## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
