### PR TITLE
Update github-tag-and-release.yml

### DIFF
--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -46,6 +46,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./apps/backend
+          platforms: linux/amd64,linux/arm64/v8
           file: ./apps/backend/Dockerfile
           push: true
           tags: ghcr.io/userofficeproject/user-office-backend:${{ steps.tag_version.outputs.new_tag }}
@@ -68,6 +69,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./apps/frontend
+          platforms: linux/amd64,linux/arm64/v8
           file: ./apps/frontend/Dockerfile
           push: true
           tags: ghcr.io/userofficeproject/user-office-frontend:${{ steps.tag_version.outputs.new_tag }}


### PR DESCRIPTION
## Description

At the moment release images are not built for arm64(Apple silicon), this should be changed so releases can be deployed locally

