### PR TITLE
SWAP-3111:  Handling session expiration

### DIFF
--- a/apps/user-office-frontend/src/context/UserContextProvider.tsx
+++ b/apps/user-office-frontend/src/context/UserContextProvider.tsx
@@ -19,6 +19,7 @@ interface UserContextData {
   handleLogin: React.Dispatch<string | null | undefined>;
   handleNewToken: React.Dispatch<string | null | undefined>;
   handleLogout: () => Promise<void>;
+  handleSessionExpired: () => Promise<void>;
   handleRole: React.Dispatch<string | null | undefined>;
 }
 
@@ -61,6 +62,9 @@ const initUserData: UserContextData = {
   handleLogin: (value) => value,
   handleNewToken: (value) => value,
   handleLogout: async () => {
+    return;
+  },
+  handleSessionExpired: async () => {
     return;
   },
   handleRole: (value) => value,
@@ -198,6 +202,19 @@ export const UserContextProvider: React.FC = (props): JSX.Element => {
     }
   }
 
+  async function userSessionExpiredHandler() {
+    const loginUrl = settingsContext.settingsMap.get(
+      SettingsId.EXTERNAL_AUTH_LOGIN_URL
+    )?.settingsValue;
+    clearSession();
+    if (loginUrl) {
+      window.location.assign(loginUrl);
+    } else {
+      // if there is no logout url, just clear the user context
+      dispatch({ type: ActionType.LOGOFFUSER, payload: null });
+    }
+  }
+
   return (
     <UserContext.Provider
       value={{
@@ -205,6 +222,7 @@ export const UserContextProvider: React.FC = (props): JSX.Element => {
         handleLogin: (data): void =>
           dispatch({ type: ActionType.LOGINUSER, payload: data }),
         handleLogout: userLogoutHandler,
+        handleSessionExpired: userSessionExpiredHandler,
         handleRole: (role: string): void =>
           dispatch({ type: ActionType.SELECTROLE, payload: role }),
         handleNewToken: useCallback(

--- a/apps/user-office-frontend/src/hooks/common/useDataApi.ts
+++ b/apps/user-office-frontend/src/hooks/common/useDataApi.ts
@@ -211,7 +211,8 @@ export function useDataApi() {
     FeatureId.STFC_IDLE_TIMER
   )?.isEnabled;
 
-  const { token, handleNewToken, handleLogout } = useContext(UserContext);
+  const { token, handleNewToken, handleSessionExpired } =
+    useContext(UserContext);
   const { handleUserActive, isIdle } = useContext(IdleContext);
   const { enqueueSnackbar } = useSnackbar();
 
@@ -224,7 +225,7 @@ export function useDataApi() {
               token,
               enqueueSnackbar,
               () => {
-                handleLogout();
+                handleSessionExpired();
               },
               handleUserActive,
               isIdle,
@@ -242,7 +243,7 @@ export function useDataApi() {
       isIdleContextEnabled,
       handleNewToken,
       externalAuthLoginUrl,
-      handleLogout,
+      handleSessionExpired,
     ]
   );
 }


### PR DESCRIPTION
## Description

When a users session expires the user is currently redirected to the OIDC session logout endpoint, the user should instead be redirected to re-login. The user should only be redirected to the OIDC logout on explicit  logout

## Motivation and Context

Fixes confusing behaviour for users that has had session expiring

## How Has This Been Tested

Locally

## Fixes

SWAP-3111
