### PR TITLE
Fix PI name and email not showing in user officer table  after viewing proposal

### DIFF
--- a/apps/user-office-backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/user-office-backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -64,7 +64,7 @@ function toEssBasicUserDetails(
     '',
     new Date(),
     false,
-    ''
+    stfcUser.email ?? ''
   );
 }
 

--- a/apps/user-office-frontend/src/utils/helperFunctions.ts
+++ b/apps/user-office-frontend/src/utils/helperFunctions.ts
@@ -63,6 +63,7 @@ export const getProposalStatus = (
 export const fromProposalToProposalView = (proposal: Proposal) => {
   return {
     primaryKey: proposal.primaryKey,
+    principalInvestigator: proposal.proposer || null,
     title: proposal.title,
     status: proposal.status?.name || '',
     statusId: proposal.status?.id || 1,


### PR DESCRIPTION


<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
PI name and email (in User Officer role on proposals table )information  not showing after view the proposal info and then close that proposal.

<!--- Describe your changes in detail -->

## Motivation and Context

Users Officer need to see the PI information on proposals.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual 
## Fixes
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/876
<!--- Does this fix a user story, if so add a reference here -->

## Changes

Files changed:

- apps/user-office-backend/src/datasources/stfc/StfcUserDataSource.ts
- apps/user-office-frontend/src/utils/helperFunctions.ts

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [x] All relevant doc has been updated
