### PR TITLE
feat: enable gzip compression in nginx

### DIFF
--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -1,5 +1,14 @@
 server {
   listen 80;
+
+  gzip on;
+  gzip_disable "msie6";
+
+  gzip_vary on;
+  gzip_proxied no-cache no-store private expired auth;
+  gzip_buffers 16 8k;
+  gzip_http_version 1.1;
+  gzip_types text/plain application/javascript text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype;
   
   location / {
     root /usr/share/nginx/html;


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR aims to enable `gzip` compression in the `nginx` server on the frontend.

## Motivation and Context

There was no compression enabled before and this quite important to reduce the amount of data sent over the network especially for larger files.

## How Has This Been Tested

- manually tests loacally

## Fixes

https://jira.esss.lu.se/browse/SWAP-3660

## Changes

![performance-score-before-after-compression](https://github.com/UserOfficeProject/user-office-core/assets/6333063/b72fbfd7-a7b8-4f15-9246-2a3b95f85b5e)


## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
