### PR TITLE
Add SEP roles for STFC

### DIFF
--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -29,6 +29,10 @@ const stfcRolesToEssRoleDefinitions: StfcRolesToEssRole = {
   'CLF HPL Link Scientist': [Roles.INSTRUMENT_SCIENTIST],
   'CLF LSF FAP Secretary': [Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST],
   'CLF LSF Link Scientist': [Roles.INSTRUMENT_SCIENTIST],
+  'FAP Member': [Roles.SEP_REVIEWER],
+  'FAP Secretary': [Roles.SEP_SECRETARY],
+  'FAP Chair': [Roles.SEP_CHAIR],
+  'Internal Reviewer': [Roles.INTERNAL_REVIEWER],
 };
 
 export type stfcRole = {


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/869 https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/910

## Description

Add a mapping from STFC roles to SEP rolls. Needed for testing on dev, 
Turning on the feature fully will be done later with modification to e2e test to make sure they can still run in STFC mode. 


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
