### PR TITLE
fix: run patches in transaction, and make sure to upsert an appsetting GRADE_PRECISION

### DIFF
--- a/apps/user-office-backend/db_patches/0133_NonIntergerGrade.sql
+++ b/apps/user-office-backend/db_patches/0133_NonIntergerGrade.sql
@@ -6,7 +6,12 @@ BEGIN
 		  INSERT INTO 
 			settings(settings_id, description)
 		  VALUES
-			('GRADE_PRECISION', 'What the increment of the grade number should be');
+			('GRADE_PRECISION', 'What the increment of the grade number should be')
+		  ON
+		    CONFLICT (settings_id)
+		  DO
+		    UPDATE SET description = EXCLUDED.description;
+
 
 			DROP VIEW proposal_table_view;
 

--- a/apps/user-office-backend/src/datasources/postgres/AdminDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/AdminDataSource.ts
@@ -274,18 +274,19 @@ export default class PostgresAdminDataSource implements AdminDataSource {
         path.join(dbPatchesFolderPath, file),
         'utf8'
       );
-      await database
-        .raw(contents)
-        .then(() => {
-          const msg = `${file} executed.`;
-          log.push(msg);
-        })
-        .catch((err) => {
-          const msg = `${file} failed: ${err}`;
-          log.push(msg);
-
-          throw log.join('\n');
-        });
+      await database.transaction(async (trx) => {
+        trx
+          .raw(contents)
+          .then(() => {
+            const msg = `${file} executed.`;
+            log.push(msg);
+          })
+          .catch((err) => {
+            const msg = `${file} failed: ${err}`;
+            log.push(msg);
+            throw log.join('\n');
+          });
+      });
     }
 
     logger.logInfo('Applying patches finished', { timestamp: new Date() });


### PR DESCRIPTION

## Description
This PR aims to add extra safety by wrapping the patch in knex transaction. In case the patch fails the rollback is automatically performed by knex.

This PR also addresses the small issue with db_patch, where db_patch tries to insert app setting. However the appsetting is already added by the code in configureESSEnvironment.ts and configureSTFCEnvironment.ts and since those run before the patches are applied, then there is a conflict when the app setting is inserted. A quick on conflict clause is addressing this issue

## Motivation and Context

Make patches more resiliant



## Fixes

SWAP-3456

## Changes

Patches


