### PR TITLE
Fix: Changed test db patch scientist user name

### DIFF
--- a/apps/backend/db_patches/db_seeds/0002_InstrumentScientiests.sql
+++ b/apps/backend/db_patches/db_seeds/0002_InstrumentScientiests.sql
@@ -5,12 +5,12 @@ BEGIN
   INSERT INTO users(
     user_id, user_title, middlename, firstname, lastname, username, preferredname, oidc_sub, oauth_access_token, oauth_refresh_token, gender, birthdate, department, "position", email, 
     telephone, telephone_alt, created_at, updated_at, organisation, nationality, placeholder)
-    VALUES (100, '', '1', 'Instrument', 'Scientist', 'instr.sci1', '-', 'instr.sci1.oauthsub', 'dummy-access-token', 'dummy-refresh-token', 'e2e user', '2020-10-10', 'IT', '', 'instr.sci1@local.host', '', '', NOW(), NOW(), 1, 169, false);
+    VALUES (100, '', '1', 'Instrument', 'Scientist1', 'instr.sci1', '-', 'instr.sci1.oauthsub', 'dummy-access-token', 'dummy-refresh-token', 'e2e user', '2020-10-10', 'IT', '', 'instr.sci1@local.host', '', '', NOW(), NOW(), 1, 169, false);
 
   INSERT INTO users(
     user_id, user_title, middlename, firstname, lastname, username, preferredname, oidc_sub, oauth_access_token, oauth_refresh_token, gender, birthdate, department, "position", email, 
     telephone, telephone_alt, created_at, updated_at, organisation, nationality, placeholder)
-    VALUES (101, '', '2', 'Instrument', 'Scientist', 'instr.sci2',  '-', 'instr.sci2.oauthsub', 'dummy-access-token', 'dummy-refresh-token', 'e2e user', '2020-10-10', 'IT', '', 'instr.sci2@local.host', '', '', NOW(), NOW(), 1, 169, false);
+    VALUES (101, '', '2', 'Instrument', 'Scientist2', 'instr.sci2',  '-', 'instr.sci2.oauthsub', 'dummy-access-token', 'dummy-refresh-token', 'e2e user', '2020-10-10', 'IT', '', 'instr.sci2@local.host', '', '', NOW(), NOW(), 1, 169, false);
 
   -- user account with every roles except instrument scientist and user officer
   INSERT INTO users(


### PR DESCRIPTION
## Description

This PR changed e2e database patch instrument scientists username.

Currently, in the e2e database patch, two instrument scientists are injected with an identical user name, which makes it hard to see if the dropdown list sorting feature is working or not in the new feature cypress test for scheduler.  


