### PR TITLE
Proposal pdf filename is changed to RB_SURNAME_YYYY format

### DIFF
--- a/apps/backend/src/factory/pdf/proposal.ts
+++ b/apps/backend/src/factory/pdf/proposal.ts
@@ -235,9 +235,9 @@ export const collectProposalPDFData = async (
   });
 
   notify?.(
-    `${proposal.created.getUTCFullYear()}_${principalInvestigator.lastname}_${
-      proposal.proposalId
-    }.pdf`
+    `${proposal.proposalId}_${
+      principalInvestigator.lastname
+    }_${proposal.created.getUTCFullYear()}.pdf`
   );
 
   const genericTemplateAttachments: Attachment[] = [];
@@ -262,9 +262,9 @@ export const collectProposalPDFData = async (
   );
 
   notify?.(
-    `${proposal.created.getUTCFullYear()}_${principalInvestigator.lastname}_${
-      proposal.proposalId
-    }.pdf`
+    `${proposal.proposalId}_${
+      principalInvestigator.lastname
+    }_${proposal.created.getUTCFullYear()}.pdf`
   );
 
   const out: ProposalPDFData = {
@@ -461,9 +461,9 @@ export const collectProposalPDFDataTokenAccess = async (
   });
 
   notify?.(
-    `${proposal.created.getUTCFullYear()}_${principalInvestigator.lastname}_${
-      proposal.proposalId
-    }.pdf`
+    `${proposal.proposalId}_${
+      principalInvestigator.lastname
+    }_${proposal.created.getUTCFullYear()}.pdf`
   );
 
   const genericTemplateAttachments: Attachment[] = [];
@@ -499,9 +499,9 @@ export const collectProposalPDFDataTokenAccess = async (
   );
 
   notify?.(
-    `${proposal.created.getUTCFullYear()}_${principalInvestigator.lastname}_${
-      proposal.proposalId
-    }.pdf`
+    `${proposal.proposalId}_${
+      principalInvestigator.lastname
+    }_${proposal.created.getUTCFullYear()}.pdf`
   );
 
   // Add information from each topic in proposal

--- a/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
+++ b/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
@@ -380,6 +380,35 @@ context('Proposal administration tests', () => {
       );
     });
 
+    it('Downloaded proposal filename format is RB_SURNAME_YYYY', function () {
+      if (!featureFlags.getEnabledFeatures().get(FeatureId.SCHEDULER)) {
+        //temporarily skipping, until issue is fixed on github actions
+        this.skip();
+      }
+      cy.contains('Proposals').click();
+
+      cy.contains(proposalName1)
+        .parent()
+        .find('input[type="checkbox"]')
+        .check();
+
+      cy.get('[data-cy="download-proposals"]').click();
+
+      cy.contains('Proposal(s)').click();
+
+      cy.get('[data-cy="preparing-download-dialog"]').should('exist');
+      cy.get('[data-cy="preparing-download-dialog-item"]').contains(
+        proposalName1
+      );
+
+      const currentYear = new Date().getFullYear();
+      const downloadedFileName = `${createdProposalId}_${initialDBData.users.user1.lastName}_${currentYear}.pdf`;
+      const downloadsFolder = Cypress.config('downloadsFolder');
+      const downloadFilePath = `${downloadsFolder}/${downloadedFileName}`;
+
+      cy.readFile(downloadFilePath).should('exist');
+    });
+
     it('Should be able to verify pdf download and compare with a fixture', function () {
       if (!featureFlags.getEnabledFeatures().get(FeatureId.SCHEDULER)) {
         //temporarily skipping, until issue is fixed on github actions


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Fixes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/768

## Motivation and Context

As a user officer, I would like the proposal PDF filename changed to RB_SURNAME_YYYY format so that it's easier to manage

## How Has This Been Tested

Manual
e2e tests

## Fixes

https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/768

## Changes

Proposal pdf filename is changed to RB_SURNAME_YYYY format

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated

## Screenshots
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/40f27ba8-33b1-40a9-960b-06d2702aaf75)
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/1b015668-5e5c-4332-a41d-bb2270465987)
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/a7fae41a-0035-4412-9d8f-267ff1ae3a51)
