### PR TITLE
Add spinner while waiting for sub template answers to load

### DIFF
--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/GenericTemplate/GenericTemplateSelectModalOnCopy.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/GenericTemplate/GenericTemplateSelectModalOnCopy.tsx
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
 import MultiMenuItem from 'components/common/MultiMenuItem';
+import UOLoader from 'components/common/UOLoader';
 import {
   CopyAnswerInput,
   GenericTemplatesFilter,
@@ -79,8 +80,9 @@ const GenericTemplateSelectModalOnCopy = ({
   const classes = useStyles();
   const { api, isExecutingCall } = useDataApiWithFeedback();
   const { enqueueSnackbar } = useSnackbar();
-  const [genericTemplates, setGenericTemplates] =
-    useState<GenericTemplates>(null);
+  const [genericTemplates, setGenericTemplates] = useState<
+    NonNullable<GenericTemplates>
+  >([]);
   const [selectedProposalPk, setSelectedProposalPk] = useState<number>(0);
 
   const [genericTemplateAnswer, setGenericTemplateAnswer] = useState<string[]>(
@@ -148,107 +150,106 @@ const GenericTemplateSelectModalOnCopy = ({
 
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          {genericTemplates && (
-            <div className={classes.selectorContainer}>
-              <Autocomplete
-                id="generic-template-proposal-select"
-                aria-labelledby="generic-template-proposal-select-label"
-                fullWidth={true}
-                noOptionsText={capitalize(
-                  `No proposal(s) with matching ${question || 'answers(s)'}`
-                )}
-                disableClearable
-                onChange={(_event, selectedValue) => {
-                  setGenericTemplateAnswer([]);
-                  setSelectedProposalPk(selectedValue.proposalPk);
-                }}
-                getOptionLabel={(option) => option.proposal.title}
-                isOptionEqualToValue={(option, value) =>
-                  option.proposalPk === value.proposalPk
-                }
-                options={genericTemplates.filter(
-                  (template, index) =>
-                    genericTemplates.findIndex(
-                      (value) => value.proposalPk == template.proposalPk
-                    ) === index
-                )}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    key={params.id}
-                    data-cy="genericTemplateProposalTitle"
-                    label="Proposal title"
-                    placeholder="Select proposal title"
-                  />
-                )}
-                renderOption={(props, option) => {
-                  return (
-                    <li {...props} key={option.proposalPk}>
-                      {option.proposal.title}
-                    </li>
-                  );
-                }}
-                loading={isExecutingCall}
-              />
+          <div className={classes.selectorContainer}>
+            <Autocomplete
+              id="generic-template-proposal-select"
+              aria-labelledby="generic-template-proposal-select-label"
+              fullWidth={true}
+              noOptionsText={capitalize(
+                `No proposal(s) with matching ${question || 'answers(s)'}`
+              )}
+              disableClearable
+              onChange={(_event, selectedValue) => {
+                setGenericTemplateAnswer([]);
+                setSelectedProposalPk(selectedValue.proposalPk);
+              }}
+              getOptionLabel={(option) => option.proposal.title}
+              isOptionEqualToValue={(option, value) =>
+                option.proposalPk === value.proposalPk
+              }
+              options={genericTemplates.filter(
+                (template, index) =>
+                  genericTemplates.findIndex(
+                    (value) => value.proposalPk == template.proposalPk
+                  ) === index
+              )}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  key={params.id}
+                  data-cy="genericTemplateProposalTitle"
+                  label="Proposal title"
+                  placeholder="Select proposal title"
+                />
+              )}
+              renderOption={(props, option) => {
+                return (
+                  <li {...props} key={option.proposalPk}>
+                    {option.proposal.title}
+                  </li>
+                );
+              }}
+              loading={isExecutingCall}
+              loadingText={'Please wait loading proposal title(s)'}
+            />
 
-              <FormControl
-                fullWidth
-                disabled={selectedProposalPk ? false : true}
+            <FormControl fullWidth disabled={selectedProposalPk ? false : true}>
+              <InputLabel id="generic-template-answer-label">
+                {question || 'Answer(s)'}
+              </InputLabel>
+
+              <Select
+                labelId="generic-template-answer-select-label"
+                id="generic-template-answer-select"
+                data-cy="genericTemplateAnswers"
+                multiple={isMultipleCopySelect}
+                value={
+                  isMultipleCopySelect
+                    ? genericTemplateAnswer
+                    : genericTemplateAnswer.length > 0
+                    ? genericTemplateAnswer[0]
+                    : ''
+                }
+                onChange={(event: SelectChangeEvent<string | string[]>) => {
+                  if (Array.isArray(event.target.value)) {
+                    setGenericTemplateAnswer(event.target.value);
+                  } else {
+                    setGenericTemplateAnswer([event.target.value]);
+                  }
+                }}
+                renderValue={(selected) =>
+                  Array.isArray(selected)
+                    ? `${question || ''} selected(${selected.length})`
+                    : genericTemplates.find((value) => value.id === +selected)
+                        ?.title
+                }
+                MenuProps={{
+                  variant: 'menu',
+                }}
               >
-                <InputLabel id="generic-template-answer-label">
-                  {question || 'Answer(s)'}
-                </InputLabel>
-                <Select
-                  labelId="generic-template-answer-select-label"
-                  id="generic-template-answer-select"
-                  data-cy="genericTemplateAnswers"
-                  multiple={isMultipleCopySelect}
-                  value={
-                    isMultipleCopySelect
-                      ? genericTemplateAnswer
-                      : genericTemplateAnswer.length > 0
-                      ? genericTemplateAnswer[0]
-                      : ''
-                  }
-                  onChange={(event: SelectChangeEvent<string | string[]>) => {
-                    if (Array.isArray(event.target.value)) {
-                      setGenericTemplateAnswer(event.target.value);
-                    } else {
-                      setGenericTemplateAnswer([event.target.value]);
-                    }
-                  }}
-                  renderValue={(selected) =>
-                    Array.isArray(selected)
-                      ? `${question || ''} selected(${selected.length})`
-                      : genericTemplates.find((value) => value.id === +selected)
-                          ?.title
-                  }
-                  MenuProps={{
-                    variant: 'menu',
-                  }}
-                >
-                  {genericTemplates
-                    .filter((template) =>
-                      selectedProposalPk
-                        ? template.proposalPk === selectedProposalPk
-                        : false
-                    )
-                    .map((option) => {
-                      return (
-                        <SelectMenuItem value={option.id} key={option.id}>
-                          {option.title}
-                        </SelectMenuItem>
-                      );
-                    })}
-                </Select>
-              </FormControl>
-            </div>
-          )}
+                {genericTemplates
+                  .filter((template) =>
+                    selectedProposalPk
+                      ? template.proposalPk === selectedProposalPk
+                      : false
+                  )
+                  .map((option) => {
+                    return (
+                      <SelectMenuItem value={option.id} key={option.id}>
+                        {option.title}
+                      </SelectMenuItem>
+                    );
+                  })}
+              </Select>
+            </FormControl>
+          </div>
         </Grid>
       </Grid>
+
       <div className={classes.buttonContainer}>
+        {isExecutingCall && <UOLoader size="2em" />}
         <Button
-          disabled={genericTemplateAnswer ? false : true}
+          disabled={genericTemplateAnswer.length <= 0}
           data-cy="genericTemplateAnswerSaveButton"
           onClick={() => {
             close();


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
When copying sub template  answers sometimes it takes longer depending on the number of proposals the user has matching the question. This will add a spinner and some text to notify the user that the app is doing background processing.
<!--- Describe your changes in detail -->

## Motivation and Context


<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Manual testing.

![image](https://github.com/UserOfficeProject/user-office-core/assets/71100224/a8973273-48dc-49db-a497-f981a411732b)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/848
<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->
Files updated:

- apps/user-office-frontend/src/components/questionary/questionaryComponents/GenericTemplate/GenericTemplateSelectModalOnCopy.tsx

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [x] All relevant doc has been updated
