### PR TITLE
fix: redirect to correct session expired url

### DIFF
--- a/apps/user-office-frontend/src/context/UserContextProvider.tsx
+++ b/apps/user-office-frontend/src/context/UserContextProvider.tsx
@@ -216,7 +216,12 @@ export const UserContextProvider = (props: {
     )?.settingsValue;
     clearSession();
     if (loginUrl) {
-      window.location.assign(loginUrl);
+      const url = new URL(loginUrl);
+      url.searchParams.set(
+        'redirect_uri',
+        encodeURI(`${window.location.href}external-auth`)
+      );
+      window.location.href = url.toString();
     } else {
       // if there is no logout url, just clear the user context
       dispatch({ type: ActionType.LOGOFFUSER, payload: null });


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR aims to fix the incorrect redirect URL that is used after session expired error handling.

## Motivation and Context

Before if there was a session expired error frontend was redirected to invalid login URL without `redirect_uri` parameter.

## How Has This Been Tested

- manual tests

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
