### PR TITLE
ci: "build" job needs to be run successfully before "test_backend" and "e2e" jobs will run

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -137,7 +137,7 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    needs: [resolve_dep, install-and-cache]
+    needs: install-and-cache
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -190,7 +190,7 @@ jobs:
 
   test_backend:
     runs-on: ubuntu-latest
-    needs: [resolve_dep, install-and-cache]
+    needs: build
 
     steps:
       - uses: actions/checkout@v3
@@ -225,7 +225,7 @@ jobs:
           npm run test:backend
   e2e:
     runs-on: ubuntu-latest
-    needs: [resolve_dep, install-and-cache]
+    needs: build
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -225,7 +225,7 @@ jobs:
           npm run test:backend
   e2e:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [resolve_dep, build]
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

The update involves changing job dependencies to avoid unnecessary job runs.

## Motivation and Context

If the "build" job fails, then there is no need to run other tests.
