### PR TITLE
fix : dynamic multichoice add missing field to FE

### DIFF
--- a/apps/user-office-backend/src/resolvers/types/FieldConfig.ts
+++ b/apps/user-office-backend/src/resolvers/types/FieldConfig.ts
@@ -103,6 +103,7 @@ export class DynamicMultipleChoiceConfig extends ConfigBase {
   @Field(() => [String])
   options: string[];
 
+  @Field(() => Boolean)
   externalApiCall: boolean;
 }
 

--- a/apps/user-office-frontend/src/graphql/template/fragment.fieldConfig.graphql
+++ b/apps/user-office-frontend/src/graphql/template/fragment.fieldConfig.graphql
@@ -133,6 +133,7 @@ fragment fieldConfig on FieldConfig {
     url
     options
     jsonPath
+    externalApiCall
     isMultipleSelect
     variant
   }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Dynamic multichoice question only makes api call for the first time when question is created, subsequent update on question has no effect to answers. Thats due to missing `externalApiCall` flag on front-end, which is required to make new api call on backend, otherwise BE will always return the result of very first api call.

## How Has This Been Tested

- e2e
- manual

## Fixes

Dynamic multichoice questionary dropdown does not update option values on question update 




## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
