### PR TITLE
chore: Fix failure running pipelines

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [develop]
 
+env:
+  NODE_VERSION: 16.x
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   resolve_dep:
@@ -56,10 +59,6 @@ jobs:
     needs: resolve_dep
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
@@ -67,7 +66,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: $NODE_VERSION
 
       - name: Cache node_modules
         id: cached-node-modules-root
@@ -80,7 +79,7 @@ jobs:
         if: steps.cached-node-modules-root.outputs.cache-hit != 'true'
         # We use --ignore-scripts flag to ignore the postinstall script which is actually installing dependencies in all other apps.
         # Caution! The option --ignore-scripts disables ALL scripts - even from the dependencies. If the dependencies need to run scripts to e.g. install some binaries they may break / be incomplete. For now this works and if we experience some issues we can try to find better solution.
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Cache backend node_modules
         id: cached-node-modules-backend
@@ -129,7 +128,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: $NODE_VERSION
 
       - name: Restore node_modules
         id: cached-node-modules-root
@@ -179,7 +178,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: $NODE_VERSION
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
@@ -231,7 +230,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: $NODE_VERSION
 
       - name: Restore node_modules
         id: cached-node-modules-root

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: $NODE_VERSION
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache node_modules
         id: cached-node-modules-root
@@ -128,7 +128,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: $NODE_VERSION
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
         id: cached-node-modules-root
@@ -178,7 +178,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: $NODE_VERSION
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
@@ -230,7 +230,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: $NODE_VERSION
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
         id: cached-node-modules-root


### PR DESCRIPTION
## Description

The syntax we used to use for specifying node_version appears to not work anymore, and even though v16 is specified pipeline takes node version v18

This PR simplifies the syntax and uses a simple variable to define the node version.
