### PR TITLE
fix: return the updated user after external token login instead of the old version

### DIFF
--- a/apps/user-office-backend/src/auth/OAuthAuthorization.ts
+++ b/apps/user-office-backend/src/auth/OAuthAuthorization.ts
@@ -131,7 +131,7 @@ export abstract class OAuthAuthorization extends UserAuthorization {
     const user = userWithOAuthSubMatch ?? userWithEmailMatch;
 
     if (user) {
-      await this.userDataSource.update({
+      const updatedUser = await this.userDataSource.update({
         ...user,
         firstname: userInfo.given_name,
         lastname: userInfo.family_name,
@@ -146,7 +146,7 @@ export abstract class OAuthAuthorization extends UserAuthorization {
         organisation: institutionId ?? user.organisation,
       });
 
-      return user;
+      return updatedUser;
     } else {
       const newUser = await this.userDataSource.create(
         'unspecified',


### PR DESCRIPTION
## Description

This PR fixes the return of old user's data after `externalTokenLogin` update of the user.

## Motivation and Context

The old data was returned instead of updated user.
