### PR TITLE
feat: As a user officer I want to create sample declaration template easier

### DIFF
--- a/apps/frontend/src/components/call/CallGeneralInfo.tsx
+++ b/apps/frontend/src/components/call/CallGeneralInfo.tsx
@@ -1,6 +1,5 @@
 import HelpIcon from '@mui/icons-material/Help';
 import LaunchIcon from '@mui/icons-material/Launch';
-import RefreshIcon from '@mui/icons-material/Refresh';
 import DateAdapter from '@mui/lab/AdapterLuxon';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
 import {
@@ -31,6 +30,7 @@ import { DateTimePicker } from 'formik-mui-lab';
 import React, { useContext, useEffect, useState } from 'react';
 
 import FormikUIAutocomplete from 'components/common/FormikUIAutocomplete';
+import RefreshListIcon from 'components/common/RefresListIcon';
 import { ProposalStatusDefaultShortCodes } from 'components/proposal/ProposalsSharedConstants';
 import { FeatureContext } from 'context/FeatureContextProvider';
 import {
@@ -42,10 +42,6 @@ import {
   UpdateCallMutationVariables,
 } from 'generated/sdk';
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
-
-type AdornmentIconProps = {
-  onClick: (event: React.MouseEvent<HTMLElement>) => void;
-};
 
 const useStyles = makeStyles((theme) => ({
   iconVerticalAlign: {
@@ -208,19 +204,6 @@ const CallGeneralInfo = ({
     })
   )(TableRow);
 
-  const AdornmentIcon = (props: AdornmentIconProps) => {
-    return (
-      <IconButton
-        edge="end"
-        title="Refresh"
-        aria-label="Refresh the list"
-        onClick={props.onClick}
-      >
-        <RefreshIcon fontSize="small" />
-      </IconButton>
-    );
-  };
-
   function populateTable(format: string, refNumber: string) {
     return { format, refNumber };
   }
@@ -371,7 +354,7 @@ const CallGeneralInfo = ({
           noOptionsText="No templates"
           items={templateOptions}
           InputProps={{ 'data-cy': 'call-template' }}
-          AdornmentIcon={<AdornmentIcon onClick={reloadTemplates} />}
+          AdornmentIcon={<RefreshListIcon onClick={reloadTemplates} />}
           required
         />
         <Link
@@ -394,7 +377,7 @@ const CallGeneralInfo = ({
             noOptionsText="No templates"
             items={esiTemplateOptions}
             InputProps={{ 'data-cy': 'call-esi-template' }}
-            AdornmentIcon={<AdornmentIcon onClick={reloadEsi} />}
+            AdornmentIcon={<RefreshListIcon onClick={reloadEsi} />}
             required
           />
           <Link
@@ -421,7 +404,7 @@ const CallGeneralInfo = ({
         noOptionsText="No templates"
         items={pdfTemplateOptions}
         InputProps={{ 'data-cy': 'call-pdf-template' }}
-        AdornmentIcon={<AdornmentIcon onClick={reloadPdfTemplates} />}
+        AdornmentIcon={<RefreshListIcon onClick={reloadPdfTemplates} />}
       />
       <FormikUIAutocomplete
         name="proposalWorkflowId"
@@ -432,7 +415,7 @@ const CallGeneralInfo = ({
         InputProps={{
           'data-cy': 'call-workflow',
         }}
-        AdornmentIcon={<AdornmentIcon onClick={reloadProposalWorkflows} />}
+        AdornmentIcon={<RefreshListIcon onClick={reloadProposalWorkflows} />}
         required
       />
       <LocalizationProvider dateAdapter={DateAdapter}>

--- a/apps/frontend/src/components/common/RefresListIcon.tsx
+++ b/apps/frontend/src/components/common/RefresListIcon.tsx
@@ -1,0 +1,22 @@
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { IconButton } from '@mui/material';
+import React from 'react';
+
+type RefreshListIconProps = {
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
+};
+
+const RefreshListIcon = (props: RefreshListIconProps) => {
+  return (
+    <IconButton
+      edge="end"
+      title="Refresh"
+      aria-label="Refresh the list"
+      onClick={props.onClick}
+    >
+      <RefreshIcon fontSize="small" />
+    </IconButton>
+  );
+};
+
+export default RefreshListIcon;

--- a/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionSampleDeclarationForm.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionSampleDeclarationForm.tsx
@@ -6,6 +6,7 @@ import React, { useContext, ChangeEvent } from 'react';
 import * as Yup from 'yup';
 
 import FormikUIAutocomplete from 'components/common/FormikUIAutocomplete';
+import RefreshListIcon from 'components/common/RefresListIcon';
 import TitledContainer from 'components/common/TitledContainer';
 import { QuestionFormProps } from 'components/questionary/QuestionaryComponentRegistry';
 import { FeatureContext } from 'context/FeatureContextProvider';
@@ -24,20 +25,19 @@ export const QuestionSampleDeclarationForm = (props: QuestionFormProps) => {
   const config = field.config as SampleDeclarationConfig;
   const naturalKeySchema = useNaturalKeySchema(field.naturalKey);
   const { featuresMap } = useContext(FeatureContext);
-  const { templates } = useActiveTemplates(
-    TemplateGroupId.SAMPLE,
-    config.templateId
-  );
-  const { templates: esiTemplates } = useActiveTemplates(
-    TemplateGroupId.SAMPLE_ESI,
-    config.esiTemplateId
-  );
+  const {
+    templates: sampleTemplates,
+    refreshTemplates: refreshSampleTemplates,
+  } = useActiveTemplates(TemplateGroupId.SAMPLE, config.templateId);
 
-  if (!templates || !esiTemplates) {
+  const { templates: esiTemplates, refreshTemplates: refreshEsiTemplates } =
+    useActiveTemplates(TemplateGroupId.SAMPLE_ESI, config.esiTemplateId);
+
+  if (!sampleTemplates || !esiTemplates) {
     return null;
   }
 
-  const templateOptions = templates.map((template) => ({
+  const templateOptions = sampleTemplates.map((template) => ({
     value: template.templateId,
     text: template.name,
   }));
@@ -101,6 +101,9 @@ export const QuestionSampleDeclarationForm = (props: QuestionFormProps) => {
                 items={templateOptions}
                 InputProps={{ 'data-cy': 'template-id' }}
                 TextFieldProps={{ margin: 'none' }}
+                AdornmentIcon={
+                  <RefreshListIcon onClick={refreshSampleTemplates} />
+                }
                 required
               />
               <Link
@@ -113,14 +116,26 @@ export const QuestionSampleDeclarationForm = (props: QuestionFormProps) => {
             </FormControl>
 
             {featuresMap.get(FeatureId.RISK_ASSESSMENT)?.isEnabled && (
-              <FormikUIAutocomplete
-                name="config.esiTemplateId"
-                label="ESI template name"
-                noOptionsText="No active templates"
-                items={ESITemplateOptions}
-                InputProps={{ 'data-cy': 'esi-template-id' }}
-                TextFieldProps={{ margin: 'none' }}
-              />
+              <FormControl fullWidth>
+                <FormikUIAutocomplete
+                  name="config.esiTemplateId"
+                  label="ESI template name"
+                  noOptionsText="No active templates"
+                  items={ESITemplateOptions}
+                  InputProps={{ 'data-cy': 'esi-template-id' }}
+                  TextFieldProps={{ margin: 'none' }}
+                  AdornmentIcon={
+                    <RefreshListIcon onClick={refreshEsiTemplates} />
+                  }
+                />
+                <Link
+                  href="/SampleEsiTemplates/"
+                  target="blank"
+                  style={{ textAlign: 'right' }}
+                >
+                  View all templates
+                </Link>
+              </FormControl>
             )}
           </TitledContainer>
 

--- a/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionTemplateRelationSampleDeclarationForm.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionTemplateRelationSampleDeclarationForm.tsx
@@ -6,6 +6,7 @@ import { ChangeEvent, default as React, useContext } from 'react';
 import * as Yup from 'yup';
 
 import FormikUIAutocomplete from 'components/common/FormikUIAutocomplete';
+import RefreshListIcon from 'components/common/RefresListIcon';
 import TitledContainer from 'components/common/TitledContainer';
 import { QuestionTemplateRelationFormProps } from 'components/questionary/QuestionaryComponentRegistry';
 import { FeatureContext } from 'context/FeatureContextProvider';
@@ -25,21 +26,21 @@ export const QuestionTemplateRelationSampleDeclarationForm = (
 ) => {
   const config = props.questionRel.config as SampleDeclarationConfig;
 
-  const { templates } = useActiveTemplates(
-    TemplateGroupId.SAMPLE,
-    config.templateId
-  );
-  const { templates: esiTemplates } = useActiveTemplates(
-    TemplateGroupId.SAMPLE_ESI,
-    config.esiTemplateId
-  );
+  const {
+    templates: sampleTemplates,
+    refreshTemplates: refreshSampleTemplates,
+  } = useActiveTemplates(TemplateGroupId.SAMPLE, config.templateId);
+
+  const { templates: esiTemplates, refreshTemplates: refreshEsiTemplates } =
+    useActiveTemplates(TemplateGroupId.SAMPLE_ESI, config.esiTemplateId);
+
   const { featuresMap } = useContext(FeatureContext);
 
-  if (!templates || !esiTemplates) {
+  if (!sampleTemplates || !esiTemplates) {
     return null;
   }
 
-  const templateOptions = templates.map((template) => ({
+  const templateOptions = sampleTemplates.map((template) => ({
     value: template.templateId,
     text: template.name,
   }));
@@ -83,6 +84,9 @@ export const QuestionTemplateRelationSampleDeclarationForm = (
                 items={templateOptions}
                 InputProps={{ 'data-cy': 'template-id' }}
                 TextFieldProps={{ margin: 'none' }}
+                AdornmentIcon={
+                  <RefreshListIcon onClick={refreshSampleTemplates} />
+                }
                 required
               />
               <Link
@@ -95,14 +99,26 @@ export const QuestionTemplateRelationSampleDeclarationForm = (
             </FormControl>
 
             {featuresMap.get(FeatureId.RISK_ASSESSMENT)?.isEnabled && (
-              <FormikUIAutocomplete
-                name="config.esiTemplateId"
-                label="ESI template name"
-                noOptionsText="No active templates"
-                items={ESITemplateOptions}
-                InputProps={{ 'data-cy': 'esi-template-id' }}
-                TextFieldProps={{ margin: 'none' }}
-              />
+              <FormControl fullWidth>
+                <FormikUIAutocomplete
+                  name="config.esiTemplateId"
+                  label="ESI template name"
+                  noOptionsText="No active templates"
+                  items={ESITemplateOptions}
+                  InputProps={{ 'data-cy': 'esi-template-id' }}
+                  AdornmentIcon={
+                    <RefreshListIcon onClick={refreshEsiTemplates} />
+                  }
+                  TextFieldProps={{ margin: 'none' }}
+                />
+                <Link
+                  href="/SampleEsiTemplates/"
+                  target="blank"
+                  style={{ textAlign: 'right' }}
+                >
+                  View all templates
+                </Link>
+              </FormControl>
             )}
           </TitledContainer>
 


### PR DESCRIPTION
## Description

The aim of this Pull Request (PR) is to enhance the user experience during the creation of sample declaration questions. It introduces a new feature: a refresh list button and a link titled "View all templates" on the sample declaration question form. This link directs users to the sample declaration ESI (Experiment safety input) templates page. This addition is particularly helpful in situations where there are no existing sample declaration ESI templates available, or if the author wishes to add a new template. Once a new template is added, the author can return to the original form and click 'refresh' to view the newly added template.
 
Additionally, this PR reuses the RefreshIcon from calls, therefore it is refactored and moved outside into a new component so that it can be reused

## Motivation and Context
Improve user experience

## Fixes

SWAP-1456


## Screenshots
![image](https://github.com/UserOfficeProject/user-office-core/assets/16946916/774ddb0d-4930-432b-8d25-b539f1293811)
