### PR TITLE
Swap 3466 support sub templates

### DIFF
--- a/apps/user-office-backend/db_patches/0138_AddProposalTemplateSampleDeclaration.sql
+++ b/apps/user-office-backend/db_patches/0138_AddProposalTemplateSampleDeclaration.sql
@@ -1,0 +1,12 @@
+DO
+$$
+BEGIN
+	IF register_patch('AddProposalTemplateSampleDeclaration.sql', 'Yoganandan Pandiyan', 'Adding Sample Declaration to Proposal Template', '2023-09-20') THEN
+		BEGIN
+    	ALTER TABLE pdf_templates 
+			ADD COLUMN template_sample_declaration TEXT NOT NULL DEFAULT '';
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/user-office-backend/src/datasources/mockups/PdfTemplateDataSource.ts
+++ b/apps/user-office-backend/src/datasources/mockups/PdfTemplateDataSource.ts
@@ -15,6 +15,7 @@ const dummyPdfTemplateFactory = (values?: Partial<PdfTemplate>) => {
     values?.templateData || '...',
     values?.templateHeader || '...',
     values?.templateFooter || '...',
+    values?.templateSampleDeclaration || '...',
     values?.creatorId || 1,
     values?.created || new Date()
   );
@@ -58,6 +59,7 @@ export class PdfTemplateDataSourceMock implements PdfTemplateDataSource {
     templateData,
     templateHeader,
     templateFooter,
+    templateSampleDeclaration,
     creatorId,
   }: CreatePdfTemplateInputWithCreator): Promise<PdfTemplate> {
     dummyPdfTemplate = dummyPdfTemplateFactory({
@@ -65,6 +67,7 @@ export class PdfTemplateDataSourceMock implements PdfTemplateDataSource {
       templateData,
       templateHeader,
       templateFooter,
+      templateSampleDeclaration,
       creatorId,
     });
 

--- a/apps/user-office-backend/src/datasources/postgres/PdfTemplateDataSource.ts
+++ b/apps/user-office-backend/src/datasources/postgres/PdfTemplateDataSource.ts
@@ -20,6 +20,7 @@ export default class PostgresPdfTemplateDataSource
     templateData,
     templateHeader,
     templateFooter,
+    templateSampleDeclaration,
     creatorId,
   }: CreatePdfTemplateInputWithCreator): Promise<PdfTemplate> {
     const templates: PdfTemplateRecord[] = await database(
@@ -30,6 +31,7 @@ export default class PostgresPdfTemplateDataSource
         template_data: templateData,
         template_header: templateHeader,
         template_footer: templateFooter,
+        template_sample_declaration: templateSampleDeclaration,
         creator_id: creatorId,
       },
       '*'
@@ -88,6 +90,7 @@ export default class PostgresPdfTemplateDataSource
           template_data: args.templateData,
           template_header: args.templateHeader,
           template_footer: args.templateFooter,
+          template_sample_declaration: args.templateSampleDeclaration,
         },
         '*'
       )
@@ -127,6 +130,7 @@ export default class PostgresPdfTemplateDataSource
       templateData: sourceTemplate.template_data,
       templateHeader: sourceTemplate.template_header,
       templateFooter: sourceTemplate.template_footer,
+      templateSampleDeclaration: sourceTemplate.template_sample_declaration,
       creatorId: sourceTemplate.creator_id,
     });
 
