### PR TITLE
fix: send to exchange instead of direct message queue

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [develop]
 
+env:
+  NODE_VERSION: 16.x
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   resolve_dep:
@@ -56,10 +59,6 @@ jobs:
     needs: resolve_dep
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
@@ -67,7 +66,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache node_modules
         id: cached-node-modules-root
@@ -80,7 +79,7 @@ jobs:
         if: steps.cached-node-modules-root.outputs.cache-hit != 'true'
         # We use --ignore-scripts flag to ignore the postinstall script which is actually installing dependencies in all other apps.
         # Caution! The option --ignore-scripts disables ALL scripts - even from the dependencies. If the dependencies need to run scripts to e.g. install some binaries they may break / be incomplete. For now this works and if we experience some issues we can try to find better solution.
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Cache backend node_modules
         id: cached-node-modules-backend
@@ -129,7 +128,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
         id: cached-node-modules-root
@@ -179,7 +178,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
@@ -231,7 +230,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
         id: cached-node-modules-root

--- a/apps/user-office-backend/package-lock.json
+++ b/apps/user-office-backend/package-lock.json
@@ -15,7 +15,7 @@
         "@graphql-tools/utils": "^9.1.3",
         "@user-office-software/duo-localisation": "^1.2.0",
         "@user-office-software/duo-logger": "^2.1.1",
-        "@user-office-software/duo-message-broker": "^1.4.0",
+        "@user-office-software/duo-message-broker": "^1.4.2",
         "@user-office-software/duo-validation": "^3.4.3",
         "@user-office-software/openid": "^1.2.1",
         "await-to-js": "^2.1.1",
@@ -2643,26 +2643,17 @@
       }
     },
     "node_modules/@user-office-software/duo-message-broker": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.4.0.tgz",
-      "integrity": "sha512-/NUaIA7Ztq0TvbZczpSXJ5++8bOq2ftrdZ/ihmDgzt3Sg7OTwtIcTemOBIO78wHJ4ocyqnAMb3JecouijAjzUA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.4.2.tgz",
+      "integrity": "sha512-lvZ1iLuGa6ETyKQrOB1o4b+6fTL/QswZ5bNt4bZEavlkeOYw5sdDA7TfG76uC/WwtXKFO5ZCcL0K2LqrfwoE6Q==",
       "dependencies": {
         "@types/amqplib": "^0.8.2",
-        "@user-office-software/duo-logger": "^1.1.3",
-        "amqplib": "^0.10.2"
+        "@user-office-software/duo-logger": "^2.1.1",
+        "amqplib": "^0.10.3"
       },
       "engines": {
         "node": ">=16.14.0",
         "npm": ">=8.5.0"
-      }
-    },
-    "node_modules/@user-office-software/duo-message-broker/node_modules/@user-office-software/duo-logger": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-logger/-/duo-logger-1.2.0.tgz",
-      "integrity": "sha512-/4DnoO8ehMIofExIdRrmwE7pOp40KG3PPvgV4dDDGHKz9dlmAvjARAgo46y5etw6L9ME6ZUsEkczFll0D6AQJw==",
-      "dependencies": {
-        "fast-safe-stringify": "^2.1.1",
-        "gelf-pro": "^1.3.6"
       }
     },
     "node_modules/@user-office-software/duo-validation": {
@@ -14311,24 +14302,13 @@
       }
     },
     "@user-office-software/duo-message-broker": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.4.0.tgz",
