### PR TITLE
chore: limit open PRs from dependabot to avoid reaching job runners limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Limit PRs open from dependabot to avoid reaching job runners limt
+    open-pull-requests-limit: 2
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen because docker hub doesn't want slashes
       # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Add limitation of open PRs from dependabot to avoid reaching job runners limit and entering a state where we can not run our open PRs workflow correctly.