### PR TITLE
fix: useFilesMetadata updates the file list based on the previous file list

### DIFF
--- a/apps/frontend/src/hooks/file/useFilesMetadata.ts
+++ b/apps/frontend/src/hooks/file/useFilesMetadata.ts
@@ -15,6 +15,11 @@ export function useFilesMetadata(filesFilter: FilesMetadataFilter) {
   useEffect(() => {
     let unmounted = false;
 
+    // If there are no fileIds, do not fetch anything
+    if (filter.fileIds?.length === 0) {
+      return;
+    }
+
     api()
       .getFilesMetadata({ filter: filter })
       .then((data) => {
@@ -22,9 +27,8 @@ export function useFilesMetadata(filesFilter: FilesMetadataFilter) {
           return;
         }
 
-        if (data.filesMetadata) {
-          setFiles(data.filesMetadata);
-        }
+        // Update the state based on the previous state
+        setFiles((prevFiles) => [...prevFiles, ...data.filesMetadata]);
       });
 
     return () => {


### PR DESCRIPTION
## Description

This pull request addresses a race condition issue where the current file list was being overwritten by API call results. To fix this problem, the useFilesMetadata function updates the file list based on its previous value.

## Motivation and Context

The race condition occurred between the API call and the setFiles function call. In some cases, this led to the unintended overwriting of the current file list. By modifying the useFilesMetadata function to consider the previous value, we have resolved this issue and ensured the file list remains consistent.

## How Has This Been Tested

- Manually
- E2E test (templatesAdvanced.cy.ts: "User can add captions after uploading image/* file" test case / slow cpu)

## Fixes

https://jira.esss.lu.se/browse/SWAP-3572