-      "integrity": "sha512-/NUaIA7Ztq0TvbZczpSXJ5++8bOq2ftrdZ/ihmDgzt3Sg7OTwtIcTemOBIO78wHJ4ocyqnAMb3JecouijAjzUA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.4.2.tgz",
+      "integrity": "sha512-lvZ1iLuGa6ETyKQrOB1o4b+6fTL/QswZ5bNt4bZEavlkeOYw5sdDA7TfG76uC/WwtXKFO5ZCcL0K2LqrfwoE6Q==",
       "requires": {
         "@types/amqplib": "^0.8.2",
-        "@user-office-software/duo-logger": "^1.1.3",
-        "amqplib": "^0.10.2"
-      },
-      "dependencies": {
-        "@user-office-software/duo-logger": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@user-office-software/duo-logger/-/duo-logger-1.2.0.tgz",
-          "integrity": "sha512-/4DnoO8ehMIofExIdRrmwE7pOp40KG3PPvgV4dDDGHKz9dlmAvjARAgo46y5etw6L9ME6ZUsEkczFll0D6AQJw==",
-          "requires": {
-            "fast-safe-stringify": "^2.1.1",
-            "gelf-pro": "^1.3.6"
-          }
-        }
+        "@user-office-software/duo-logger": "^2.1.1",
+        "amqplib": "^0.10.3"
       }
     },
     "@user-office-software/duo-validation": {

--- a/apps/user-office-backend/package.json
+++ b/apps/user-office-backend/package.json
@@ -39,7 +39,7 @@
     "@graphql-tools/utils": "^9.1.3",
     "@user-office-software/duo-localisation": "^1.2.0",
     "@user-office-software/duo-logger": "^2.1.1",
-    "@user-office-software/duo-message-broker": "^1.4.0",
+    "@user-office-software/duo-message-broker": "^1.4.2",
     "@user-office-software/duo-validation": "^3.4.3",
     "@user-office-software/openid": "^1.2.1",
     "await-to-js": "^2.1.1",

--- a/apps/user-office-backend/src/eventHandlers/messageBroker.ts
+++ b/apps/user-office-backend/src/eventHandlers/messageBroker.ts
@@ -30,14 +30,17 @@ type Member = {
 };
 
 type ProposalMessageData = {
+  abstract: string;
+  allocatedTime: number;
+  callId: number;
+  instrument?: Pick<Instrument, 'id' | 'shortCode'>;
+  members: Member[];
+  newStatus?: string;
   proposalPk: number;
+  proposer?: Member;
   shortCode: string;
   title: string;
-  abstract: string;
-  newStatus?: string;
-  members: Member[];
-  proposer?: Member;
-  instrument?: Pick<Instrument, 'id' | 'shortCode'>;
+  instrumentId?: number; // instrumentId is here for backwards compatibility.
 };
 
 let rabbitMQCachedBroker: null | RabbitMQMessageBroker = null;
@@ -87,6 +90,11 @@ const getProposalMessageData = async (proposal: Proposal) => {
   const instrumentDataSource = container.resolve<InstrumentDataSource>(
     Tokens.InstrumentDataSource
   );
+
+  const callDataSource = container.resolve<CallDataSource>(
+    Tokens.CallDataSource
+  );
+
   const proposalStatus = await proposalSettingsDataSource.getProposalStatus(
     proposal.statusId
   );
@@ -97,6 +105,16 @@ const getProposalMessageData = async (proposal: Proposal) => {
 
   const maybeInstrument = await instrumentDataSource.getInstrumentByProposalPk(
     proposal.primaryKey
+  );
+
+  const call = await callDataSource.getCall(proposal.callId);
+  if (!call) {
+    throw new Error('Call not found');
+  }
+
+  const proposalAllocatedTime = getSecondsPerAllocationTimeUnit(
+    proposal.managementTimeAllocation,
+    call.allocationTimeUnit
   );
 
   const instrument = maybeInstrument
@@ -112,6 +130,9 @@ const getProposalMessageData = async (proposal: Proposal) => {
     instrument: instrument,
     title: proposal.title,
     abstract: proposal.abstract,
+    callId: call.id,
+    allocatedTime: proposalAllocatedTime,
+    instrumentId: instrument?.id,
     members: proposalUsers.map((proposalUser) => ({
       firstName: proposalUser.firstname,
       lastName: proposalUser.lastname,
@@ -153,6 +174,7 @@ const getSecondsPerAllocationTimeUnit = (
 };
 
 export function createPostToRabbitMQHandler() {
+  const EXCHANGE_NAME = 'user_office_backend.fanout';
   const rabbitMQ = getRabbitMQMessageBroker();
 
   const proposalSettingsDataSource =
@@ -162,12 +184,6 @@ export function createPostToRabbitMQHandler() {
 
   const proposalDataSource = container.resolve<ProposalDataSource>(
     Tokens.ProposalDataSource
-  );
-  const instrumentDataSource = container.resolve<InstrumentDataSource>(
-    Tokens.InstrumentDataSource
-  );
-  const callDataSource = container.resolve<CallDataSource>(
-    Tokens.CallDataSource
   );
 
   return async (event: ApplicationEvent) => {
@@ -184,10 +200,6 @@ export function createPostToRabbitMQHandler() {
         const proposalStatus =
           await proposalSettingsDataSource.getProposalStatus(proposal.statusId);
 
-        const instrument = await instrumentDataSource.getInstrumentByProposalPk(
-          proposal.primaryKey
-        );
-
         if (!proposalStatus) {
           logger.logError(`Unknown proposalStatus '${proposal.statusId}'`, {
             proposal,
@@ -196,59 +208,13 @@ export function createPostToRabbitMQHandler() {
           return;
         }
 
-        const call = await callDataSource.getCall(proposal.callId);
+        const message = await getProposalMessageData(event.proposal);
 
-        if (!call) {
-          logger.logError(`Proposal '${proposal.primaryKey}' has no call`, {
-            proposal,
-          });
-
-          return;
-        }
-
-        const proposalAllocatedTime = getSecondsPerAllocationTimeUnit(
-          proposal.managementTimeAllocation,
-          call.allocationTimeUnit
-        );
-
-        // NOTE: maybe use shared types?
-        const message = {
-          proposalPk: proposal.primaryKey,
-          proposalId: proposal.proposalId,
-          callId: proposal.callId,
-          allocatedTime: proposalAllocatedTime,
-          instrumentId: instrument?.id,
-          newStatus: proposalStatus.shortCode,
-        };
-
-        const schedulerMessage = JSON.stringify(message);
-
-        const fullProposalMessage = await getProposalMessageData(
-          event.proposal
-        );
-
-        // NOTE: This message is consumed by scichat
-        await rabbitMQ.sendMessage(
-          Queue.SCICHAT_PROPOSAL,
-          event.type,
-          fullProposalMessage
-        );
-        // NOTE: This message is consumed by scicat
-        await rabbitMQ.sendMessage(
-          Queue.SCICAT_PROPOSAL,
-          event.type,
-          fullProposalMessage
-        );
-        // NOTE: Send message for scheduler in a separate queue
-        await rabbitMQ.sendMessage(
-          Queue.SCHEDULING_PROPOSAL,
-          event.type,
-          schedulerMessage
-        );
+        rabbitMQ.sendMessageToExchange(EXCHANGE_NAME, event.type, message);
 
         logger.logDebug(
           'Proposal event successfully sent to the message broker',
-          { eventType: event.type, fullProposalMessage }
+          { eventType: event.type, fullProposalMessage: message }
         );
 
         break;
@@ -365,20 +331,10 @@ export function createListenToRabbitMQHandler() {
         );
 
         /**
-         * NOTE: After running the workflow engine send back messages to all the queues with updated data.
+         * NOTE: After running the workflow engine, we send the message to the exchange
          */
-        rabbitMQ.sendMessage(
-          Queue.SCICHAT_PROPOSAL,
-          Event.PROPOSAL_STATUS_CHANGED_BY_WORKFLOW,
-          fullProposalMessage
-        );
-        rabbitMQ.sendMessage(
-          Queue.SCICAT_PROPOSAL,
-          Event.PROPOSAL_STATUS_CHANGED_BY_WORKFLOW,
-          fullProposalMessage
-        );
-        rabbitMQ.sendMessage(
-          Queue.SCHEDULING_PROPOSAL,
+        rabbitMQ.sendMessageToExchange(
+          'user_office_backend.fanout',
           Event.PROPOSAL_STATUS_CHANGED_BY_WORKFLOW,
           fullProposalMessage
         );


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
This PR changes so that backend does not send message directly to `queues`, but use `exchange`

## Motivation and Context

This helps decouple the services because core should now know who is listening to the events



## Changes

Message broker that is used by ESS

## Depends on
N/A
