### PR TITLE
Fix PI details displaying in proposal tables

### DIFF
--- a/apps/user-office-backend/src/queries/UserQueries.ts
+++ b/apps/user-office-backend/src/queries/UserQueries.ts
@@ -28,7 +28,7 @@ export default class UserQueries {
     return this.dataSource.getUser(id);
   }
 
-  @Authorized([Roles.USER_OFFICER])
+  @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST])
   async get(agent: UserWithRole | null, id: number) {
     return this.dataSource.getUser(id);
   }

--- a/apps/user-office-frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/apps/user-office-frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -78,6 +78,9 @@ let columns: Column<ProposalViewData>[] = [
     ...{ width: 'auto' },
   },
   {
+    title: 'Principal Investigator',
+    field: 'principalInvestigator',
+    emptyValue: '-',
     render: (proposalView) => {
       if (
         proposalView.principalInvestigator?.lastname &&
@@ -88,8 +91,6 @@ let columns: Column<ProposalViewData>[] = [
 
       return '';
     },
-    title: 'Principal Investigator',
-    emptyValue: '-',
   },
   {
     title: 'PI Email',

--- a/apps/user-office-frontend/src/components/proposal/ProposalTableOfficer.tsx
+++ b/apps/user-office-frontend/src/components/proposal/ProposalTableOfficer.tsx
@@ -114,6 +114,9 @@ let columns: Column<ProposalViewData>[] = [
     ...{ width: 'auto' },
   },
   {
+    title: 'Principal Investigator',
+    field: 'principalInvestigator',
+    emptyValue: '-',
     render: (proposalView) => {
       if (
         proposalView.principalInvestigator?.lastname &&
@@ -124,8 +127,6 @@ let columns: Column<ProposalViewData>[] = [
 
       return '';
     },
-    title: 'Principal Investigator',
-    emptyValue: '-',
   },
   {
     title: 'PI Email',


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

When we released today, a recent feature is that PI name and email is supposed to show in the proposal table in User Office view and Instrument Scientist view. These details weren't displaying properly

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Fixes UserOfficeProject/user-office-project-issue-tracker#860

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
