### PR TITLE
Improve proposal search by waiting for user to finish typing search term 

### DIFF
--- a/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -827,7 +827,7 @@ const ProposalTableInstrumentScientist = ({
           headerSelectionProps: {
             inputProps: { 'aria-label': 'Select All Rows' },
           },
-          debounceInterval: 400,
+          debounceInterval: 600,
           columnsButton: true,
           selectionProps: (rowData: ProposalViewData) => ({
             inputProps: {

--- a/apps/frontend/src/components/proposal/ProposalTableOfficer.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableOfficer.tsx
@@ -886,7 +886,7 @@ const ProposalTableOfficer = ({
           headerSelectionProps: {
             inputProps: { 'aria-label': 'Select All Rows' },
           },
-          debounceInterval: 400,
+          debounceInterval: 600,
           columnsButton: true,
           selectionProps: (rowdata: ProposalViewData) => ({
             inputProps: {


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->
Closes: [Improve proposal search by waiting for user to finish typing search term #920](https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/920)
## Description

Looked for debounceInterval and changed the value of it from 400 to 600.

## Motivation and Context

Was changed to improve the quality of use from the users, as the query would search as the user was typing in the proposal search bar. Was a beginner issues to get my practice with local testing and get more of an understanding with the code within the repos used for the website. 

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
Used user.localhost and office.localhost to see the local code changes on the machine.
<!--- Include details of your testing environment, and the tests you ran to -->
Manually tested the search bar while also console.log the searchText input from the user, to see if the code was still searching before the user was allowed to finish typing.
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->
Just a constant value change. Here: apps/frontend/src/components/proposal/ProposalTableOfficer.tsx

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
