### PR TITLE
Enabling interaction with embellishment pop up windows

### DIFF
--- a/apps/frontend/src/components/questionary/questionaryComponents/Embellishment/QuestionEmbellishmentForm.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/Embellishment/QuestionEmbellishmentForm.tsx
@@ -13,6 +13,9 @@ import { QuestionFormShell } from '../QuestionFormShell';
 export const QuestionEmbellishmentForm = (props: QuestionFormProps) => {
   const field = props.question;
   const naturalKeySchema = useNaturalKeySchema(field.naturalKey);
+  document.addEventListener('focusin', function (e) {
+    e.stopImmediatePropagation();
+  });
 
   return (
     <QuestionFormShell

--- a/apps/frontend/src/components/questionary/questionaryComponents/Embellishment/QuestionTemplateRelationEmbellishmentForm.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/Embellishment/QuestionTemplateRelationEmbellishmentForm.tsx
@@ -13,6 +13,10 @@ import { QuestionTemplateRelationFormShell } from '../QuestionTemplateRelationFo
 export const QuestionTemplateRelationEmbellishmentForm = (
   props: QuestionTemplateRelationFormProps
 ) => {
+  document.addEventListener('focusin', function (e) {
+    e.stopImmediatePropagation();
+  });
+
   return (
     <QuestionTemplateRelationFormShell
       {...props}


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

As a user officer, I should be able to add links/images to embellishment questions.
Fixes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/830

## Motivation and Context

When adding an embellishment question, you cannot interact with any of the embellishment pop up windows. This stops you from being able to click/type in it to add things like links, images, etc.

## How Has This Been Tested

Manual. Screenshots attached.

## Fixes

https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/830

## Changes

Added fix to prevent Bootstrap dialog from blocking focusing.

## Screenshots

![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/4506b055-869f-4c64-9242-a38ca4e4994c)
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/57f8c82e-d58b-4519-9896-50966f7f0ab9)
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/d7103cc9-c93c-4c3e-8a6d-24d6b18967d4)
![image](https://github.com/UserOfficeProject/user-office-core/assets/149392207/b4f05a41-9a58-406e-a1ed-4ae0e0052dc0)

