### PR TITLE
fix: Ensure that side effects when proposal is automatically assigned to instrument are run

### DIFF
--- a/apps/user-office-backend/package-lock.json
+++ b/apps/user-office-backend/package-lock.json
@@ -52,7 +52,7 @@
         "simple-oauth2": "^4.3.0",
         "soap": "^0.45.0",
         "sparkpost": "^2.1.4",
-        "tsyringe": "^4.6.0",
+        "tsyringe": "^4.8.0",
         "type-graphql": "2.0.0-beta.1",
         "yup": "^0.32.11"
       },
@@ -11770,9 +11770,9 @@
       "dev": true
     },
     "node_modules/tsyringe": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
-      "integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.8.0.tgz",
+      "integrity": "sha512-YB1FG+axdxADa3ncEtRnQCFq/M0lALGLxSZeVNbTU8NqhOVc51nnv2CISTcvc1kyv6EGPtXVr0v6lWeDxiijOA==",
       "dependencies": {
         "tslib": "^1.9.3"
       },
@@ -21440,9 +21440,9 @@
       }
     },
     "tsyringe": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
-      "integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.8.0.tgz",
+      "integrity": "sha512-YB1FG+axdxADa3ncEtRnQCFq/M0lALGLxSZeVNbTU8NqhOVc51nnv2CISTcvc1kyv6EGPtXVr0v6lWeDxiijOA==",
       "requires": {
         "tslib": "^1.9.3"
       },

--- a/apps/user-office-backend/package.json
+++ b/apps/user-office-backend/package.json
@@ -76,7 +76,7 @@
     "simple-oauth2": "^4.3.0",
     "soap": "^0.45.0",
     "sparkpost": "^2.1.4",
-    "tsyringe": "^4.6.0",
+    "tsyringe": "^4.8.0",
     "type-graphql": "2.0.0-beta.1",
     "yup": "^0.32.11"
   },

--- a/apps/user-office-backend/src/asyncJobs/jobs/checkAllCallsEnded.ts
+++ b/apps/user-office-backend/src/asyncJobs/jobs/checkAllCallsEnded.ts
@@ -1,13 +1,14 @@
 import { logger } from '@user-office-software/duo-logger';
 
 import { CallDataSource } from '../../datasources/CallDataSource';
