### PR TITLE
Hotfix: fix users not being to update proposals

### DIFF
--- a/apps/user-office-backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/UserDataSource.ts
@@ -353,7 +353,7 @@ export default class PostgresUserDataSource implements UserDataSource {
   }
 
   async ensureDummyUserExists(userId: number): Promise<User> {
-    // ensureDummyUsersExist throws an error if it could not create all users it was given,
+    // ensureDummyUsersExist throws an error if it could not create all users ot was given,
     // so on success it will always return a list of exactly 1 element here.
     // In the code below, always returning the first element should therefore be safe
     return this.ensureDummyUsersExist([userId]).then((users) => users[0]);

--- a/apps/user-office-backend/src/mutations/ProposalMutations.spec.ts
+++ b/apps/user-office-backend/src/mutations/ProposalMutations.spec.ts
@@ -148,20 +148,6 @@ test('A user not on a proposal can not update it', () => {
   ).resolves.toBeInstanceOf(Rejection);
 });
 
-test('A user can not add duplicate co-proposers', async () => {
-  return expect(
-    proposalMutations.update(dummyUserWithRole, {
-      proposalPk: 1,
-      title: 'newTitle',
-      abstract: 'newAbstract',
-      users: [dummyUserWithRole.id],
-    })
-  ).resolves.toHaveProperty(
-    'reason',
-    'Can not associate duplicate co-proposers with proposal'
-  );
-});
-
 //Submit
 
 test('A user officer can not reject a proposal that does not exist', () => {

--- a/apps/user-office-backend/src/mutations/ProposalMutations.ts
+++ b/apps/user-office-backend/src/mutations/ProposalMutations.ts
@@ -149,21 +149,6 @@ export default class ProposalMutations {
     }
 
     if (users !== undefined) {
-      if (
-        await this.userDataSource
-          .getProposalUsers(proposal.primaryKey)
-          .then((currentUsers) => {
-            return currentUsers.some((currentUser) =>
-              users.includes(currentUser.id)
-            );
-          })
-      ) {
-        return rejection(
-          'Can not associate duplicate co-proposers with proposal',
-          { primaryKey: proposalPk, agent }
-        );
-      }
-
       await this.proposalDataSource
         .setProposalUsers(proposalPk, users)
         .catch((error) => {


### PR DESCRIPTION
Fixes #275 

The check of `users.includes(currentUser.id)` will always return true as `users` contains co-proposers and `getProposalUsers()` returns the PI as well as co-proposers

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
