### PR TITLE
feat: Show which proposals has been created with the proposal template

### DIFF
--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -470,6 +470,16 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
             );
         }
 
+        if (filter?.templateIds) {
+          query
+            .leftJoin(
+              'questionary',
+              'questionary.questionary_id',
+              'proposals.questionary_id'
+            )
+            .whereIn('questionary.template_id', filter.templateIds);
+        }
+
         if (filter?.proposalStatusId) {
           query.where('proposals.status_id', filter?.proposalStatusId);
         }

--- a/apps/backend/src/resolvers/queries/ProposalsQuery.ts
+++ b/apps/backend/src/resolvers/queries/ProposalsQuery.ts
@@ -59,6 +59,9 @@ export class ProposalsFilter {
 
   @Field(() => [String], { nullable: true })
   public referenceNumbers?: string[];
+
+  @Field(() => [Int], { nullable: true })
+  public templateIds?: number[];
 }
 
 @ArgsType()

--- a/apps/e2e/cypress/e2e/templatesBasic.cy.ts
+++ b/apps/e2e/cypress/e2e/templatesBasic.cy.ts
@@ -796,6 +796,23 @@ context('Template tests', () => {
       cy.contains('Yes').click();
     });
 
+    it('User officer can view proposals on template', () => {
+      cy.login('officer');
+      cy.visit('/');
+
+      cy.navigateToTemplatesSubmenu('Proposal');
+
+      cy.contains(initialDBData.template.name)
+        .parent()
+        .find('[data-cy=proposals-count]')
+        .contains('1')
+        .click();
+
+      cy.get('[data-cy=proposals-modal]').contains(
+        initialDBData.proposal.title
+      );
+    });
+
     it('should render the Date field with default value and min max values when set', () => {
       let dateFieldId: string;
       const minDate = DateTime.fromJSDate(faker.date.past()).toFormat(


### PR DESCRIPTION
## Description

This PR adds functionality to show the modal popup when a number of proposals for the template is clicked. This opens a window to list all the associated proposals to the template.

## Motivation and Context

Sometimes user officer want's to know which proposal exactly is using the template.

## How Has This Been Tested
Manually,
Added e2e tests

## Fixes

SWAP-800

## Screenshots
![image](https://github.com/UserOfficeProject/user-office-core/assets/16946916/468e5d10-e105-4448-8c47-7c68a8efc8b8)


