### PR TITLE
Fix: copy build-version.txt from the build stage to address a permission issue in the frontend Dockerfile

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -2,8 +2,11 @@
 FROM node:18.17.1-alpine as build-stage
 
 ARG ORCID_REDIRECT=
+ARG BUILD_VERSION=<unknown>
 
 WORKDIR /app
+
+RUN echo $BUILD_VERSION > build-version.txt
 
 RUN echo "REACT_APP_ORCID_REDIRECT=$ORCID_REDIRECT" > .env
 
@@ -21,9 +24,7 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:1.25-alpine
 
 COPY --from=build-stage /app/build/ /usr/share/nginx/html
-
-ARG BUILD_VERSION=<unknown>
-RUN echo $BUILD_VERSION > /usr/share/nginx/html/build-version.txt
+COPY --from=build-stage /app/build-version.txt /usr/share/nginx/html
 
 # Copy the default nginx.conf provided by tiangolo/node-frontend
 COPY default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Description
This PR addresses a permission issue in the frontend Dockerfile by copying `build-version.txt` from the build stage.

## Motivation and Context
This change is necessary to resolve a permission issue that was arising due to the Dockerfile trying to write the `build-version.txt` in a directory where it didn't have write permissions. This change fixes the issue by creating the `build-version.txt` file in the build stage and copying it over to the necessary directory, thereby avoiding the need for write permissions.

## Changes
- The `build-version.txt` file is now created in the build stage with the help of the `RUN` command.
- The `ARG BUILD_VERSION=<unknown>` command has been shifted to the build stage.
- The `COPY` command is now used to copy the `build-version.txt` file from the build stage to the required directory in the final stage. 

This change ensures that the permission issue is resolved without any change in the functionality of the Dockerfile.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated