### PR TITLE
Fix sorting issue for proposal table

### DIFF
--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -52,6 +52,8 @@ const fieldMap: { [key: string]: string } = {
   statusName: 'proposal_table_view.proposal_status_id',
   proposalId: 'proposal_table_view.proposal_id',
   title: 'title',
+  submitted: 'proposal_table_view.submitted',
+  notified: 'proposal_table_view.notified',
 };
 
 export async function calculateReferenceNumber(

--- a/apps/e2e/cypress/e2e/proposals.cy.ts
+++ b/apps/e2e/cypress/e2e/proposals.cy.ts
@@ -614,7 +614,8 @@ context('Proposal tests', () => {
       cy.contains(longProposalTitle)
         .parent()
         .invoke('outerWidth')
-        .should('eq', 400);
+        .should('be.gte', 400)
+        .should('be.lt', 410);
 
       cy.contains(longProposalTitle)
         .parent()

--- a/apps/frontend/src/components/proposal/ProposalTableOfficer.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableOfficer.tsx
@@ -118,6 +118,7 @@ let columns: Column<ProposalViewData>[] = [
   {
     title: 'Principal Investigator',
     field: 'principalInvestigator',
+    sorting: false,
     emptyValue: '-',
     render: (proposalView) => {
       if (
@@ -133,6 +134,7 @@ let columns: Column<ProposalViewData>[] = [
   {
     title: 'PI Email',
     field: 'principalInvestigator.email',
+    sorting: false,
     emptyValue: '-',
   },
   {


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Fixes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/881

## Motivation and Context

The user office proposal table is not able to sort by the following column principal investigator name ,PI email, submitted and notified. When we select any of the above columns, the table show blank data.

## How Has This Been Tested

Manual

## Fixes

https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/881

## Changes

Fields 'notified' and 'submitted' is added to the known fields list of proposal view.
Sorting for email and name column is disabled as per discussion.

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated

## Screenshots

![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/0cccc07d-2357-4251-a2cf-cac095bb9cfd)
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/6374c240-0968-4ee7-a36c-30fb1568c5d9)
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/2118543e-e996-469c-a130-5ab549d2b08a)
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/308f0c5e-c02e-4549-9a67-0360b6a77118)


