### PR TITLE
feat: cache the frontend sdk per each run and attempt only to reduce the issues related to it in the actions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   NODE_VERSION: 18.x
-  FRONTEND_SDK_KEY: sdk-frontend-${{ github.sha }}
+  FRONTEND_SDK_KEY: sdk-frontend-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -121,6 +121,18 @@ jobs:
         if: steps.cached-node-modules-frontend.outputs.cache-hit != 'true'
         run: npm run install:frontend
 
+      - name: Cache frontend SDK
+        id: cached-sdk-frontend
+        uses: actions/cache@v3
+        with:
+          path: apps/frontend/src/generated
+          key: sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+
+      - name: Generate frontend SDK
+        run: |
+          cp apps/frontend/example.development.env apps/frontend/.env
+          npm run generate:sdk
+
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -156,7 +168,15 @@ jobs:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
-      - run: npm run generate:sdk
+      - name: Restore frontend SDK
+        id: cached-sdk-frontend
+        uses: actions/cache@v3
+        with:
+          path: apps/frontend/src/generated
+          key: sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+          restore-keys: |
+            sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+            sdk-frontend-
 
       - run: npm ci
 
@@ -252,8 +272,15 @@ jobs:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
-      - run: ls
-      - run: ls -a
+      - name: Restore frontend SDK
+        id: cached-sdk-frontend
+        uses: actions/cache@v3
+        with:
+          path: apps/frontend/src/generated
+          key: sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+          restore-keys: |
+            sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+            sdk-frontend-
 
       # TODO: See how to proceed with e2e caching because there is some error:
       # - You're caching 'node_modules' but are not caching this path: /home/runner/.cache/Cypress

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   NODE_VERSION: 18.x
+  FRONTEND_SDK_KEY: sdk-frontend-${{ github.sha }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -126,7 +127,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: apps/frontend/src/generated
-          key: sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+          key: ${{ env.FRONTEND_SDK_KEY }}
 
       - name: Generate frontend SDK
         run: |
@@ -173,9 +174,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: apps/frontend/src/generated
-          key: sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+          key: ${{ env.FRONTEND_SDK_KEY }}
           restore-keys: |
-            sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+            ${{ env.FRONTEND_SDK_KEY }}
             sdk-frontend-
 
       - run: npm ci
@@ -277,9 +278,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: apps/frontend/src/generated
-          key: sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+          key: ${{ env.FRONTEND_SDK_KEY }}
           restore-keys: |
-            sdk-frontend-${{ steps.extract_branch.outputs.branch }}
+            ${{ env.FRONTEND_SDK_KEY }}
             sdk-frontend-
 
       # TODO: See how to proceed with e2e caching because there is some error:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -121,19 +121,6 @@ jobs:
         if: steps.cached-node-modules-frontend.outputs.cache-hit != 'true'
         run: npm run install:frontend
 
-      - name: Cache frontend SDK
-        id: cached-sdk-frontend
-        uses: actions/cache@v3
-        with:
-          path: apps/frontend/src/generated
-          key: sdk-frontend-${{ hashFiles('**/**.graphql') }}
-
-      - name: Generate frontend SDK
-        if: steps.cached-sdk-frontend.outputs.cache-hit != 'true'
-        run: |
-          cp apps/frontend/example.development.env apps/frontend/.env
-          npm run generate:sdk
-
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -169,15 +156,7 @@ jobs:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
-      - name: Restore frontend SDK
-        id: cached-sdk-frontend
-        uses: actions/cache@v3
-        with:
-          path: apps/frontend/src/generated
-          key: sdk-frontend-${{ hashFiles('**/**.graphql') }}
-          restore-keys: |
-            sdk-frontend-${{ hashFiles('**/**.graphql') }}
-            sdk-frontend-
+      - run: npm run generate:sdk
 
       - run: npm ci
 
@@ -273,15 +252,8 @@ jobs:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
-      - name: Restore frontend SDK
-        id: cached-sdk-frontend
-        uses: actions/cache@v3
-        with:
-          path: apps/frontend/src/generated
-          key: sdk-frontend-${{ hashFiles('**/**.graphql') }}
-          restore-keys: |
-            sdk-frontend-${{ hashFiles('**/**.graphql') }}
-            sdk-frontend-
+      - run: ls
+      - run: ls -a
 
       # TODO: See how to proceed with e2e caching because there is some error:
       # - You're caching 'node_modules' but are not caching this path: /home/runner/.cache/Cypress


### PR DESCRIPTION
## Description
This PR modifies the SDK caching strategy due to issues it causes when running the workflows.

## Motivation and Context
The SDK caching has been causing problems when running the workflows, which hampers the smooth running of our tasks and operations. Changing the caching strategy to only be reused in the current run and attempt will lead to more stable and reliable workflows.

## Changes
- Changed the key of actions/cache to be unique only per run and attempt in the GitHub workflows for caching the frontend SDK.

## How Has This Been Tested?

- manual tests

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-3652](https://jira.esss.lu.se/browse/SWAP-3652)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated