### PR TITLE
Fix: 834 Cloned proposals have no validation

### DIFF
--- a/apps/user-office-backend/src/datasources/GenericTemplateDataSource.ts
+++ b/apps/user-office-backend/src/datasources/GenericTemplateDataSource.ts
@@ -4,7 +4,10 @@ import { GenericTemplatesArgs } from '../resolvers/queries/GenericTemplatesQuery
 
 export interface GenericTemplateDataSource {
   delete(genericTemplateId: number): Promise<GenericTemplate>;
-  cloneGenericTemplate(genericTemplateId: number): Promise<GenericTemplate>;
+  cloneGenericTemplate(
+    genericTemplateId: number,
+    reviewBeforeSubmit?: boolean
+  ): Promise<GenericTemplate>;
   updateGenericTemplate(
     args: UpdateGenericTemplateArgs
   ): Promise<GenericTemplate>;

--- a/apps/user-office-backend/src/datasources/QuestionaryDataSource.ts
+++ b/apps/user-office-backend/src/datasources/QuestionaryDataSource.ts
@@ -31,7 +31,10 @@ export interface QuestionaryDataSource {
     isComplete: boolean
   ): Promise<void>;
   create(creator_id: number, template_id: number): Promise<Questionary>;
-  clone(questionaryId: number): Promise<Questionary>;
+  clone(
+    questionaryId: number,
+    reviewBeforeSubmit?: boolean
+  ): Promise<Questionary>;
   copyAnswers(
     sourceQuestionaryId: number,
     targetQuestionaryId: number

--- a/apps/user-office-backend/src/datasources/mockups/GenericTemplateDataSource.ts
+++ b/apps/user-office-backend/src/datasources/mockups/GenericTemplateDataSource.ts
@@ -82,7 +82,8 @@ export class GenericTemplateDataSourceMock
   }
 
   async cloneGenericTemplate(
-    genericTemplateId: number
+    genericTemplateId: number,
+    reviewBeforeSubmit?: boolean
   ): Promise<GenericTemplate> {
     const genericTemplate = await this.getGenericTemplate(genericTemplateId);
     if (!genericTemplate) {

--- a/apps/user-office-backend/src/datasources/postgres/GenericTemplateDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/GenericTemplateDataSource.ts
@@ -21,7 +21,8 @@ export default class PostgresGenericTemplateDataSource
   ) {}
 
   async cloneGenericTemplate(
-    genericTemplateId: number
+    genericTemplateId: number,
+    reviewBeforeSubmit?: boolean
   ): Promise<GenericTemplate> {
     const sourceGenericTemplate = await this.getGenericTemplate(
       genericTemplateId
@@ -35,7 +36,8 @@ export default class PostgresGenericTemplateDataSource
     }
 
     const newQuestionary = await this.questionaryDataSource.clone(
-      sourceGenericTemplate.questionaryId
+      sourceGenericTemplate.questionaryId,
+      reviewBeforeSubmit
     );
 
     const newGenericTemplate = await this.create(

--- a/apps/user-office-backend/src/datasources/postgres/QuestionaryDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/QuestionaryDataSource.ts
@@ -440,7 +440,10 @@ export default class PostgresQuestionaryDataSource
     );
   }
 
-  async clone(questionaryId: number): Promise<Questionary> {
+  async clone(
+    questionaryId: number,
+    reviewBeforeSubmit?: boolean
+  ): Promise<Questionary> {
     const sourceQuestionary = await this.getQuestionary(questionaryId);
     if (!sourceQuestionary) {
       logger.logError(
@@ -467,11 +470,11 @@ export default class PostgresQuestionaryDataSource
           :clonedQuestionaryId
         , question_id
         , answer
-      FROM 
+      FROM
         answers
       WHERE
         questionary_id = :sourceQuestionaryId
-    `,
+      `,
       {
         clonedQuestionaryId: clonedQuestionary.questionaryId,
         sourceQuestionaryId: sourceQuestionary.questionaryId,
@@ -488,14 +491,15 @@ export default class PostgresQuestionaryDataSource
       SELECT 
           :clonedQuestionaryId
         , topic_id
-        , is_complete
+        , :reviewBeforeSubmit
       FROM
         topic_completenesses
       WHERE
         questionary_id = :sourceQuestionaryId
-    `,
+      `,
       {
         clonedQuestionaryId: clonedQuestionary.questionaryId,
+        reviewBeforeSubmit: !reviewBeforeSubmit,
         sourceQuestionaryId: sourceQuestionary.questionaryId,
       }
     );

--- a/apps/user-office-backend/src/mutations/ProposalMutations.ts
+++ b/apps/user-office-backend/src/mutations/ProposalMutations.ts
@@ -540,7 +540,8 @@ export default class ProposalMutations {
       );
 
       const clonedQuestionary = await this.questionaryDataSource.clone(
-        sourceProposal.questionaryId
+        sourceProposal.questionaryId,
+        true
       );
 
       // if user clones the proposal then it is his/her,
@@ -600,7 +601,8 @@ export default class ProposalMutations {
       for await (const genericTemplate of proposalGenericTemplates) {
         const clonedGenericTemplate =
           await this.genericTemplateDataSource.cloneGenericTemplate(
-            genericTemplate.id
+            genericTemplate.id,
+            true
           );
         await this.genericTemplateDataSource.updateGenericTemplate({
           genericTemplateId: clonedGenericTemplate.id,

--- a/apps/user-office-backend/src/queries/QuestionaryQueries.ts
+++ b/apps/user-office-backend/src/queries/QuestionaryQueries.ts
@@ -94,8 +94,6 @@ export default class QuestionaryQueries {
       return null;
     }
 
-    const q = await this.dataSource.getQuestionarySteps(questionaryId);
-
     return this.dataSource.getQuestionarySteps(questionaryId);
   }
 

--- a/apps/user-office-frontend/src/components/proposal/CallSelectModalOnProposalClone.tsx
+++ b/apps/user-office-frontend/src/components/proposal/CallSelectModalOnProposalClone.tsx
@@ -70,7 +70,8 @@ const CallSelectModalOnProposalsClone: React.FC<
               component="h1"
               className={classes.cardHeader}
             >
-              Clone proposal/s to call
+              Clone proposal/s to call. You will need to review the proposal
+              before it is submitted.
             </Typography>
 
             <Grid container spacing={3}>

--- a/apps/user-office-frontend/src/components/proposal/ProposalSummary.tsx
+++ b/apps/user-office-frontend/src/components/proposal/ProposalSummary.tsx
@@ -57,21 +57,22 @@ function ProposalReview({ confirm }: ProposalSummaryProps) {
     proposal.questionary.steps.every((step) => step.isCompleted);
 
   const [submitDisabled] = useState(() => {
-    const submitionDisabled =
+    const submissionDisabled =
       (!isUserOfficer && callHasEnded) || // disallow submit for non user officers if the call ended
       !allStepsComplete ||
       proposal.submitted;
 
     if (
       !proposal.submitted &&
-      submitionDisabled &&
+      submissionDisabled &&
       isInternalUser &&
-      isCallActiveInternal
+      isCallActiveInternal &&
+      allStepsComplete
     ) {
       return false; // allow submit for intenal users if the call ended
     }
 
-    return submitionDisabled;
+    return submissionDisabled;
   });
 
   // Show a different submit confirmation if


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/834
## Description

Added a flag to stop cloning a proposal to mark a topic as complete so now a user must review and save all the steps in the front. This was done as if template constraints change the cloned data and could violate them but still be submitted. I have done this through a flag rather than as default behavior as the clone method is used in various places where I am unsure if this validation would be needed. There was also a bug were internal users could submit uncompleted proposals which we (STFC) should probably hotfix right away.

A previous version that I have saved locally wouldn't clone any answers that violated any of the questionaries constraints but I felt keeping the old answers made more sense for when the user is reviewing the proposal. If others disagree I can add it back. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
