### PR TITLE
fix: Multiple data fetch on questionary details in the proposal review

### DIFF
--- a/apps/frontend/src/components/proposal/ProposalQuestionaryDetails.tsx
+++ b/apps/frontend/src/components/proposal/ProposalQuestionaryDetails.tsx
@@ -12,11 +12,13 @@ interface ProposalQuestionaryDetailsProps extends QuestionaryDetailsProps {
 }
 
 function ProposalQuestionaryDetails(props: ProposalQuestionaryDetailsProps) {
-  const { proposalPk, questionaryId, additionalDetails } = props;
+  const { proposalPk, questionaryId, questionaryData, additionalDetails } =
+    props;
 
   return (
     <QuestionaryDetails
       questionaryId={questionaryId}
+      questionaryData={questionaryData}
       additionalDetails={additionalDetails}
       answerRenderer={(answer) => {
         if (answer.question.dataType === DataType.SAMPLE_DECLARATION) {

--- a/apps/frontend/src/components/questionary/QuestionaryDetails.tsx
+++ b/apps/frontend/src/components/questionary/QuestionaryDetails.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 import React, { ReactElement } from 'react';
 
 import UOLoader from 'components/common/UOLoader';
-import { Answer, DataType } from 'generated/sdk';
+import { Answer, DataType, Questionary } from 'generated/sdk';
 import { useQuestionary } from 'hooks/questionary/useQuestionary';
 import { areDependenciesSatisfied } from 'models/questionary/QuestionaryFunctions';
 
@@ -19,15 +19,25 @@ export interface TableRowData {
 export interface QuestionaryDetailsProps
   extends TableProps<(props: unknown) => ReactElement> {
   questionaryId: number;
+  questionaryData?: Questionary; // If provided, it will be used instead of fetching the questionary
   additionalDetails?: Array<TableRowData>;
   title?: string;
   answerRenderer?: (answer: Answer) => JSX.Element | null;
 }
 
 function QuestionaryDetails(props: QuestionaryDetailsProps) {
-  const { answerRenderer, questionaryId, additionalDetails, title } = props;
+  const {
+    answerRenderer,
+    questionaryId,
+    questionaryData,
+    additionalDetails,
+    title,
+  } = props;
 
-  const { questionary, loadingQuestionary } = useQuestionary(questionaryId);
+  const { questionary, loadingQuestionary } = useQuestionary(
+    questionaryId,
+    questionaryData
+  );
 
   if (loadingQuestionary) {
     return (

--- a/apps/frontend/src/components/review/ProposalQuestionaryReview.tsx
+++ b/apps/frontend/src/components/review/ProposalQuestionaryReview.tsx
@@ -47,6 +47,7 @@ export default function ProposalQuestionaryReview(
   return (
     <ProposalQuestionaryDetails
       questionaryId={data.questionaryId}
+      questionaryData={data.questionary}
       additionalDetails={additionalDetails}
       title="Proposal information"
       proposalPk={data.primaryKey}

--- a/apps/frontend/src/hooks/questionary/useQuestionary.ts
+++ b/apps/frontend/src/hooks/questionary/useQuestionary.ts
@@ -1,16 +1,25 @@
 import { useEffect, useState } from 'react';
 
-import { GetQuestionaryQuery } from 'generated/sdk';
+import { GetQuestionaryQuery, Questionary } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 
-export function useQuestionary(questionaryId: number) {
-  const [loadingQuestionary, setLoadingQuestionary] = useState<boolean>(true);
-  const [questionary, setQuestionary] =
-    useState<GetQuestionaryQuery['questionary']>(null);
+export function useQuestionary(
+  questionaryId: number,
+  questionaryData?: Questionary
+) {
+  const [loadingQuestionary, setLoadingQuestionary] = useState<boolean>(
+    !questionaryData
+  );
+  const [questionary, setQuestionary] = useState<
+    GetQuestionaryQuery['questionary']
+  >(questionaryData ?? null);
 
   const api = useDataApi();
 
   useEffect(() => {
+    // If questionaryData is provided, we don't need to fetch it
+    if (questionaryData) return;
+
     let unmounted = false;
 
     setLoadingQuestionary(true);
@@ -30,7 +39,7 @@ export function useQuestionary(questionaryId: number) {
     return () => {
       unmounted = true;
     };
-  }, [api, questionaryId]);
+  }, [api, questionaryId, questionaryData]);
 
   return { questionary, loadingQuestionary };
 }


### PR DESCRIPTION
## Description

The "QuestionaryDetails" component has a new prop, 'questionaryData.' If it is provided, it will be used instead of refetching the questionary data.

## Motivation and Context

In the "ProposalQuestionaryReview", the proposal information is provided, so it can be used in the "QuestionaryDetails"

## How Has This Been Tested

- Manually

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
