### PR TITLE
Fix: Generic templates show ambiguous error message when data input does not meet constraints #644

### DIFF
--- a/apps/user-office-backend/src/mutations/QuestionaryMutations.ts
+++ b/apps/user-office-backend/src/mutations/QuestionaryMutations.ts
@@ -112,7 +112,9 @@ export default class QuestionaryMutations {
           !(await isMatchingConstraints(questionTemplateRelation, value))
         ) {
           return rejection(
-            'Can not answer topic because provided value is not satisfying constraint',
+            'Please enter a valid input for "' +
+              questionTemplateRelation.question.question +
+              '"',
             { answer, questionTemplateRelation }
           );
         }


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/664

## Description
The backend of proposal submission system validates data input against the constraints before saving to the database. Error message is shown if data input does not meet the constraints. The message is rather ambiguous, so user do not know how to track the problem.

## Motivation and Context
Update the error message to be more friendly to help user to track the problem. 

## How Has This Been Tested
Manually tested the error message. 

## Changes
Amend backend file QuestionaryMutations.ts to return more friendly error message.

## Tests included/Docs Updated?
- [x] I have added tests to cover my changes.

![FixedErrorMsg](https://user-images.githubusercontent.com/114708346/231494557-1ada80db-ff54-465f-8ac5-7801f5448619.jpg)

