### PR TITLE
Add created date field to query for proposal migration script

### DIFF
--- a/apps/backend/src/mutations/ProposalMutations.ts
+++ b/apps/backend/src/mutations/ProposalMutations.ts
@@ -143,7 +143,7 @@ export default class ProposalMutations {
     agent: UserWithRole | null,
     { proposal, args }: { proposal: Proposal; args: UpdateProposalArgs }
   ): Promise<Proposal | Rejection> {
-    const { proposalPk, title, abstract, users, proposerId } = args;
+    const { proposalPk, title, abstract, users, proposerId, created } = args;
 
     if (title !== undefined) {
       proposal.title = title;
@@ -151,6 +151,10 @@ export default class ProposalMutations {
 
     if (abstract !== undefined) {
       proposal.abstract = abstract;
+    }
+
+    if (created !== undefined) {
+      proposal.created = created;
     }
 
     if (users !== undefined) {
@@ -724,7 +728,6 @@ export default class ProposalMutations {
       proposal: proposal as Proposal,
       args: {
         proposalPk: proposal.primaryKey,
-        created: created,
         ...args,
       },
     });

--- a/apps/backend/src/mutations/ProposalMutations.ts
+++ b/apps/backend/src/mutations/ProposalMutations.ts
@@ -661,6 +661,7 @@ export default class ProposalMutations {
       proposerId,
       referenceNumber,
       users: coiIds,
+      created,
     } = args;
 
     const submitter = await this.userDataSource.getUser(submitterId);
@@ -723,6 +724,7 @@ export default class ProposalMutations {
       proposal: proposal as Proposal,
       args: {
         proposalPk: proposal.primaryKey,
+        created: created,
         ...args,
       },
     });

--- a/apps/backend/src/resolvers/mutations/ImportProposalMutation.ts
+++ b/apps/backend/src/resolvers/mutations/ImportProposalMutation.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import {
   Args,
   ArgsType,
@@ -33,6 +34,9 @@ export class ImportProposalArgs {
 
   @Field(() => Int)
   public callId: number;
+
+  @Field(() => Date, { nullable: true })
+  public created?: Date;
 }
 
 @Resolver()

--- a/apps/backend/src/resolvers/mutations/ImportProposalMutation.ts
+++ b/apps/backend/src/resolvers/mutations/ImportProposalMutation.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import {
   Args,
   ArgsType,

--- a/apps/backend/src/resolvers/mutations/UpdateProposalMutation.ts
+++ b/apps/backend/src/resolvers/mutations/UpdateProposalMutation.ts
@@ -27,6 +27,9 @@ export class UpdateProposalArgs {
 
   @Field(() => Int, { nullable: true })
   public proposerId?: number;
+
+  @Field(() => Date, { nullable: true })
+  public created?: Date;
 }
 
 @Resolver()


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Changes done as part of https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/955. New field is added to graphql mutation to update the actual submitted date of proposals while running the proposal migration script.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manually tested.

## Fixes

Part of the issue https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/955 will be fixed with this PR. Proposal migration scripts will be changed and committed after this.

## Changes

New field created date is added to import proposal and update proposal queries.
