### PR TITLE
fix: deactivate call if call has SEPs

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -16,7 +16,7 @@
         "@user-office-software/duo-localisation": "^1.2.0",
         "@user-office-software/duo-logger": "^2.1.1",
         "@user-office-software/duo-message-broker": "^1.6.0",
-        "@user-office-software/duo-validation": "^3.4.14",
+        "@user-office-software/duo-validation": "^3.4.15",
         "@user-office-software/openid": "^1.3.0",
         "await-to-js": "^2.1.1",
         "axios": "^0.27.2",
@@ -2734,9 +2734,9 @@
       }
     },
     "node_modules/@user-office-software/duo-validation": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-3.4.14.tgz",
-      "integrity": "sha512-z1IyUDWAjM/rr08JzJ8y/SpdGiIFNrE9aQXQoJFtKyS7cNL0/ewV9aqlRt4ea5wXhnPgqdcFNz6lav9TGfk7Uw==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-3.4.15.tgz",
+      "integrity": "sha512-L2Ywr8m7f7XgVEz50eyMVVhhTSjLPdRCYi3HIL7nIEofK0pEqpyrjJrSTN80zCH9nNl2gHOTXnWAXNzCt7lr8w==",
       "dependencies": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",
@@ -15223,9 +15223,9 @@
       }
     },
     "@user-office-software/duo-validation": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-3.4.14.tgz",
-      "integrity": "sha512-z1IyUDWAjM/rr08JzJ8y/SpdGiIFNrE9aQXQoJFtKyS7cNL0/ewV9aqlRt4ea5wXhnPgqdcFNz6lav9TGfk7Uw==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-3.4.15.tgz",
+      "integrity": "sha512-L2Ywr8m7f7XgVEz50eyMVVhhTSjLPdRCYi3HIL7nIEofK0pEqpyrjJrSTN80zCH9nNl2gHOTXnWAXNzCt7lr8w==",
       "requires": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -16,7 +16,7 @@
         "@user-office-software/duo-localisation": "^1.2.0",
         "@user-office-software/duo-logger": "^2.1.1",
         "@user-office-software/duo-message-broker": "^1.6.0",
-        "@user-office-software/duo-validation": "^3.4.8",
+        "@user-office-software/duo-validation": "^3.4.14",
         "@user-office-software/openid": "^1.3.0",
         "await-to-js": "^2.1.1",
         "axios": "^0.27.2",
@@ -2734,9 +2734,9 @@
       }
     },
     "node_modules/@user-office-software/duo-validation": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-3.4.8.tgz",
-      "integrity": "sha512-GrDqd7ElLv1HGA8FrwUDJ5G2Z4KYB2Sigmr6BJCuGMAKVfZwyFp3BplrDzrWFBgmJRX3gxSgFVtS7Ngc7eTMlA==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-3.4.14.tgz",
+      "integrity": "sha512-z1IyUDWAjM/rr08JzJ8y/SpdGiIFNrE9aQXQoJFtKyS7cNL0/ewV9aqlRt4ea5wXhnPgqdcFNz6lav9TGfk7Uw==",
       "dependencies": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",
@@ -15223,9 +15223,9 @@
       }
     },
     "@user-office-software/duo-validation": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-3.4.8.tgz",
-      "integrity": "sha512-GrDqd7ElLv1HGA8FrwUDJ5G2Z4KYB2Sigmr6BJCuGMAKVfZwyFp3BplrDzrWFBgmJRX3gxSgFVtS7Ngc7eTMlA==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-3.4.14.tgz",
+      "integrity": "sha512-z1IyUDWAjM/rr08JzJ8y/SpdGiIFNrE9aQXQoJFtKyS7cNL0/ewV9aqlRt4ea5wXhnPgqdcFNz6lav9TGfk7Uw==",
       "requires": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -40,7 +40,7 @@
     "@user-office-software/duo-localisation": "^1.2.0",
     "@user-office-software/duo-logger": "^2.1.1",
     "@user-office-software/duo-message-broker": "^1.6.0",
