### PR TITLE
Allow Internal Reviewer to view PI name and email

### DIFF
--- a/apps/backend/src/queries/UserQueries.ts
+++ b/apps/backend/src/queries/UserQueries.ts
@@ -27,7 +27,11 @@ export default class UserQueries {
     return this.dataSource.getUser(id);
   }
 
-  @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST])
+  @Authorized([
+    Roles.USER_OFFICER,
+    Roles.INSTRUMENT_SCIENTIST,
+    Roles.INTERNAL_REVIEWER,
+  ])
   async get(agent: UserWithRole | null, id: number) {
     return this.dataSource.getUser(id);
   }

--- a/apps/backend/src/resolvers/types/BasicUserDetails.ts
+++ b/apps/backend/src/resolvers/types/BasicUserDetails.ts
@@ -28,7 +28,11 @@ export class BasicUserDetails implements Partial<BasicUserDetailsOrigin> {
   @Field()
   public position: string;
 
-  @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST])
+  @Authorized([
+    Roles.USER_OFFICER,
+    Roles.INSTRUMENT_SCIENTIST,
+    Roles.INTERNAL_REVIEWER,
+  ])
   @Field({ nullable: true })
   public email: string;
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Closes [980](https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/980)
The Internal Reviewer is granted access to view Principal Invetigators name and email.
<!--- Describe your changes in detail -->

## Motivation and Context
Initially the PI name and email columns were displaying empty values in the Internal Reviewer dashboard and only the Proposal Information was only displaying the PI name as shown below:

![image](https://github.com/UserOfficeProject/user-office-core/assets/69144386/2c58736b-aff2-47bf-8775-5d6e7bb76cab)

![image](https://github.com/UserOfficeProject/user-office-core/assets/69144386/e6a76f92-c2a4-42ed-bd0e-60f402684098)

<!--- Why is this change required? What problem does it solve? -->
These changes allow the Internal Reviewer to view PI name and email in both the dashboard and the Proposal Information tab:

![image](https://github.com/UserOfficeProject/user-office-core/assets/69144386/57ac7534-b6ad-422d-88cb-49e87e9f005c)

![image](https://github.com/UserOfficeProject/user-office-core/assets/69144386/bb8e8dc6-cf56-4aae-95dd-6835db2acef6)

## How Has This Been Tested
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
[980](https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/980)
## Changes

<!--- What types of changes does your code introduce? In what place? -->
Gave the Internal Reviewer role access to `UserQueries` and `BasicUserDetails` 
## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->
N/A

