### PR TITLE
Fix: reference number gap because the SUBMITTED button on result page is clicked multiple times after a proposal submission #740

### DIFF
--- a/apps/user-office-backend/src/mutations/ProposalMutations.ts
+++ b/apps/user-office-backend/src/mutations/ProposalMutations.ts
@@ -226,6 +226,12 @@ export default class ProposalMutations {
         proposalPk,
       });
     }
+    if (proposal.submitted) {
+      return rejection('Can not submit the proposal again', {
+        agent,
+        proposal,
+      });
+    }
 
     return this.submitProposal(agent, proposal);
   }

--- a/apps/user-office-frontend/src/components/proposal/ProposalSummary.tsx
+++ b/apps/user-office-frontend/src/components/proposal/ProposalSummary.tsx
@@ -50,6 +50,9 @@ function ProposalReview({ confirm }: ProposalSummaryProps) {
 
   const proposal = state.proposal;
 
+  // Declare state of submission. This is first submission. (3-Feb-23)
+  const [firstSubmit, setFirstSubmit] = React.useState(true);
+
   const downloadPDFProposal = useDownloadPDFProposal();
 
   const allStepsComplete =
@@ -172,6 +175,7 @@ function ProposalReview({ confirm }: ProposalSummaryProps) {
                     itemWithQuestionary: submitProposal,
                   });
                 } finally {
+                  setFirstSubmit(false); //Set state after first submission. (3-Feb-23)
                   setIsSubmitting(false);
                 }
               },
@@ -181,7 +185,7 @@ function ProposalReview({ confirm }: ProposalSummaryProps) {
               }
             )();
           }}
-          disabled={submitDisabled}
+          disabled={submitDisabled || !firstSubmit} //Disable button after first submission. (3-Feb-23)
           isBusy={isSubmitting}
           data-cy="button-submit-proposal"
         >


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/740

## Description
After a proposal submission, the SUBMITTED button is enable on the result page. If the button is clicked, the proposal is re-submitted with the next reference number in the sequence. 

## Motivation and Context
To prevent a proposal re-submission. Both backend and frontend are fixed. 
1. Backend rejects the proposal re-submission after a proposal submission. 
2. Frontend disable the SUBMITTED button on the result page after a proposal submission. 

## How Has This Been Tested
Manually tested. A backend and frontend re-submission checking are added. Each fix is tested individually. 
1. Backend fix is tested first because frontend fix will disable the SUBMITTED button after a proposal submission that forbid the backend fix testing. 
2. Frontend fix is deployed and tested after backend fix is tested.  

## Changes
Amend backend file ProposalMutations.ts to reject re-submission.
Amend frontend file ProposalSummary.tsx file to disable the SUBMITTED button after a proposal submission.

## Tests included/Docs Updated?
- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
