### PR TITLE
Fixed the bug of proposal SEP assignment, when Instrument picker is a…

### DIFF
--- a/apps/backend/src/models/questionTypes/InstrumentPicker.ts
+++ b/apps/backend/src/models/questionTypes/InstrumentPicker.ts
@@ -7,6 +7,7 @@ import { Tokens } from '../../config/Tokens';
 import { InstrumentDataSource } from '../../datasources/InstrumentDataSource';
 import { ProposalDataSource } from '../../datasources/ProposalDataSource';
 import InstrumentMutations from '../../mutations/InstrumentMutations';
+import SEPMutations from '../../mutations/SEPMutations';
 import { InstrumentPickerConfig } from '../../resolvers/types/FieldConfig';
 import { QuestionFilterCompareOperator } from '../Questionary';
 import { DataType, QuestionTemplateRelation } from '../Template';
@@ -81,6 +82,7 @@ export const instrumentPickerDefinition: Question<DataType.INSTRUMENT_PICKER> =
         Tokens.ProposalDataSource
       );
       const instrumentMutations = container.resolve(InstrumentMutations);
+      const sepMutation = container.resolve(SEPMutations);
 
       const proposal = await proposalDataSource.getByQuestionaryId(
         questionaryId
@@ -93,11 +95,18 @@ export const instrumentPickerDefinition: Question<DataType.INSTRUMENT_PICKER> =
       const { value } = JSON.parse(answer.value);
       const instrumentId = value;
 
+      // Assign the Proposals to Instrument
       await instrumentMutations.assignProposalsToInstrumentInternal(null, {
         instrumentId,
         proposals: [
           { primaryKey: proposal.primaryKey, callId: proposal.callId },
         ],
+      });
+
+      // Assign the Proposals to SEP using Call Instrument
+      await sepMutation.assignProposalsToSEPUsingCallInstrument(null, {
+        instrumentId: instrumentId,
+        proposalPks: [proposal.primaryKey],
       });
     },
   };


### PR DESCRIPTION
## Description

When an Instrument Questionare is answered, an Instrument will be assigned to the Proposal. But the corresponding SEP was not assigned to the Proposal. However when trying to assign the Instrument to the Proposal manually, the SEP assignment is happening. 

## Motivation and Context

To enable automatic and seamless assignment of the Instrument and SEP to the Proposal. 

## How Has This Been Tested

Manually

## Fixes

Automatic assignment of SEP to the Proposal, when an Instrument is assigned to the Proposal. 