-import { eventBus } from '../../events';
+import { resolveApplicationEventBus } from '../../events';
 import { Event } from '../../events/event.enum';
 import { UserOfficeAsyncJob } from '../startAsyncJobs';
 
 const checkCallsEnded = async (dataSource: CallDataSource) => {
   const updatedCalls = [];
   try {
+    const eventBus = resolveApplicationEventBus();
     const notEndedCalls = await dataSource.getCalls({
       isCallEndedByEvent: false,
     });
@@ -41,6 +42,7 @@ const checkCallsEnded = async (dataSource: CallDataSource) => {
   }
 };
 const checkCallsEndedInternal = async (dataSource: CallDataSource) => {
+  const eventBus = resolveApplicationEventBus();
   const updatedCalls = [];
   try {
     const notEndedInternalCalls = await dataSource.getCalls({

--- a/apps/user-office-backend/src/asyncJobs/jobs/checkCallsReviewEnded.ts
+++ b/apps/user-office-backend/src/asyncJobs/jobs/checkCallsReviewEnded.ts
@@ -1,11 +1,13 @@
 import { logger } from '@user-office-software/duo-logger';
 
 import { CallDataSource } from '../../datasources/CallDataSource';
-import { eventBus } from '../../events';
+import { resolveApplicationEventBus } from '../../events';
 import { Event } from '../../events/event.enum';
 import { UserOfficeAsyncJob } from '../startAsyncJobs';
 
 const checkCallsReviewEnded = async (dataSource: CallDataSource) => {
+  const eventBus = resolveApplicationEventBus();
+
   const isTestingMode = process.env.NODE_ENV === 'test';
 
   try {

--- a/apps/user-office-backend/src/asyncJobs/jobs/checkCallsSEPReviewEnded.ts
+++ b/apps/user-office-backend/src/asyncJobs/jobs/checkCallsSEPReviewEnded.ts
@@ -5,7 +5,7 @@ import { container } from 'tsyringe';
 import { Tokens } from '../../config/Tokens';
 import { CallDataSource } from '../../datasources/CallDataSource';
 import { SEPDataSource } from '../../datasources/SEPDataSource';
-import { eventBus } from '../../events';
+import { resolveApplicationEventBus } from '../../events';
 import { Event } from '../../events/event.enum';
 import { Call } from '../../models/Call';
 import { ReviewStatus } from '../../models/Review';
@@ -19,6 +19,7 @@ const checkAndNotifySEPReviewersBeforeReviewEnds = async (
   sepReviewNotEndedCalls: Call[],
   currentDate: DateTime
 ) => {
+  const eventBus = resolveApplicationEventBus();
   const callsThatShouldSendEmailsToSEPReviewers = sepReviewNotEndedCalls.filter(
     (sepReviewNotEndedCall) =>
       sepReviewNotEndedCall.endSEPReview.getTime() <=
@@ -49,6 +50,7 @@ const checkAndNotifySEPReviewersBeforeReviewEnds = async (
 
 // NOTE: This check is for call SEP review ended and for notifying SEP reviewers 2 days before sep review ends.
 const checkCallsSEPReviewEnded = async (dataSource: CallDataSource) => {
+  const eventBus = resolveApplicationEventBus();
   try {
     const sepReviewNotEndedCalls = await dataSource.getCalls({
       isSEPReviewEnded: false,

--- a/apps/user-office-backend/src/config/Tokens.ts
+++ b/apps/user-office-backend/src/config/Tokens.ts
@@ -6,6 +6,7 @@ export const Tokens = {
   ConfigureEnvironment: Symbol('ConfigureEnvironment'),
   ConfigureLogger: Symbol('ConfigureLogger'),
   EmailEventHandler: Symbol('EmailEventHandler'),
+  EventBus: Symbol('EventBus'),
   EventLogsDataSource: Symbol('EventLogsDataSource'),
   FeedbackDataSource: Symbol('FeedbackDataSource'),
   FileDataSource: Symbol('FileDataSource'),

--- a/apps/user-office-backend/src/config/dependencyConfigE2E.ts
+++ b/apps/user-office-backend/src/config/dependencyConfigE2E.ts
@@ -33,6 +33,7 @@ import {
   createSkipListeningHandler,
   createSkipPostingHandler,
 } from '../eventHandlers/messageBroker';
+import { createApplicationEventBus } from '../events';
 import { SkipAssetRegistrar } from '../services/assetRegistrar/skip/SkipAssetRegistrar';
 import { configureESSDevelopmentEnvironment } from './ess/configureESSEnvironment';
 import { Tokens } from './Tokens';
@@ -76,6 +77,7 @@ mapClass(Tokens.MailService, SkipSendMailService);
 mapValue(Tokens.EmailEventHandler, essEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createSkipPostingHandler());
+mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 
 mapValue(Tokens.ConfigureEnvironment, configureESSDevelopmentEnvironment);

--- a/apps/user-office-backend/src/config/dependencyConfigESS.ts
+++ b/apps/user-office-backend/src/config/dependencyConfigESS.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import 'reflect-metadata';
+
 import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
 import PostgresCallDataSource from '../datasources/postgres/CallDataSource';
@@ -32,6 +33,7 @@ import {
   createListenToRabbitMQHandler,
   createPostToRabbitMQHandler,
 } from '../eventHandlers/messageBroker';
+import { createApplicationEventBus } from '../events';
 import { EAMAssetRegistrar } from '../services/assetRegistrar/eam/EAMAssetRegistrar';
 import { configureESSDevelopmentEnvironment } from './ess/configureESSEnvironment';
 import { configureGraylogLogger } from './ess/configureGrayLogLogger';
@@ -78,6 +80,7 @@ mapClass(Tokens.MailService, SparkPostMailService);
 mapValue(Tokens.EmailEventHandler, essEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createPostToRabbitMQHandler());
+mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createListenToRabbitMQHandler());
 
 mapValue(

--- a/apps/user-office-backend/src/config/dependencyConfigSTFC.ts
+++ b/apps/user-office-backend/src/config/dependencyConfigSTFC.ts
@@ -33,6 +33,7 @@ import {
   createPostToRabbitMQHandler,
   createSkipListeningHandler,
 } from '../eventHandlers/messageBroker';
+import { createApplicationEventBus } from '../events';
 import { SkipAssetRegistrar } from '../services/assetRegistrar/skip/SkipAssetRegistrar';
 import { configureSTFCEnvironment } from './stfc/configureSTFCEnvironment';
 import { Tokens } from './Tokens';
@@ -76,6 +77,7 @@ mapClass(Tokens.MailService, SMTPMailService);
 mapValue(Tokens.EmailEventHandler, stfcEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createPostToRabbitMQHandler());
+mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 
 mapValue(Tokens.ConfigureEnvironment, configureSTFCEnvironment);

--- a/apps/user-office-backend/src/config/dependencyConfigTest.ts
+++ b/apps/user-office-backend/src/config/dependencyConfigTest.ts
@@ -32,6 +32,7 @@ import {
   createSkipListeningHandler,
   createSkipPostingHandler,
 } from '../eventHandlers/messageBroker';
+import { EventBus } from '../events/eventBus';
 import { SkipAssetRegistrar } from '../services/assetRegistrar/skip/SkipAssetRegistrar';
 import { SampleEsiDataSourceMock } from './../datasources/mockups/SampleEsiDataSource';
 import { VisitDataSourceMock } from './../datasources/mockups/VisitDataSource';
@@ -72,6 +73,7 @@ mapClass(Tokens.UserAuthorization, UserAuthorizationMock);
 mapClass(Tokens.AssetRegistrar, SkipAssetRegistrar);
 
 mapValue(Tokens.PostToMessageQueue, createSkipPostingHandler());
+mapValue(Tokens.EventBus, jest.mocked(new EventBus()));
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 
 mapClass(Tokens.MailService, SkipSendMailService);

--- a/apps/user-office-backend/src/decorators/EventBus.ts
+++ b/apps/user-office-backend/src/decorators/EventBus.ts
@@ -1,6 +1,6 @@
 import { logger } from '@user-office-software/duo-logger';
 
-import { eventBus } from '../events';
+import { resolveApplicationEventBus } from '../events';
 import { ApplicationEvent } from '../events/applicationEvents';
 import { Event } from '../events/event.enum';
 import { Rejection, isRejection } from '../models/Rejection';
@@ -39,6 +39,7 @@ const EventBusDecorator = (eventType: Event) => {
 
       // NOTE: Do not log the event in testing environment.
       if (process.env.NODE_ENV !== 'test') {
+        const eventBus = resolveApplicationEventBus();
         eventBus
           .publish(event)
           .catch((e) =>

--- a/apps/user-office-backend/src/eventHandlers/customHandler.ts
+++ b/apps/user-office-backend/src/eventHandlers/customHandler.ts
@@ -4,7 +4,7 @@ import { container } from 'tsyringe';
 import { Tokens } from '../config/Tokens';
 import { ProposalDataSource } from '../datasources/ProposalDataSource';
 import { ReviewDataSource } from '../datasources/ReviewDataSource';
-import { eventBus } from '../events';
+import { resolveApplicationEventBus } from '../events';
 import { ApplicationEvent } from '../events/applicationEvents';
 import { Event } from '../events/event.enum';
 import { ProposalEndStatus } from '../models/Proposal';
@@ -40,6 +40,7 @@ export default function createCustomHandler() {
       return;
     }
 
+    const eventBus = resolveApplicationEventBus();
     switch (event.type) {
       case Event.PROPOSAL_MANAGEMENT_DECISION_UPDATED:
         if (event.proposal.managementDecisionSubmitted) {

--- a/apps/user-office-backend/src/eventHandlers/proposalWorkflow.ts
+++ b/apps/user-office-backend/src/eventHandlers/proposalWorkflow.ts
@@ -2,7 +2,7 @@ import { container } from 'tsyringe';
 
 import { Tokens } from '../config/Tokens';
 import { ProposalDataSource } from '../datasources/ProposalDataSource';
-import { eventBus } from '../events';
+import { resolveApplicationEventBus } from '../events';
 import { ApplicationEvent } from '../events/applicationEvents';
 import { Event } from '../events/event.enum';
 import { searchObjectByKey } from '../utils/helperFunctions';
@@ -25,6 +25,8 @@ export const handleWorkflowEngineChange = async (
     event.type,
     proposal
   );
+
+  const eventBus = resolveApplicationEventBus();
 
   if (updatedProposals) {
     updatedProposals.forEach(
@@ -99,6 +101,8 @@ export default function createHandler() {
                 // NOTE: If proposal status is updated manually then we need to fire another event.
                 // TODO: This could be refactored and we use only one event instead of two. Ref. changeProposalsStatus inside ProposalMutations.ts
                 if (event.type === Event.PROPOSAL_STATUS_UPDATED) {
+                  const eventBus = resolveApplicationEventBus();
+
                   eventBus.publish({
                     type: Event.PROPOSAL_STATUS_CHANGED_BY_USER,
                     proposal: proposal,

--- a/apps/user-office-backend/src/events/index.ts
+++ b/apps/user-office-backend/src/events/index.ts
@@ -1,7 +1,18 @@
+import { container } from 'tsyringe';
+
+import { Tokens } from '../config/Tokens';
 import createEventHandlers from '../eventHandlers';
 import { ApplicationEvent } from './applicationEvents';
 import { EventBus } from './eventBus';
 
-const eventHandlers = createEventHandlers();
+export type ApplicationEventBus = EventBus<ApplicationEvent>;
 
-export const eventBus = new EventBus<ApplicationEvent>(eventHandlers);
+export function createApplicationEventBus() {
+  const eventHandlers = createEventHandlers();
+
+  return new EventBus<ApplicationEvent>(eventHandlers);
+}
+
+export function resolveApplicationEventBus() {
+  return container.resolve<ApplicationEventBus>(Tokens.EventBus);
+}

--- a/apps/user-office-backend/src/models/questionTypes/InstrumentPicker.ts
+++ b/apps/user-office-backend/src/models/questionTypes/InstrumentPicker.ts
@@ -6,10 +6,12 @@ import { container } from 'tsyringe';
 import { Tokens } from '../../config/Tokens';
 import { InstrumentDataSource } from '../../datasources/InstrumentDataSource';
 import { ProposalDataSource } from '../../datasources/ProposalDataSource';
+import InstrumentMutations from '../../mutations/InstrumentMutations';
 import { InstrumentPickerConfig } from '../../resolvers/types/FieldConfig';
 import { QuestionFilterCompareOperator } from '../Questionary';
 import { DataType, QuestionTemplateRelation } from '../Template';
 import { Question } from './QuestionRegistry';
+
 export class InstrumentOptionClass {
   constructor(public id: number, public name: string) {}
 }
@@ -75,25 +77,27 @@ export const instrumentPickerDefinition: Question<DataType.INSTRUMENT_PICKER> =
       return fallBackConfig;
     },
     async onBeforeSave(questionaryId, questionTemplateRelation, answer) {
-      const instrumentDataSource = container.resolve<InstrumentDataSource>(
-        Tokens.InstrumentDataSource
-      );
-
       const proposalDataSource = container.resolve<ProposalDataSource>(
         Tokens.ProposalDataSource
       );
+      const instrumentMutations = container.resolve(InstrumentMutations);
 
       const proposal = await proposalDataSource.getByQuestionaryId(
         questionaryId
       );
+
       if (!proposal) {
         throw new GraphQLError('Proposal not found');
       }
 
       const { value } = JSON.parse(answer.value);
-      await instrumentDataSource.assignProposalsToInstrument(
-        [proposal?.primaryKey],
-        value
-      );
+      const instrumentId = value;
+
+      await instrumentMutations.assignProposalsToInstrumentInternal(null, {
+        instrumentId,
+        proposals: [
+          { primaryKey: proposal.primaryKey, callId: proposal.callId },
+        ],
+      });
     },
   };

--- a/apps/user-office-backend/src/mutations/InstrumentMutations.ts
+++ b/apps/user-office-backend/src/mutations/InstrumentMutations.ts
@@ -125,10 +125,17 @@ export default class InstrumentMutations {
     );
   }
 
-  @EventBus(Event.PROPOSAL_INSTRUMENT_SELECTED)
-  @ValidateArgs(assignProposalsToInstrumentValidationSchema)
   @Authorized([Roles.USER_OFFICER])
   async assignProposalsToInstrument(
+    agent: UserWithRole | null,
+    args: AssignProposalsToInstrumentArgs
+  ): Promise<ProposalPks | Rejection> {
+    return this.assignProposalsToInstrumentInternal(agent, args);
+  }
+
+  @EventBus(Event.PROPOSAL_INSTRUMENT_SELECTED)
+  @ValidateArgs(assignProposalsToInstrumentValidationSchema)
+  async assignProposalsToInstrumentInternal(
     agent: UserWithRole | null,
     args: AssignProposalsToInstrumentArgs
   ): Promise<ProposalPks | Rejection> {


### PR DESCRIPTION

## Description

This PR addresses the issue that side effects were not run when instrument was assigned to the proposal, because previously onBeforeSave InstrumentPicker questionary component used data source directly
Now it calls the method on InstrumentMutations so that additional business logic is also invoked.

This however required to resolve circular dependency resolving issue, where EventBus tried to resolve some dependencies prematurely. The solution was made that EventBus was moved into dependency container as well

## Motivation and Context

Side effects should be run also when user answers the question with Instrument Picker

## How Has This Been Tested
Manual tests
E2E tests


