### PR TITLE
Update STFC e2e dockerfile after Cypress upgrade

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -10,13 +10,17 @@ RUN npm ci --silent
 
 # Copy e2e tests to container. Install node modules needed for e2e tests
 WORKDIR /e2e
-COPY apps/user-office-frontend-e2e/cypress.json ./user-office-frontend-e2e/
+COPY apps/user-office-frontend-e2e/cypress.config.ts ./user-office-frontend-e2e/
 COPY apps/user-office-frontend-e2e/package* ./user-office-frontend-e2e/
 COPY apps/user-office-frontend-e2e/tsconfig.json ./user-office-frontend-e2e/tsconfig.json
 COPY apps/user-office-frontend-e2e/wait-for-frontend.sh ./user-office-frontend-e2e/
 COPY apps/user-office-frontend-e2e/cypress ./user-office-frontend-e2e/cypress/
+COPY apps/user-office-frontend-e2e/webpack.config.js ./user-office-frontend-e2e/
 
 WORKDIR /e2e/user-office-frontend-e2e
 RUN npm ci --silent
+
+# Install necessary dependencies for wait-for-frontend.sh
+RUN apt-get update && apt-get install curl -y
 
 ENTRYPOINT ["npm", "run", "cy:run"]


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Part of an update to get the e2e tests running for STFC locally after the Cypress upgrade. Will additonally require https://github.com/isisbusapps/docker-orchestration/pull/438

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Part of UserOfficeProject/user-office-project-issue-tracker#862

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
