### PR TITLE
Fix: Error occurs when removing max or min value from a question #837

### DIFF
--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/RichTextInput/QuestionRichTextInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/RichTextInput/QuestionRichTextInputForm.tsx
@@ -1,10 +1,11 @@
 import { Field } from 'formik';
 import { CheckboxWithLabel, TextField } from 'formik-mui';
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import * as Yup from 'yup';
 
 import TitledContainer from 'components/common/TitledContainer';
 import { QuestionFormProps } from 'components/questionary/QuestionaryComponentRegistry';
+import { TextInputConfig } from 'generated/sdk';
 import { useNaturalKeySchema } from 'utils/userFieldValidationSchema';
 
 import { QuestionFormShell } from '../QuestionFormShell';
@@ -24,7 +25,7 @@ export const QuestionRichTextInputForm = (props: QuestionFormProps) => {
         }),
       })}
     >
-      {() => (
+      {(formikProps) => (
         <>
           <Field
             name="naturalKey"
@@ -63,6 +64,12 @@ export const QuestionRichTextInputForm = (props: QuestionFormProps) => {
               component={TextField}
               fullWidth
               data-cy="max"
+              onChange={({
+                target: { value },
+              }: ChangeEvent<HTMLInputElement>) =>
+                formikProps.setFieldValue('config.max', value || null)
+              }
+              value={(formikProps.values.config as TextInputConfig).max ?? ''}
             />
           </TitledContainer>
         </>

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/RichTextInput/QuestionTemplateRelationRichTextInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/RichTextInput/QuestionTemplateRelationRichTextInputForm.tsx
@@ -45,6 +45,12 @@ export const QuestionTemplateRelationRichTextInputForm = (
               component={TextField}
               fullWidth
               data-cy="max"
+              onChange={({
+                target: { value },
+              }: ChangeEvent<HTMLInputElement>) =>
+                formikProps.setFieldValue('config.max', value || null)
+              }
+              value={(formikProps.values.config as TextInputConfig).max ?? ''}
             />
           </TitledContainer>
 

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/TextInput/QuestionTemplateRelationTextInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/TextInput/QuestionTemplateRelationTextInputForm.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import { Field } from 'formik';
 import { CheckboxWithLabel, TextField } from 'formik-mui';
-import React from 'react';
+import { ChangeEvent, default as React } from 'react';
 import * as Yup from 'yup';
 
 import FormikUICustomEditor from 'components/common/FormikUICustomEditor';
@@ -54,6 +54,12 @@ export const QuestionTemplateRelationTextInputForm = (
               component={TextField}
               fullWidth
               data-cy="min"
+              onChange={({
+                target: { value },
+              }: ChangeEvent<HTMLInputElement>) =>
+                formikProps.setFieldValue('config.min', value || null)
+              }
+              value={(formikProps.values.config as TextInputConfig).min ?? ''}
             />
 
             <Field
@@ -64,6 +70,12 @@ export const QuestionTemplateRelationTextInputForm = (
               component={TextField}
               fullWidth
               data-cy="max"
+              onChange={({
+                target: { value },
+              }: ChangeEvent<HTMLInputElement>) =>
+                formikProps.setFieldValue('config.max', value || null)
+              }
+              value={(formikProps.values.config as TextInputConfig).max ?? ''}
             />
           </TitledContainer>
           <TitledContainer label="Options">

--- a/apps/user-office-frontend/src/components/questionary/questionaryComponents/TextInput/QuestionTextInputForm.tsx
+++ b/apps/user-office-frontend/src/components/questionary/questionaryComponents/TextInput/QuestionTextInputForm.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import { Field } from 'formik';
 import { CheckboxWithLabel, TextField } from 'formik-mui';
-import React from 'react';
+import { ChangeEvent, default as React } from 'react';
 import * as Yup from 'yup';
 
 import FormikUICustomEditor from 'components/common/FormikUICustomEditor';
@@ -74,6 +74,12 @@ export const QuestionTextInputForm = (props: QuestionFormProps) => {
               component={TextField}
               fullWidth
               data-cy="min"
+              onChange={({
+                target: { value },
+              }: ChangeEvent<HTMLInputElement>) =>
+                formikProps.setFieldValue('config.min', value || null)
+              }
+              value={(formikProps.values.config as TextInputConfig).min ?? ''}
             />
 
             <Field
@@ -84,6 +90,12 @@ export const QuestionTextInputForm = (props: QuestionFormProps) => {
               component={TextField}
               fullWidth
               data-cy="max"
+              onChange={({
+                target: { value },
+              }: ChangeEvent<HTMLInputElement>) =>
+                formikProps.setFieldValue('config.max', value || null)
+              }
+              value={(formikProps.values.config as TextInputConfig).max ?? ''}
             />
           </TitledContainer>
           <TitledContainer label="Options">


### PR DESCRIPTION
Closes # https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/837 

## Description
When removing max or min values from a Rich Text Input or Text Input the system produces an error.  

## Motivation and Context
Resolve the error when removing max or min values from a Rich Text Input or Text Input. 

## How Has This Been Tested
Manually tested user-friendly error message. 

## Changes
Update frontend pages to resolve the error.

## Tests included/Docs Updated?
- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
