### PR TITLE
feat: Added jsonpath documentation modal for jsonpath field in dynami…

### DIFF
--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/DynamicMultipleChoice/QuestionDynamicMultipleChoiceForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/DynamicMultipleChoice/QuestionDynamicMultipleChoiceForm.tsx
@@ -233,12 +233,7 @@ export const QuestionDynamicMultipleChoiceForm: FC<QuestionFormProps> = (
                   endAdornment: (
                     <InputAdornment position="end">
                       <IconButton
-                        onClick={() =>
-                          setIsJsonPathFieldDocPopupOpen(
-                            (isJsonPathFieldDocPopupOpen) =>
-                              !isJsonPathFieldDocPopupOpen
-                          )
-                        }
+                        onClick={() => setIsJsonPathFieldDocPopupOpen(true)}
                       >
                         <Help />
                       </IconButton>

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/DynamicMultipleChoice/QuestionDynamicMultipleChoiceForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/DynamicMultipleChoice/QuestionDynamicMultipleChoiceForm.tsx
@@ -1,8 +1,27 @@
+import { Help } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  tableCellClasses,
+} from '@mui/material';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import { SelectChangeEvent } from '@mui/material/Select';
+import { styled } from '@mui/material/styles';
 import { Field } from 'formik';
 import { Checkbox, Select, TextField } from 'formik-mui';
 import React, { FC, useState } from 'react';
@@ -15,6 +34,65 @@ import { urlValidationSchema } from 'utils/helperFunctions';
 import { useNaturalKeySchema } from 'utils/userFieldValidationSchema';
 
 import { QuestionFormShell } from '../QuestionFormShell';
+
+const jsonPathFieldsDocRows = [
+  {
+    operator: '$',
+    description: 'The root element to query. This starts all path expressions.',
+  },
+  {
+    operator: '@',
+    description: 'The current node being processed by a filter predicate.',
+  },
+  {
+    operator: '*',
+    description: 'Wildcard. Available anywhere a name or numeric are required.',
+  },
+  {
+    operator: '..',
+    description: 'Deep scan. Available anywhere a name is required.',
+  },
+  {
+    operator: '.<name>',
+    description: 'Dot-notated child',
+  },
+  {
+    operator: "['<name>' (, '<name>')]",
+    description: 'Bracket-notated child or children',
+  },
+  {
+    operator: '[<number> (, <number>)]',
+    description: 'Array index or indexes',
+  },
+  {
+    operator: '[start:end]',
+    description: 'Array slice operator',
+  },
+  {
+    operator: '[?(<expression>)]',
+    description:
+      'Filter expression. Expression must evaluate to a boolean value.',
+  },
+];
+
+const CustomizedTableCell = styled(TableCell)(({ theme }) => ({
+  [`&.${tableCellClasses.head}`]: {
+    background: theme.palette.common.black,
+    color: theme.palette.common.white,
+  },
+  [`&.${tableCellClasses.body}`]: {
+    fontSize: 14,
+  },
+}));
+
+const CustomizedTableRow = styled(TableRow)(({ theme }) => ({
+  '&:nth-of-type(odd)': {
+    backgroundColor: theme.palette.action.hover,
+  },
+  '&:last-child td, &:last-child th': {
+    border: 0,
+  },
+}));
 
 export const QuestionDynamicMultipleChoiceForm: FC<QuestionFormProps> = (
   props
@@ -31,6 +109,9 @@ export const QuestionDynamicMultipleChoiceForm: FC<QuestionFormProps> = (
     { label: 'Radio', value: 'radio' },
     { label: 'Dropdown', value: 'dropdown' },
   ];
+
+  const [isJsonPathFieldDocPopupOpen, setIsJsonPathFieldDocPopupOpen] =
+    useState(false);
 
   return (
     <QuestionFormShell
@@ -148,6 +229,128 @@ export const QuestionDynamicMultipleChoiceForm: FC<QuestionFormProps> = (
                 component={TextField}
                 fullWidth
                 inputProps={{ 'data-cy': 'dynamic-url-jsonPath' }}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={() =>
+                          setIsJsonPathFieldDocPopupOpen(
+                            (isJsonPathFieldDocPopupOpen) =>
+                              !isJsonPathFieldDocPopupOpen
+                          )
+                        }
+                      >
+                        <Help />
+                      </IconButton>
+                      <Dialog
+                        open={isJsonPathFieldDocPopupOpen}
+                        onClose={() => setIsJsonPathFieldDocPopupOpen(false)}
+                        aria-labelledby="customized-dialog-title"
+                      >
+                        <DialogContent>
+                          <div>
+                            JsonPath expressions always refer to a JSON
+                            structure in the same way as XPath expression are
+                            used in combination with an XML document. The
+                            &quot;root member object&quot; in JsonPath is always
+                            referred to as $ regardless if it is an object or
+                            array.
+                            <br />
+                            <br />
+                            JsonPath expressions can use the dot–notation
+                            <br />
+                            <Box
+                              component="div"
+                              sx={{
+                                display: 'block',
+                                p: 2,
+                                my: 1,
+                                bgcolor: 'grey.300',
+                                color: 'grey.800',
+                                border: '1px solid',
+                                borderColor: (theme) =>
+                                  theme.palette.mode === 'dark'
+                                    ? 'grey.800'
+                                    : 'grey.300',
+                                borderRadius: 2,
+                                fontSize: '0.875rem',
+                              }}
+                            >
+                              <code>$.store.book[0].title</code>
+                            </Box>
+                            or the bracket–notation
+                            <br />
+                            <Box
+                              component="div"
+                              sx={{
+                                display: 'block',
+                                p: 2,
+                                my: 1,
+                                bgcolor: 'grey.300',
+                                color: 'grey.800',
+                                border: '1px solid',
+                                borderColor: (theme) =>
+                                  theme.palette.mode === 'dark'
+                                    ? 'grey.800'
+                                    : 'grey.300',
+                                borderRadius: 2,
+                                fontSize: '0.875rem',
+                              }}
+                            >
+                              <code>
+                                $[&apos;store&apos;][&apos;book&apos;][0][&apos;title&apos;]
+                              </code>
+                            </Box>
+                            <h3>Operators</h3>
+                            <TableContainer component={Paper}>
+                              <Table aria-label="customized table">
+                                <TableHead
+                                  sx={{
+                                    background: 'background.default',
+                                  }}
+                                >
+                                  <TableRow>
+                                    <CustomizedTableCell width={'45%'}>
+                                      <strong>Operator</strong>
+                                    </CustomizedTableCell>
+                                    <CustomizedTableCell width={'55%'}>
+                                      <strong>Description</strong>
+                                    </CustomizedTableCell>
+                                  </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                  {jsonPathFieldsDocRows.map((row) => (
+                                    <CustomizedTableRow key={row.operator}>
+                                      <CustomizedTableCell
+                                        component="th"
+                                        scope="row"
+                                      >
+                                        <code>{row.operator}</code>
+                                      </CustomizedTableCell>
+                                      <CustomizedTableCell>
+                                        {row.description}
+                                      </CustomizedTableCell>
+                                    </CustomizedTableRow>
+                                  ))}
+                                </TableBody>
+                              </Table>
+                            </TableContainer>
+                          </div>
+                        </DialogContent>
+                        <DialogActions>
+                          <Button
+                            variant="text"
+                            onClick={() =>
+                              setIsJsonPathFieldDocPopupOpen(false)
+                            }
+                          >
+                            CLOSE
+                          </Button>
+                        </DialogActions>
+                      </Dialog>
+                    </InputAdornment>
+                  ),
+                }}
               />
             </FormControl>
           </TitledContainer>


### PR DESCRIPTION
## Description

Add a documentation modal for jsonpath field in dynamic multi-choice question and add the content to the modal

## Motivation and Context

The JSONPath field in Dynamic Multi choice question is quite a complex field, that needs a help option to understand what it is and how to use it efficiently. Hence, we are bringing in an Info tooltip as popup, which opens up a detailed documentation of the field.

## How Has This Been Tested

- Manually

## Changes

Introducing Popup using MUI Dialog. Worked only on a single file - apps/user-office-frontend/src/components/questionary/questionaryComponents/DynamicMultipleChoice/QuestionDynamicMultipleChoiceForm.tsx

## Fixes

https://jira.esss.lu.se/browse/SWAP-3270

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
