### PR TITLE
979 multiple secretary pre fap

### DIFF
--- a/apps/backend/db_patches/0146_MultipleFAPSecretary.sql
+++ b/apps/backend/db_patches/0146_MultipleFAPSecretary.sql
@@ -1,0 +1,21 @@
+DO
+$$
+BEGIN
+	IF register_patch('MultipleFAPSecretary.sql', 'Thomas Cottee Meldrum', 'Multiple FAP Secretary', '2023-01-19') THEN
+	BEGIN
+
+		CREATE TABLE "fap_secretaries" (
+				user_id  int NOT NULL REFERENCES users(user_id) ON DELETE CASCADE
+			, fap_id int NOT NULL REFERENCES "faps"(fap_id) ON DELETE CASCADE
+			, PRIMARY KEY (user_id, fap_id)
+		);
+
+		INSERT INTO fap_secretaries (SELECT fap_secretary_user_id, fap_id FROM faps WHERE fap_secretary_user_id IS NOT NULL);
+
+		ALTER TABLE faps DROP COLUMN fap_secretary_user_id;
+
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/backend/src/datasources/postgres/FapDataSource.ts
+++ b/apps/backend/src/datasources/postgres/FapDataSource.ts
@@ -42,6 +42,7 @@ import {
   createReviewObject,
   UserRecord,
   createBasicUserObject,
+  FapSecretariesRecord,
 } from './records';
 
 export default class PostgresFapDataSource implements FapDataSource {
@@ -123,7 +124,8 @@ export default class PostgresFapDataSource implements FapDataSource {
       .first()
       .then((fap: FapRecord) => {
         return fap ? createFapObject(fap) : null;
-      });
+      })
+      .then((fap) => (fap ? this.getSecretaries(fap) : null));
   }
 
   async getUserFapsByRoleAndFapId(
@@ -134,6 +136,7 @@ export default class PostgresFapDataSource implements FapDataSource {
     const fapRecords = await database<FapRecord[]>('faps')
       .select<FapRecord[]>('faps.*')
       .leftJoin('fap_reviewers', 'fap_reviewers.fap_id', '=', 'faps.fap_id')
+      .leftJoin('fap_secretaries', 'fap_secretaries.fap_id', '=', 'faps.fap_id')
       .where((qb) => {
         if (fapId) {
           qb.where('faps.fap_id', fapId);
@@ -141,7 +144,7 @@ export default class PostgresFapDataSource implements FapDataSource {
         if (role.shortCode === Roles.FAP_CHAIR) {
           qb.where('fap_chair_user_id', userId);
         } else if (role.shortCode === Roles.FAP_SECRETARY) {
-          qb.where('fap_secretary_user_id', userId);
+          qb.where('fap_secretaries.user_id', userId);
         } else {
           qb.where('fap_reviewers.user_id', userId);
         }
@@ -161,6 +164,9 @@ export default class PostgresFapDataSource implements FapDataSource {
       .distinct('s.fap_id')
       .then((faps: FapRecord[]) => {
         return faps.map(createFapObject);
+      })
+      .then((faps) => {
+        return Promise.all(faps.map(this.getSecretaries));
       });
   }
 
@@ -170,7 +176,12 @@ export default class PostgresFapDataSource implements FapDataSource {
     if (role.shortCode === Roles.FAP_CHAIR) {
       qb.where('fap_chair_user_id', userId);
     } else if (role.shortCode === Roles.FAP_SECRETARY) {
-      qb.where('fap_secretary_user_id', userId);
+      qb.join(
+        'fap_secretaries',
+        'fap_secretaries.fap_id',
+        '=',
+        'faps.fap_id'
+      ).where('fap_secretaries.user_id', userId);
     } else if (role.shortCode === Roles.FAP_REVIEWER) {
       qb.join(
         'fap_reviewers',
@@ -189,7 +200,9 @@ export default class PostgresFapDataSource implements FapDataSource {
 
     const fapRecords = await qb;
 
-    return fapRecords.map(createFapObject);
+    return Promise.all(
+      fapRecords.map(createFapObject).map(this.getSecretaries)
+    );
   }
 
   async getFaps({
@@ -225,12 +238,16 @@ export default class PostgresFapDataSource implements FapDataSource {
         }
       })
       .then((allFaps: FapRecord[]) => {
-        const faps = allFaps.map((fap) => createFapObject(fap));
+        const faps = Promise.all(
+          allFaps.map(createFapObject).map(this.getSecretaries)
+        ).then((faps) => {
+          return {
+            totalCount: allFaps[0] ? allFaps[0].full_count : 0,
+            faps: faps,
+          };
+        });
 
-        return {
-          totalCount: allFaps[0] ? allFaps[0].full_count : 0,
-          faps,
-        };
+        return faps;
       });
   }
 
@@ -421,6 +438,17 @@ export default class PostgresFapDataSource implements FapDataSource {
       .from('fap_reviewers')
       .where('fap_id', fapId);
 
+    const secretaryRecords: FapSecretariesRecord[] = await database
+      .from('fap_secretaries')
+      .where('fap_id', fapId);
+
+    secretaryRecords.map((secretary) => {
+      reviewerRecords.unshift({
+        user_id: secretary.user_id,
+        fap_id: fapId,
+      });
+    });
+
     const fap = await this.getFap(fapId);
 
     if (!fap) {
@@ -430,12 +458,6 @@ export default class PostgresFapDataSource implements FapDataSource {
     fap.fapChairUserId !== null &&
       reviewerRecords.unshift({
         user_id: fap.fapChairUserId,
-        fap_id: fapId,
-      });
-
-    fap.fapSecretaryUserId !== null &&
-      reviewerRecords.unshift({
-        user_id: fap.fapSecretaryUserId,
         fap_id: fapId,
       });
 
@@ -452,6 +474,11 @@ export default class PostgresFapDataSource implements FapDataSource {
 
   async getFapUserRole(userId: number, fapId: number): Promise<Role | null> {
     const fap = await this.getFap(fapId);
+    const fapSecretaries = await database<FapSecretariesRecord>(
+      'fap_secretaries'
+    )
+      .select('user_id')
+      .where('fap_id', fapId);
 
     if (!fap) {
       throw new GraphQLError(`Fap not found ${fapId}`);
@@ -461,7 +488,11 @@ export default class PostgresFapDataSource implements FapDataSource {
 
     if (fap.fapChairUserId === userId) {
       shortCode = Roles.FAP_CHAIR;
-    } else if (fap.fapSecretaryUserId === userId) {
+    } else if (
+      !!fapSecretaries.find((security) => {
+        security.user_id === userId;
+      })
+    ) {
       shortCode = Roles.FAP_SECRETARY;
     } else {
       shortCode = Roles.FAP_REVIEWER;
@@ -503,7 +534,7 @@ export default class PostgresFapDataSource implements FapDataSource {
       .first()
       .then((fap: FapRecord) => {
         if (fap) {
-          return createFapObject(fap);
+          return this.getSecretaries(createFapObject(fap));
         }
 
         return null;
@@ -527,12 +558,16 @@ export default class PostgresFapDataSource implements FapDataSource {
     await database.transaction(async (trx) => {
       const isChairAssignment = args.roleId === UserRole.FAP_CHAIR;
 
-      await trx<FapRecord>('faps')
-        .update({
-          [isChairAssignment ? 'fap_chair_user_id' : 'fap_secretary_user_id']:
-            args.userId,
-        })
-        .where('fap_id', args.fapId);
+      isChairAssignment
+        ? await trx<FapRecord>('faps')
+            .update({
+              fap_chair_user_id: args.userId,
+            })
+            .where('fap_id', args.fapId)
+        : await trx<FapSecretariesRecord>('fap_secretaries').insert({
+            user_id: args.userId,
+            fap_id: args.fapId,
+          });
 
       const shortCode = isChairAssignment
         ? Roles.FAP_CHAIR
@@ -583,36 +618,33 @@ export default class PostgresFapDataSource implements FapDataSource {
     throw new GraphQLError(`Fap not found ${args.fapId}`);
   }
 
-  async removeMemberFromFap(
-    args: UpdateMemberFapArgs,
-    isMemberChairOrSecretaryOfFap: boolean
-  ) {
-    if (isMemberChairOrSecretaryOfFap) {
-      const field =
-        args.roleId === UserRole.FAP_CHAIR
-          ? 'fap_chair_user_id'
-          : 'fap_secretary_user_id';
-
+  async removeMemberFromFap(args: UpdateMemberFapArgs, isMemberChair: boolean) {
+    if (isMemberChair) {
       const updateResult = await database<FapRecord>('faps')
         .update({
-          [field]: null,
+          fap_chair_user_id: null,
         })
         .where('fap_id', args.fapId);
 
       if (!updateResult) {
         throw new GraphQLError(
-          `Failed to remove fap member ${args.memberId} (${field}), fap id ${args.fapId}`
+          `Failed to remove fap member ${args.memberId} (fap_chair_user_id), fap id ${args.fapId}`
         );
       }
     } else {
-      const updateResult = await database<FapReviewerRecord>('fap_reviewers')
+      const table =
+        args.roleId === UserRole.FAP_SECRETARY
+          ? 'fap_secretaries'
+          : 'fap_reviewers';
+
+      const updateResult = await database<FapReviewerRecord>(table)
         .where('fap_id', args.fapId)
         .where('user_id', args.memberId)
         .del();
 
       if (!updateResult) {
         throw new GraphQLError(
-          `Failed to remove fap member ${args.memberId}, fap id ${args.fapId}`
+          `Failed to remove ${args.memberId}from ${table}, fap id ${args.fapId}`
         );
       }
     }
@@ -796,10 +828,11 @@ export default class PostgresFapDataSource implements FapDataSource {
   ): Promise<boolean> {
     const record = await database<FapRecord>('faps')
       .select('*')
-      .where('fap_id', fapId)
+      .leftJoin('fap_secretaries', 'fap_secretaries.fap_id', '=', 'faps.fap_id')
+      .where('faps.fap_id', fapId)
       .where((qb) => {
         qb.where('fap_chair_user_id', userId);
-        qb.orWhere('fap_secretary_user_id', userId);
+        qb.orWhere('fap_secretaries.user_id', userId);
       })
       .first();
 
@@ -813,10 +846,11 @@ export default class PostgresFapDataSource implements FapDataSource {
     const record = await database<FapRecord>('faps')
       .select<FapRecord>(['faps.*'])
       .join('fap_proposals', 'fap_proposals.fap_id', '=', 'faps.fap_id')
+      .leftJoin('fap_secretaries', 'fap_secretaries.fap_id', '=', 'faps.fap_id')
       .where('fap_proposals.proposal_pk', proposalPk)
       .where((qb) => {
         qb.where('fap_chair_user_id', userId);
-        qb.orWhere('fap_secretary_user_id', userId);
+        qb.orWhere('fap_secretaries.user_id', userId);
       })
       .first();
 
@@ -948,40 +982,52 @@ export default class PostgresFapDataSource implements FapDataSource {
         }
       );
   }
+
   async getRelatedUsersOnFap(id: number): Promise<number[]> {
-    const relatedFapMembeers = await database
+    const relatedFapMembers = await database
       .select('sr.user_id')
       .distinct()
       .from('faps as s')
+      .leftJoin('fap_secretaries as fs', 'fs.fap_id', 's.fap_id')
       .leftJoin('fap_reviewers as r', function () {
         this.on('s.fap_id', 'r.fap_id');
         this.andOn(function () {
           this.onVal('r.user_id', id); // where the user is part of the visit
           this.orOnVal('s.fap_chair_user_id', id); // where the user is a chair
-          this.orOnVal('s.fap_secretary_user_id', id); // where the user is the secretary
+          this.orOnVal('fs.user_id', id); // where the user is the secretary
         });
       }) // this gives a list of proposals that a user is related to
       .join('fap_reviewers as sr', { 'sr.fap_id': 's.fap_id' }); // this gives us all of the associated reviewers
 
     const relatedFapChairsAndSecs = await database
-      .select('s.fap_chair_user_id', 's.fap_secretary_user_id')
+      .select('s.fap_chair_user_id', 'fs.user_id as fap_secretary_user_id')
       .distinct()
       .from('faps as s')
+      .leftJoin('fap_secretaries as fs', 'fs.fap_id', 's.fap_id')
       .leftJoin('fap_reviewers as r', function () {
         this.on('s.fap_id', 'r.fap_id');
         this.andOn(function () {
           this.onVal('r.user_id', id); // where the user is part of the visit
           this.orOnVal('s.fap_chair_user_id', id); // where the user is a chair
-          this.orOnVal('s.fap_secretary_user_id', id); // where the user is the secretary
+          this.orOnVal('fs.user_id', id); // where the user is the secretary
         });
       });
 
     const relatedUsers = [
-      ...relatedFapMembeers.map((r) => r.user_id),
+      ...relatedFapMembers.map((r) => r.user_id),
       ...relatedFapChairsAndSecs.map((r) => r.fap_chair_user_id),
       ...relatedFapChairsAndSecs.map((r) => r.fap_secretary_user_id),
     ];
 
     return relatedUsers;
+  }
+
+  async getSecretaries(fap: Fap): Promise<Fap> {
+    const record: FapSecretariesRecord[] = await database
+      .from('fap_secretaries')
+      .select('*')
+      .where({ fap_id: fap.id });
+
+    return { ...fap, fapSecretaryUserIds: record.map((sec) => sec.user_id) };
   }
 }

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -413,7 +413,11 @@ export interface FapRecord {
   readonly active: boolean;
   readonly full_count: number;
   readonly fap_chair_user_id: number | null;
-  readonly fap_secretary_user_id: number | null;
+}
+
+export interface FapSecretariesRecord {
+  readonly user_id: number;
+  readonly fap_id: number;
 }
 
 export interface FapProposalRecord {
@@ -1079,7 +1083,7 @@ export const createFapObject = (fap: FapRecord) => {
     fap.custom_grade_guide,
     fap.active,
     fap.fap_chair_user_id,
-    fap.fap_secretary_user_id
+    []
   );
 };
 

--- a/apps/backend/src/models/Fap.ts
+++ b/apps/backend/src/models/Fap.ts
@@ -8,7 +8,7 @@ export class Fap {
     public customGradeGuide: boolean | null,
     public active: boolean,
     public fapChairUserId: number | null,
-    public fapSecretaryUserId: number | null
+    public fapSecretaryUserIds: number[] | null
   ) {}
 }
 

--- a/apps/backend/src/mutations/FapMutations.ts
+++ b/apps/backend/src/mutations/FapMutations.ts
@@ -228,7 +228,7 @@ export default class FapMutations {
     }
 
     return this.dataSource
-      .removeMemberFromFap(args, isMemberToRemoveChairOrSecretaryOfFap)
+      .removeMemberFromFap(args, args.roleId === UserRole.FAP_CHAIR)
       .catch((error) => {
         return rejection(
           'Could not remove member from scientific evaluation panel',

--- a/apps/backend/src/resolvers/types/Fap.ts
+++ b/apps/backend/src/resolvers/types/Fap.ts
@@ -37,7 +37,7 @@ export class Fap implements Partial<FapBase> {
 
   public fapChairUserId: number | null;
 
-  public fapSecretaryUserId: number | null;
+  public fapSecretaryUserIds: number[] | null;
 }
 
 @Resolver(() => Fap)
@@ -65,26 +65,30 @@ export class FapResolvers {
     );
   }
 
-  @FieldResolver(() => BasicUserDetails, { nullable: true })
+  @FieldResolver(() => [BasicUserDetails])
   async fapSecretary(@Root() fap: Fap, @Ctx() context: ResolverContext) {
-    if (!fap.fapSecretaryUserId) {
-      return null;
+    if (!fap.fapSecretaryUserIds) {
+      return [];
     }
 
-    return context.queries.user.getBasic(context.user, fap.fapSecretaryUserId);
+    return fap.fapSecretaryUserIds.map((fapSecretaryUserId) =>
+      context.queries.user.getBasic(context.user, fapSecretaryUserId)
+    );
   }
 
-  @FieldResolver(() => Int, { nullable: true })
+  @FieldResolver(() => [Int])
   async fapSecretaryProposalCount(
     @Root() fap: Fap,
     @Ctx() context: ResolverContext
   ) {
-    if (!fap.fapSecretaryUserId) {
-      return null;
+    if (!fap.fapSecretaryUserIds) {
+      return [];
     }
 
-    return context.queries.fap.dataSource.getFapReviewerProposalCount(
-      fap.fapSecretaryUserId
+    return fap.fapSecretaryUserIds.map((fapSecretaryUserId) =>
+      context.queries.fap.dataSource.getFapReviewerProposalCount(
+        fapSecretaryUserId
+      )
     );
   }
 

--- a/apps/backend/src/utils/LRUCache.ts
+++ b/apps/backend/src/utils/LRUCache.ts
@@ -65,7 +65,7 @@ export class LRUCache<T> implements ILRUCache<T> {
 
   public constructor(maxEntries: number, secondsToLive?: number) {
     this.maxEntries = maxEntries;
-    this.millisecondsToLive = secondsToLive ? secondsToLive * 1000 : 10000;
+    this.millisecondsToLive = 5000;
   }
 
   /**

--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -955,9 +955,11 @@ context('Fap meeting components tests', () => {
   let createdInstrumentId: number;
 
   beforeEach(function () {
-    if (!featureFlags.getEnabledFeatures().get(FeatureId.USER_MANAGEMENT)) {
-      this.skip();
-    }
+    cy.getAndStoreFeaturesEnabled().then(() => {
+      if (!featureFlags.getEnabledFeatures().get(FeatureId.USER_MANAGEMENT)) {
+        this.skip();
+      }
+    });
     cy.resetDB();
     cy.getAndStoreFeaturesEnabled().then(() => {
       if (!featureFlags.getEnabledFeatures().get(FeatureId.FAP_REVIEW)) {
@@ -2044,7 +2046,7 @@ context('Fap meeting components tests', () => {
       // NOTE: Testing native html required validation message.
       cy.get('[data-cy="grade-proposal"] input').then(($input) => {
         expect(($input[0] as HTMLInputElement).validationMessage).to.eq(
-          'Please fill out this field.'
+          'Please fill in this field.'
         );
       });
       cy.get('[data-cy="grade-proposal"]').click();

--- a/apps/e2e/cypress/e2e/generalFaps.cy.ts
+++ b/apps/e2e/cypress/e2e/generalFaps.cy.ts
@@ -262,7 +262,7 @@ context('General scientific evaluation panel tests', () => {
         );
       });
 
-      cy.get('[aria-label="Set Fap Secretary"]').click();
+      cy.get('[data-cy="add-secretary-button"]').click();
 
       cy.finishedLoading();
 
@@ -297,11 +297,13 @@ context('General scientific evaluation panel tests', () => {
 
       cy.contains('Members').click();
 
-      cy.get('input[id="FapSecretary"]').should((element) => {
-        expect(element.val()).to.contain(
-          `${selectedSecretaryUserFirstName} ${selectedSecretaryUserLastName}`
-        );
-      });
+      cy.get('input[id="FapSecretary-' + fapMembers.secretary.id + '"]').should(
+        (element) => {
+          expect(element.val()).to.contain(
+            `${selectedSecretaryUserFirstName} ${selectedSecretaryUserLastName}`
+          );
+        }
+      );
     });
 
     it('Officer should be able to remove assigned Fap Chair and Fap Secretary from existing Fap', function () {

--- a/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
@@ -299,11 +299,15 @@ const FapProposalsAndAssignmentsTable = ({
       )
         ? (data.fapChairProposalCount || 0) + 1
         : data.fapChairProposalCount,
-      fapSecretaryProposalCount: assignedMembers.find(
-        (assignedMember) => assignedMember.id === data.fapSecretary?.id
-      )
-        ? (data.fapSecretaryProposalCount || 0) + 1
-        : data.fapSecretaryProposalCount,
+      fapSecretaryProposalCount: data.fapSecretaryProposalCount.map(
+        (value, index) =>
+          assignedMembers.find(
+            (assignedMember) =>
+              assignedMember.id === data.fapSecretary[index].id
+          )
+            ? value + 1
+            : value
+      ),
     });
   };
 
@@ -464,10 +468,12 @@ const FapProposalsAndAssignmentsTable = ({
             assignedReviewer.fapMemberUserId === data.fapChair?.id
               ? data.fapChairProposalCount! - 1
               : data.fapChairProposalCount,
-          fapSecretaryProposalCount:
-            assignedReviewer.fapMemberUserId === data.fapSecretary?.id
-              ? data.fapSecretaryProposalCount! - 1
-              : data.fapSecretaryProposalCount,
+          fapSecretaryProposalCount: data.fapSecretaryProposalCount.map(
+            (value, index) =>
+              assignedReviewer.fapMemberUserId === data.fapSecretary[index].id
+                ? value - 1
+                : value
+          ),
         });
       };
 


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/979

## Description

Added the ability to have multiple secretaries per FAP. Also fixed the FAP meeting tests not running (sorry about that one)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manually and E2E tests
## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

- Added new table fap_secretaries and migrate old FAPS to new table
- Added ablity to see and add multiple Secretaries in frontend

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
