### PR TITLE
fix: The AddDefaultWorkflowToTheDefaultCall database patch has been fixed

### DIFF
--- a/apps/backend/db_patches/0137_AddDefaultWorkflowToTheDefaultCall.sql
+++ b/apps/backend/db_patches/0137_AddDefaultWorkflowToTheDefaultCall.sql
@@ -1,15 +1,18 @@
 DO
 $$
+DECLARE
+  var_proposal_workflow_id INTEGER;
 BEGIN
   IF register_patch('AddDefaultWorkflowToTheDefaultCall.sql', 'martintrajanovski', 'Adding default workflow and attaching it to a call because it is required valid call to have a workflow', '2023-08-23') THEN
     INSERT INTO proposal_workflows(name, description)
-    VALUES('Default workflow', 'This is the default workflow');
+    VALUES('Default workflow', 'This is the default workflow')
+    RETURNING proposal_workflow_id INTO var_proposal_workflow_id;
 
     INSERT INTO proposal_workflow_connections(proposal_workflow_id, proposal_status_id, next_proposal_status_id, prev_proposal_status_id, sort_order, droppable_group_id, parent_droppable_group_id)
-    VALUES(1, 1, null, null, 0, 'proposalWorkflowConnections_0', null);
+    VALUES(var_proposal_workflow_id, 1, null, null, 0, 'proposalWorkflowConnections_0', null);
 
     UPDATE call
-    SET proposal_workflow_id = 1
+    SET proposal_workflow_id = var_proposal_workflow_id
     WHERE call_id = 1;
   END IF;
 END;


### PR DESCRIPTION
## Description

The hardcoded proposal_workflow_id (1) has been removed and replaced with the value of the newly inserted row's ID.

## Motivation and Context

If the "proposal_workflows" table is not empty and does not contain any rows with an ID of 1, the insert into the proposal_workflow_connections table would violate a foreign key constraint.
With this change we are using the newly created id instead of the hardcoded 1.

## How Has This Been Tested

- Manually