@@ -157,6 +161,13 @@ export default class PostgresPdfTemplateDataSource
         if (filter?.pdfTemplateFooter) {
           query.where(
             'template_footer',
+            'like',
+            `%${filter.pdfTemplateFooter}%`
+          );
+        }
+        if (filter?.pdfTemplateSampleDeclaration) {
+          query.where(
+            'template_sample_declaration',
             'like',
             `%${filter.pdfTemplateFooter}%`
           );

--- a/apps/user-office-backend/src/datasources/postgres/records.ts
+++ b/apps/user-office-backend/src/datasources/postgres/records.ts
@@ -68,6 +68,7 @@ declare module 'knex/types/tables' {
     readonly template_data: string;
     readonly template_header: string;
     readonly template_footer: string;
+    readonly template_sample_declaration: string;
     readonly creator_id: number;
     readonly created_at: Date;
   }
@@ -1237,6 +1238,7 @@ export const createPdfTemplateObject = (pdfTemplate: PdfTemplateRecord) => {
     pdfTemplate.template_data,
     pdfTemplate.template_header,
     pdfTemplate.template_footer,
+    pdfTemplate.template_sample_declaration,
     pdfTemplate.creator_id,
     pdfTemplate.created_at
   );

--- a/apps/user-office-backend/src/models/PdfTemplate.ts
+++ b/apps/user-office-backend/src/models/PdfTemplate.ts
@@ -5,6 +5,7 @@ export class PdfTemplate {
     public templateData: string,
     public templateHeader: string,
     public templateFooter: string,
+    public templateSampleDeclaration: string,
     public creatorId: number,
     public created: Date
   ) {}

--- a/apps/user-office-backend/src/mutations/PdfTemplateMutations.spec.ts
+++ b/apps/user-office-backend/src/mutations/PdfTemplateMutations.spec.ts
@@ -51,6 +51,7 @@ test('A userofficer can create a PDF template', async () => {
   const templateData = '...';
   const templateHeader = '...';
   const templateFooter = '...';
+  const templateSampleDeclaration = '...';
 
   mockGetTemplate.mockImplementation((templateId: number) =>
     Promise.resolve(
@@ -65,6 +66,7 @@ test('A userofficer can create a PDF template', async () => {
       templateData,
       templateHeader,
       templateFooter,
+      templateSampleDeclaration,
     }
   );
 
@@ -81,6 +83,7 @@ test('A user cannot create a PDF template', async () => {
   const templateData = '...';
   const templateHeader = '...';
   const templateFooter = '...';
+  const templateSampleDeclaration = '...';
 
   mockGetTemplate.mockImplementation((templateId: number) =>
     Promise.resolve(
@@ -95,6 +98,7 @@ test('A user cannot create a PDF template', async () => {
       templateData,
       templateHeader,
       templateFooter,
+      templateSampleDeclaration,
     }
   );
 
@@ -106,6 +110,7 @@ test('Template must be correct type for PDF template to be created', async () =>
   const templateData = '...';
   const templateHeader = '...';
   const templateFooter = '...';
+  const templateSampleDeclaration = '...';
 
   mockGetTemplate.mockImplementation((templateId: number) =>
     Promise.resolve(
@@ -120,6 +125,7 @@ test('Template must be correct type for PDF template to be created', async () =>
       templateData,
       templateHeader,
       templateFooter,
+      templateSampleDeclaration,
     }
   );
 
@@ -131,6 +137,7 @@ test('Create PDF template database error gives friendly error', async () => {
   const templateData = '...';
   const templateHeader = '...';
   const templateFooter = '...';
+  const templateSampleDeclaration = '...';
 
   mockGetTemplate.mockImplementation((templateId: number) =>
     Promise.resolve(
@@ -147,6 +154,7 @@ test('Create PDF template database error gives friendly error', async () => {
       templateData,
       templateHeader,
       templateFooter,
+      templateSampleDeclaration,
     }
   );
 
@@ -158,6 +166,7 @@ test('A userofficer can update a PDF template', async () => {
   const newTemplateData = 'new data';
   const newTemplateHeader = 'new header';
   const newTemplateFooter = 'new footer';
+  const newTemplateSampleDeclaration = 'new sample declaration';
 
   let template = await pdfTemplateMutations.updatePdfTemplate(
     dummyUserOfficerWithRole,
@@ -166,6 +175,7 @@ test('A userofficer can update a PDF template', async () => {
       templateData: newTemplateData,
       templateHeader: newTemplateHeader,
       templateFooter: newTemplateFooter,
+      templateSampleDeclaration: newTemplateSampleDeclaration,
     }
   );
 
@@ -175,6 +185,9 @@ test('A userofficer can update a PDF template', async () => {
   expect(template.templateData).toEqual(newTemplateData);
   expect(template.templateHeader).toEqual(newTemplateHeader);
   expect(template.templateFooter).toEqual(newTemplateFooter);
+  expect(template.templateSampleDeclaration).toEqual(
+    newTemplateSampleDeclaration
+  );
 });
 
 test('A user cannot update a PDF template', async () => {
@@ -182,6 +195,7 @@ test('A user cannot update a PDF template', async () => {
   const newTemplateData = 'new data';
   const newTemplateHeader = 'new header';
   const newTemplateFooter = 'new footer';
+  const newTemplateSampleDeclaration = 'new sample declaration';
 
   const template = await pdfTemplateMutations.updatePdfTemplate(
     dummyUserWithRole,
@@ -190,6 +204,7 @@ test('A user cannot update a PDF template', async () => {
       templateData: newTemplateData,
       templateHeader: newTemplateHeader,
       templateFooter: newTemplateFooter,
+      templateSampleDeclaration: newTemplateSampleDeclaration,
     }
   );
 
@@ -201,6 +216,7 @@ test('Update PDF template database error gives friendly error', async () => {
   const newTemplateData = 'new data';
   const newTemplateHeader = 'new header';
   const newTemplateFooter = 'new footer';
+  const newTemplateSampleDeclaration = 'new sample declaration';
 
   mockUpdatePdfTemplate.mockRejectedValue(new Error('Database error'));
 
@@ -211,6 +227,7 @@ test('Update PDF template database error gives friendly error', async () => {
       templateData: newTemplateData,
       templateHeader: newTemplateHeader,
       templateFooter: newTemplateFooter,
+      templateSampleDeclaration: newTemplateSampleDeclaration,
     }
   );
 

--- a/apps/user-office-backend/src/mutations/PdfTemplateMutations.ts
+++ b/apps/user-office-backend/src/mutations/PdfTemplateMutations.ts
@@ -39,6 +39,7 @@ export default class PdfTemplateMutations {
         templateData: args.templateData,
         templateHeader: args.templateHeader,
         templateFooter: args.templateFooter,
+        templateSampleDeclaration: args.templateSampleDeclaration,
         creatorId: (agent as UserWithRole).id,
       });
     } catch (error) {

--- a/apps/user-office-backend/src/mutations/TemplateMutations.ts
+++ b/apps/user-office-backend/src/mutations/TemplateMutations.ts
@@ -131,6 +131,7 @@ export default class TemplateMutations {
           templateData: '',
           templateHeader: '',
           templateFooter: '',
+          templateSampleDeclaration: '',
           creatorId: (agent as UserWithRole).id,
         });
     }

--- a/apps/user-office-backend/src/resolvers/mutations/CreatePdfTemplateMutation.ts
+++ b/apps/user-office-backend/src/resolvers/mutations/CreatePdfTemplateMutation.ts
@@ -24,6 +24,9 @@ export class CreatePdfTemplateInput {
 
   @Field(() => String)
   templateFooter: string;
+
+  @Field(() => String)
+  templateSampleDeclaration: string;
 }
 
 @Resolver()

--- a/apps/user-office-backend/src/resolvers/mutations/UpdatePdfTemplateMutation.ts
+++ b/apps/user-office-backend/src/resolvers/mutations/UpdatePdfTemplateMutation.ts
@@ -24,6 +24,9 @@ export class UpdatePdfTemplateArgs {
 
   @Field(() => String, { nullable: true })
   templateFooter?: string;
+
+  @Field(() => String, { nullable: true })
+  templateSampleDeclaration?: string;
 }
 
 @Resolver()

--- a/apps/user-office-backend/src/resolvers/queries/PdfTemplatesQuery.ts
+++ b/apps/user-office-backend/src/resolvers/queries/PdfTemplatesQuery.ts
@@ -29,6 +29,9 @@ class PdfTemplatesFilter {
   @Field(() => String, { nullable: true })
   public pdfTemplateFooter?: string;
 
+  @Field(() => String, { nullable: true })
+  public pdfTemplateSampleDeclaration?: string;
+
   @Field(() => Int, { nullable: true })
   public creatorId?: number;
 }

--- a/apps/user-office-backend/src/resolvers/types/PdfTemplate.ts
+++ b/apps/user-office-backend/src/resolvers/types/PdfTemplate.ts
@@ -19,6 +19,9 @@ export class PdfTemplate implements Partial<PdfTemplateOrigin> {
   @Field()
   public templateFooter: string;
 
+  @Field()
+  public templateSampleDeclaration: string;
+
   @Field(() => Int)
   public creatorId: number;
 

--- a/apps/user-office-frontend-e2e/cypress/e2e/pdfTemplates.cy.ts
+++ b/apps/user-office-frontend-e2e/cypress/e2e/pdfTemplates.cy.ts
@@ -73,6 +73,19 @@ context('PDF template tests', () => {
 
       cy.notification({ variant: 'success', text: 'successfully' });
 
+      cy.contains('Sample Declaration').click();
+
+      cy.get('[data-cy="templateSampleDeclaration"] .cm-content')
+        .first()
+        .type(pdfTemplateData)
+        .should(($p) => {
+          expect($p).to.contain(pdfTemplateData);
+        });
+
+      cy.get('[data-cy=templateSampleDeclaration-submit]').click();
+
+      cy.notification({ variant: 'success', text: 'successfully' });
+
       cy.navigateToTemplatesSubmenu('PDF');
 
       cy.contains(templateName);
@@ -141,6 +154,19 @@ context('PDF template tests', () => {
 
       cy.notification({ variant: 'success', text: 'successfully' });
 
+      cy.contains('Sample Declaration').click();
+
+      cy.get('[data-cy="templateSampleDeclaration"] .cm-content')
+        .first()
+        .type(pdfTemplateData)
+        .should(($p) => {
+          expect($p).to.contain(pdfTemplateData);
+        });
+
+      cy.get('[data-cy=templateSampleDeclaration-submit]').click();
+
+      cy.notification({ variant: 'success', text: 'successfully' });
+
       cy.navigateToTemplatesSubmenu('PDF');
 
       cy.contains(createdTemplateName)
@@ -200,6 +226,19 @@ context('PDF template tests', () => {
         });
 
       cy.get('[data-cy=templateFooter-submit]').click();
+
+      cy.notification({ variant: 'success', text: 'successfully' });
+
+      cy.contains('Sample Declaration').click();
+
+      cy.get('[data-cy="templateSampleDeclaration"] .cm-content')
+        .first()
+        .type(pdfTemplateData)
+        .should(($p) => {
+          expect($p).to.contain(pdfTemplateData);
+        });
+
+      cy.get('[data-cy=templateSampleDeclaration-submit]').click();
 
       cy.notification({ variant: 'success', text: 'successfully' });
 

--- a/apps/user-office-frontend/src/components/template/PdfTemplateEditor.tsx
+++ b/apps/user-office-frontend/src/components/template/PdfTemplateEditor.tsx
@@ -26,7 +26,11 @@ interface ITemplateEditorProps<Type extends string> {
   setPdfTemplate: React.Dispatch<React.SetStateAction<PdfTemplate | null>>;
 }
 const TemplateEditor = <
-  Type extends 'templateData' | 'templateHeader' | 'templateFooter'
+  Type extends
+    | 'templateData'
+    | 'templateHeader'
+    | 'templateFooter'
+    | 'templateSampleDeclaration'
 >({
   name,
   template,
@@ -115,7 +119,9 @@ export default function PdfTemplateEditor() {
     <StyledContainer>
       <StyledPaper>
         {template && pdfTemplate && (
-          <SimpleTabs tabNames={['Body', 'Header', 'Footer']}>
+          <SimpleTabs
+            tabNames={['Body', 'Header', 'Footer', 'Sample Declaration']}
+          >
             <TemplateEditor<'templateData'>
               name="templateData"
               template={template}
@@ -139,6 +145,16 @@ export default function PdfTemplateEditor() {
               template={template}
               initialValues={{
                 templateFooter: pdfTemplate?.templateFooter,
+              }}
+              pdfTemplate={pdfTemplate}
+              setPdfTemplate={setPdfTemplate}
+            />
+            <TemplateEditor<'templateSampleDeclaration'>
+              name="templateSampleDeclaration"
+              template={template}
+              initialValues={{
+                templateSampleDeclaration:
+                  pdfTemplate?.templateSampleDeclaration,
               }}
               pdfTemplate={pdfTemplate}
               setPdfTemplate={setPdfTemplate}

--- a/apps/user-office-frontend/src/graphql/template/fragment.template.graphql
+++ b/apps/user-office-frontend/src/graphql/template/fragment.template.graphql
@@ -25,5 +25,6 @@ fragment template on Template {
     templateData
     templateHeader
     templateFooter
+    templateSampleDeclaration
   }
 }

--- a/apps/user-office-frontend/src/graphql/template/getPdfTemplate.graphql
+++ b/apps/user-office-frontend/src/graphql/template/getPdfTemplate.graphql
@@ -5,5 +5,6 @@ query getPdfTemplate($pdfTemplateId: Int!) {
     templateData
     templateHeader
     templateFooter
+    templateSampleDeclaration
   }
 }

--- a/apps/user-office-frontend/src/graphql/template/updatePdfTemplate.graphql
+++ b/apps/user-office-frontend/src/graphql/template/updatePdfTemplate.graphql
@@ -3,18 +3,21 @@ mutation updatePdfTemplate(
   $templateData: String
   $templateHeader: String
   $templateFooter: String
+  $templateSampleDeclaration: String
 ) {
   updatePdfTemplate(
     pdfTemplateId: $pdfTemplateId
     templateData: $templateData
     templateHeader: $templateHeader
     templateFooter: $templateFooter
+    templateSampleDeclaration: $templateSampleDeclaration
   ) {
     pdfTemplateId
     templateId
     templateData
     templateHeader
     templateFooter
+    templateSampleDeclaration
     created
     creatorId
   }


### PR DESCRIPTION
## Description

New PDF template field called Sample Declaration have been added alongside Body, Header and Footer. The logic is, if the Sample declaration design html is provided, it will be generated as an attachment with its own bookmark, else, it will not be generated.

## Motivation and Context

To support Sample Declaration

## How Has This Been Tested

Manually and e2e test

## Changes

New field called 'template_sample_declaration' in 'pdf_templates' table. 


## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [x] All relevant doc has been updated
