### PR TITLE
test: improve failing e2e test because of too long topic_title randomly generated

### DIFF
--- a/apps/user-office-backend/db_patches/0131_AddProposalClonedEvent.sql
+++ b/apps/user-office-backend/db_patches/0131_AddProposalClonedEvent.sql
@@ -1,0 +1,12 @@
+DO
+$$
+BEGIN
+	IF register_patch('AddProposalClonedEvent.sql', 'martintrajanovski', 'Add proposal_cloned event', '2023-03-28') THEN
+        BEGIN
+            ALTER TABLE proposal_events
+            ADD COLUMN proposal_cloned BOOLEAN DEFAULT FALSE;
+        END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/user-office-backend/src/mutations/TemplateMutations.ts
+++ b/apps/user-office-backend/src/mutations/TemplateMutations.ts
@@ -444,7 +444,7 @@ export default class TemplateMutations {
   @Authorized([Roles.USER_OFFICER])
   async updateTemplate(user: UserWithRole | null, args: UpdateTemplateArgs) {
     return this.dataSource.updateTemplate(args).catch((err) => {
-      return rejection('Could not update topic order', { user }, err);
+      return rejection('Could not update template topic order', { user }, err);
     });
   }
 

--- a/apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts
+++ b/apps/user-office-frontend-e2e/cypress/integration/generic_templates.ts
@@ -216,7 +216,7 @@ context('GenericTemplates tests', () => {
                 topicResult.createTopic.steps.length - 1
               ].topic.id;
             cy.updateTopic({
-              title: faker.lorem.words(4),
+              title: faker.lorem.words(2),
               templateId: proposalTemplateId,
               sortOrder: index + 1,
               topicId,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Fix the flaky e2e test that was failing because sometimes faker generates too long topic_title.

## Motivation and Context

E2e test was flaky

## How Has This Been Tested

- manual tests
- e2e tests

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
