### PR TITLE
Fix: Failure of PDF file upload of proposal because the filename contains a period char #742

### DIFF
--- a/apps/user-office-frontend/src/components/common/FileUploadComponent.tsx
+++ b/apps/user-office-frontend/src/components/common/FileUploadComponent.tsx
@@ -255,7 +255,7 @@ export function NewFileEntry(props: {
   };
 
   const hasExtension = (file: File) => {
-    return file.name.split('.').length - 1 == 1;
+    return file.name.split('.').length - 1 >= 1;
   };
 
   const onFileSelected = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/742

## Description
The proposal submission system requests upload of science case PDF file for specific proposal template. If the upload file name has additional periods beyond the file extension, the system prevents the upload without reason given. 

## Motivation and Context
To accept upload file name that is supported by browser. 

## How Has This Been Tested
Manually tested pdf file upload process by using file with name contain periods beyond the file extension.

## Changes
Amend frontend file FileUploadComponent.tsx to accept file with name contain periods beyond the file extension.

## Tests included/Docs Updated?
- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