-    "@user-office-software/duo-validation": "^3.4.14",
+    "@user-office-software/duo-validation": "^3.4.15",
     "@user-office-software/openid": "^1.3.0",
     "await-to-js": "^2.1.1",
     "axios": "^0.27.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -40,7 +40,7 @@
     "@user-office-software/duo-localisation": "^1.2.0",
     "@user-office-software/duo-logger": "^2.1.1",
     "@user-office-software/duo-message-broker": "^1.6.0",
-    "@user-office-software/duo-validation": "^3.4.13",
+    "@user-office-software/duo-validation": "^3.4.14",
     "@user-office-software/openid": "^1.3.0",
     "await-to-js": "^2.1.1",
     "axios": "^0.27.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -40,7 +40,7 @@
     "@user-office-software/duo-localisation": "^1.2.0",
     "@user-office-software/duo-logger": "^2.1.1",
     "@user-office-software/duo-message-broker": "^1.6.0",
-    "@user-office-software/duo-validation": "^3.4.8",
+    "@user-office-software/duo-validation": "^3.4.13",
     "@user-office-software/openid": "^1.3.0",
     "await-to-js": "^2.1.1",
     "axios": "^0.27.2",

--- a/apps/backend/src/datasources/postgres/CallDataSource.ts
+++ b/apps/backend/src/datasources/postgres/CallDataSource.ts
@@ -20,6 +20,7 @@ import {
   CallRecord,
   createCallHasInstrumentObject,
   createCallObject,
+  ProposalRecord,
 } from './records';
 
 export default class PostgresCallDataSource implements CallDataSource {
@@ -210,7 +211,13 @@ export default class PostgresCallDataSource implements CallDataSource {
          * Check if the reference number format has been changed,
          * in which case all proposals in the call need to be updated.
          */
-        const preUpdateCall = await database
+        const preUpdateCall: Pick<
+          CallRecord,
+          | 'call_id'
+          | 'reference_number_format'
+          | 'call_ended_internal'
+          | 'call_ended'
+        > = await database
           .select(
             'c.call_id',
             'c.reference_number_format',
@@ -227,12 +234,15 @@ export default class PostgresCallDataSource implements CallDataSource {
           args.referenceNumberFormat &&
           args.referenceNumberFormat !== preUpdateCall.reference_number_format
         ) {
-          const proposals = await database
+          const proposals = (await database
             .select('p.proposal_pk', 'p.reference_number_sequence')
             .from('proposals as p')
             .where({ 'p.call_id': preUpdateCall.call_id, 'p.submitted': true })
             .forUpdate()
-            .transacting(trx);
+            .transacting(trx)) as Pick<
+            ProposalRecord,
+            'proposal_pk' | 'reference_number_sequence'
+          >[];
 
           await BluePromise.map(
             proposals,
@@ -240,7 +250,7 @@ export default class PostgresCallDataSource implements CallDataSource {
               await database
                 .update({
                   proposal_id: await calculateReferenceNumber(
-                    args.referenceNumberFormat,
+                    args.referenceNumberFormat!,
                     p.reference_number_sequence
                   ),
                 })
@@ -294,6 +304,7 @@ export default class PostgresCallDataSource implements CallDataSource {
               proposal_workflow_id: args.proposalWorkflowId,
               call_ended:
                 preUpdateCall.call_ended &&
+                args.endCall &&
                 args.endCall.getTime() < currentDate.getTime(),
               call_ended_internal: args.endCallInternal
                 ? preUpdateCall.call_ended_internal &&

--- a/apps/backend/src/mutations/CallMutations.ts
+++ b/apps/backend/src/mutations/CallMutations.ts
@@ -2,6 +2,7 @@ import {
   createCallValidationSchemas,
   updateCallValidationSchemas,
   removeAssignedInstrumentFromCallValidationSchema,
+  updateCallValidationSchemaBackend,
 } from '@user-office-software/duo-validation';
 import { inject, injectable } from 'tsyringe';
 
@@ -90,7 +91,7 @@ export default class CallMutations {
     }
   }
 
-  @ValidateArgs(updateCallValidationSchema)
+  @ValidateArgs(updateCallValidationSchemaBackend)
   @Authorized([Roles.USER_OFFICER])
   async update(
     agent: UserWithRole | null,

--- a/apps/backend/src/mutations/CallMutations.ts
+++ b/apps/backend/src/mutations/CallMutations.ts
@@ -2,7 +2,7 @@ import {
   createCallValidationSchemas,
   updateCallValidationSchemas,
   removeAssignedInstrumentFromCallValidationSchema,
-  updateCallValidationSchemaBackend,
+  updateCallValidationBackendSchema,
 } from '@user-office-software/duo-validation';
 import { inject, injectable } from 'tsyringe';
 
@@ -91,7 +91,7 @@ export default class CallMutations {
     }
   }
 
-  @ValidateArgs(updateCallValidationSchemaBackend)
+  @ValidateArgs(updateCallValidationBackendSchema)
   @Authorized([Roles.USER_OFFICER])
   async update(
     agent: UserWithRole | null,

--- a/apps/backend/src/mutations/ProposalSettingsMutations.ts
+++ b/apps/backend/src/mutations/ProposalSettingsMutations.ts
@@ -643,10 +643,14 @@ export default class ProposalSettingsMutations {
   }
 
   @ValidateArgs(
-    addStatusActionsToConnectionValidationSchema<ProposalStatusActionType>(
+    addStatusActionsToConnectionValidationSchema<
+      ProposalStatusActionType,
+      string[]
+    >(
       ProposalStatusActionType.EMAIL,
       ProposalStatusActionType.RABBITMQ,
-      Object.values(ProposalStatusActionType)
+      Object.values(ProposalStatusActionType),
+      []
     )
   )
   @Authorized([Roles.USER_OFFICER])

--- a/apps/backend/src/resolvers/mutations/UpdateCallMutation.ts
+++ b/apps/backend/src/resolvers/mutations/UpdateCallMutation.ts
@@ -17,23 +17,23 @@ export class UpdateCallInput {
   @Field(() => Int)
   public id: number;
 
-  @Field()
-  public shortCode: string;
+  @Field(() => String, { nullable: true })
+  public shortCode?: string;
 
-  @Field()
-  public startCall: Date;
+  @Field(() => Date, { nullable: true })
+  public startCall?: Date;
 
-  @Field()
-  public endCall: Date;
+  @Field(() => Date, { nullable: true })
+  public endCall?: Date;
 
   @Field(() => Date, { nullable: true })
   public endCallInternal?: Date;
 
-  @Field()
-  public startReview: Date;
+  @Field(() => Date, { nullable: true })
+  public startReview?: Date;
 
-  @Field()
-  public endReview: Date;
+  @Field(() => Date, { nullable: true })
+  public endReview?: Date;
 
   @Field(() => Date, { nullable: true })
   public startSEPReview?: Date;
@@ -41,40 +41,40 @@ export class UpdateCallInput {
   @Field(() => Date, { nullable: true })
   public endSEPReview?: Date;
 
-  @Field()
-  public startNotify: Date;
+  @Field(() => Date, { nullable: true })
+  public startNotify?: Date;
 
-  @Field()
-  public endNotify: Date;
+  @Field(() => Date, { nullable: true })
+  public endNotify?: Date;
 
-  @Field()
-  public startCycle: Date;
+  @Field(() => Date, { nullable: true })
+  public startCycle?: Date;
 
-  @Field()
-  public endCycle: Date;
-
-  @Field({ nullable: true })
-  public referenceNumberFormat: string;
-
-  @Field(() => Int, { nullable: true })
-  public proposalSequence: number;
-
-  @Field()
-  public cycleComment: string;
+  @Field(() => Date, { nullable: true })
+  public endCycle?: Date;
 
   @Field({ nullable: true })
-  public submissionMessage: string;
-
-  @Field()
-  public surveyComment: string;
-
-  @Field(() => AllocationTimeUnits)
-  public allocationTimeUnit: AllocationTimeUnits;
-
-  @Field(() => Int)
-  public proposalWorkflowId: number;
+  public referenceNumberFormat?: string;
 
   @Field(() => Int, { nullable: true })
+  public proposalSequence?: number;
+
+  @Field(() => String, { nullable: true })
+  public cycleComment?: string;
+
+  @Field(() => String, { nullable: true })
+  public submissionMessage?: string;
+
+  @Field(() => String, { nullable: true })
+  public surveyComment?: string;
+
+  @Field(() => AllocationTimeUnits, { nullable: true })
+  public allocationTimeUnit?: AllocationTimeUnits;
+
+  @Field(() => Int, { nullable: true })
+  public proposalWorkflowId?: number;
+
+  @Field({ nullable: true })
   public callEnded?: boolean;
 
   @Field({ nullable: true })
@@ -86,8 +86,8 @@ export class UpdateCallInput {
   @Field(() => Int, { nullable: true })
   public callSEPReviewEnded?: boolean;
 
-  @Field(() => Int)
-  public templateId: number;
+  @Field(() => Int, { nullable: true })
+  public templateId?: number;
 
   @Field(() => Int, { nullable: true })
   public esiTemplateId?: number;
@@ -96,12 +96,12 @@ export class UpdateCallInput {
   public pdfTemplateId?: number;
 
   @Field({ nullable: true })
-  public title: string;
+  public title?: string;
 
   @Field({ nullable: true })
-  public description: string;
+  public description?: string;
 
-  @Field(() => [Int], { nullable: true })
+  @Field(() => [Int!], { nullable: true })
   public seps?: number[];
 
   @Field(() => Boolean, { nullable: true })

--- a/apps/frontend/src/components/call/CallsTable.tsx
+++ b/apps/frontend/src/components/call/CallsTable.tsx
@@ -156,7 +156,7 @@ const CallsTable = ({ confirm }: WithConfirmProps) => {
             shouldActivateCall ? 'activated' : 'deactivated'
           } successfully`,
         }).updateCall({
-          ...call,
+          id: call.id,
           isActive: shouldActivateCall,
         } as UpdateCallInput);
 

--- a/apps/frontend/src/components/call/CreateUpdateCall.tsx
+++ b/apps/frontend/src/components/call/CreateUpdateCall.tsx
@@ -13,6 +13,7 @@ import {
   AllocationTimeUnits,
   UpdateCallInput,
   TemplateGroupId,
+  CreateCallInput,
 } from 'generated/sdk';
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
 import { useActiveTemplates } from 'hooks/call/useCallTemplates';
@@ -128,7 +129,7 @@ const CreateUpdateCall = ({ call, close }: CreateUpdateCallProps) => {
           } else {
             const { createCall } = await api({
               toastSuccessMessage: 'Call created successfully!',
-            }).createCall(values as UpdateCallInput);
+            }).createCall(values as CreateCallInput);
 
             close(createCall as Call);
           }

--- a/apps/frontend/src/graphql/call/updateCall.graphql
+++ b/apps/frontend/src/graphql/call/updateCall.graphql
@@ -1,24 +1,24 @@
 mutation updateCall(
   $id: Int!
-  $shortCode: String!
-  $startCall: DateTime!
-  $endCall: DateTime!
+  $shortCode: String
+  $startCall: DateTime
+  $endCall: DateTime
   $endCallInternal: DateTime
-  $startReview: DateTime!
-  $endReview: DateTime!
+  $startReview: DateTime
+  $endReview: DateTime
   $startSEPReview: DateTime
   $endSEPReview: DateTime
-  $startNotify: DateTime!
-  $endNotify: DateTime!
-  $startCycle: DateTime!
-  $endCycle: DateTime!
-  $cycleComment: String!
+  $startNotify: DateTime
+  $endNotify: DateTime
+  $startCycle: DateTime
+  $endCycle: DateTime
+  $cycleComment: String
   $submissionMessage: String
-  $surveyComment: String!
-  $allocationTimeUnit: AllocationTimeUnits!
+  $surveyComment: String
+  $allocationTimeUnit: AllocationTimeUnits
   $referenceNumberFormat: String
-  $proposalWorkflowId: Int!
-  $templateId: Int!
+  $proposalWorkflowId: Int
+  $templateId: Int
   $esiTemplateId: Int
   $pdfTemplateId: Int
   $title: String


### PR DESCRIPTION
## Description
This pull request (PR) resolves an issue where the backend would generate an error when attempting to deactivate a call that had active SEPs. The problem stemmed from the call update process, which had certain mandatory fields. The SEP (Scientific evaluation panel) in the Call object was initially represented as an object, but the Update Call method expected it to be an array of integers. Because the call was spread throughout the update argument, the input argument was incorrect.

