### PR TITLE
fix: rename auto merge GITHUB_TOKEN to GH_TOKEN

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -38,7 +38,7 @@ jobs:
           fi
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.PR_APPROVE_TOKEN}}
+          GH_TOKEN: ${{secrets.PR_APPROVE_TOKEN}}
 
       ## NOTE: Requirements for merge has to be configured in the Branch protection rule page.
       ## To do so, go to repository > Settings > Branches > Edit


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Github job workflow > auto-merge >` Approve patch and minor updates step` expecting `GH_TOKEN` instead of `GITHUB_TOKEN`

## Fixes
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
