### PR TITLE
Tech review data added to pdf generation immaterial of the user role

### DIFF
--- a/apps/backend/src/factory/pdf/proposal.ts
+++ b/apps/backend/src/factory/pdf/proposal.ts
@@ -334,18 +334,16 @@ export const collectProposalPDFData = async (
     out.attachments.push(...genericTemplateAttachments);
   }
 
-  if (await proposalAuth.isReviewerOfProposal(user, proposal.primaryKey)) {
-    const technicalReview =
-      await baseContext.queries.review.technicalReviewForProposal(
-        user,
-        proposal.primaryKey
-      );
-    if (technicalReview) {
-      out.technicalReview = {
-        ...technicalReview,
-        status: getTechnicalReviewHumanReadableStatus(technicalReview.status),
-      };
-    }
+  const technicalReview =
+    await baseContext.queries.review.technicalReviewForProposal(
+      user,
+      proposal.primaryKey
+    );
+  if (technicalReview) {
+    out.technicalReview = {
+      ...technicalReview,
+      status: getTechnicalReviewHumanReadableStatus(technicalReview.status),
+    };
   }
 
   // Get Reviews
@@ -528,16 +526,14 @@ export const collectProposalPDFDataTokenAccess = async (
   const reviewDataSource = container.resolve<ReviewDataSource>(
     Tokens.ReviewDataSource
   );
-  if (await proposalAuth.isReviewerOfProposal(user, proposal.primaryKey)) {
-    const technicalReview = await reviewDataSource.getTechnicalReview(
-      proposal.primaryKey
-    );
-    if (technicalReview) {
-      proposalPDFData.technicalReview = {
-        ...technicalReview,
-        status: getTechnicalReviewHumanReadableStatus(technicalReview.status),
-      };
-    }
+  const technicalReview = await reviewDataSource.getTechnicalReview(
+    proposal.primaryKey
+  );
+  if (technicalReview) {
+    proposalPDFData.technicalReview = {
+      ...technicalReview,
+      status: getTechnicalReviewHumanReadableStatus(technicalReview.status),
+    };
   }
 
   return proposalPDFData;


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Fixed the issue of technical review information not showing up in the proposal pdf. 

## Motivation and Context

In the Proposal PDF, the template can be configured to display the technical review. This was working for sometime. Now it is stopped working. While debugging, it was figured out that the tech review data is not being passed for few user roles. Since we have a user level condition in the PDF template, we can provide the tech review data from user office no matter what the user role is and the pdf template can now control who can see and who can't see. 

## How Has This Been Tested

Manually