### PR TITLE
Add beam line manager details when viewing an instrument in the instrument page

### DIFF
--- a/apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
+++ b/apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
@@ -1,11 +1,4 @@
 import MaterialTable from '@material-table/core';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableRow,
-} from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import i18n from 'i18n';
 import PropTypes from 'prop-types';
@@ -52,7 +45,24 @@ const assignmentColumns = [
     field: 'organisation',
   },
 ];
-
+const beamLineManagerColumns = [
+  {
+    title: 'Name',
+    field: 'firstname',
+  },
+  {
+    title: 'Surname',
+    field: 'lastname',
+  },
+  {
+    title: 'Email',
+    field: 'email',
+  },
+  {
+    title: 'Organisation',
+    field: 'organisation',
+  },
+];
 const AssignedScientistsTable = ({
   instrument,
   removeAssignedScientistFromInstrument,
@@ -88,26 +98,27 @@ const AssignedScientistsTable = ({
       className={classes.root}
       data-cy="instrument-scientist-assignments-table"
     >
-      <TableContainer>
-        <Table className={classes.root}>
-          <TableBody>
-            <TableRow key="BeamlinemanagerName">
-              <TableCell align="center">
-                BeamLine Manager of {instrument.name} :{' '}
-                {instrument.beamlineManager?.firstname +
-                  ' ' +
-                  instrument.beamlineManager?.lastname}
-                . Below are the instrument scientists assigned to{' '}
-                {instrument.name}
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <MaterialTable
+        columns={beamLineManagerColumns}
+        title={`Beamline Manager`}
+        data={[
+          {
+            firstname: instrument.beamlineManager?.firstname,
+            lastname: instrument.beamlineManager?.lastname,
+            email: instrument.beamlineManager?.email,
+            organisation: instrument.beamlineManager?.organisation,
+          },
+        ]}
+        options={{
+          search: false,
+          paging: false,
+          headerStyle: { backgroundColor: '#fafafa' },
+        }}
+      ></MaterialTable>
       <MaterialTable
         icons={tableIcons}
         columns={assignmentColumns}
-        title={`Assigned ${i18n.format(t('instrument'), 'plural')}`}
+        title={`Assigned ${i18n.format(t('Scientist'), 'plural')}`}
         data={instrument.scientists}
         editable={
           isUserOfficer
@@ -122,7 +133,6 @@ const AssignedScientistsTable = ({
         options={{
           search: false,
           paging: false,
-          toolbar: false,
           headerStyle: { backgroundColor: '#fafafa' },
         }}
       />

--- a/apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
+++ b/apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
@@ -2,7 +2,7 @@ import MaterialTable from '@material-table/core';
 import makeStyles from '@mui/styles/makeStyles';
 import i18n from 'i18n';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useCheckAccess } from 'components/common/Can';
@@ -66,12 +66,27 @@ const AssignedScientistsTable = ({
 
     removeAssignedScientistFromInstrument(scientistId, instrument.id);
   };
+  useEffect(() => {
+    if (instrument.managerUserId) {
+      api()
+        .getUser({ userId: instrument.managerUserId })
+        .then((data) => {
+          return (instrument.beamlineManager = Object.create(data.user));
+        });
+    }
+  });
 
   return (
     <div
       className={classes.root}
       data-cy="instrument-scientist-assignments-table"
     >
+      <div>
+        Beam Line Manager :{' '}
+        {(instrument.beamlineManager?.firstname || '') +
+          ' ' +
+          instrument.beamlineManager?.lastname}
+      </div>
       <MaterialTable
         icons={tableIcons}
         columns={assignmentColumns}

--- a/apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
+++ b/apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
@@ -1,4 +1,11 @@
 import MaterialTable from '@material-table/core';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+} from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import i18n from 'i18n';
 import PropTypes from 'prop-types';
@@ -81,12 +88,22 @@ const AssignedScientistsTable = ({
       className={classes.root}
       data-cy="instrument-scientist-assignments-table"
     >
-      <div>
-        Beam Line Manager :{' '}
-        {(instrument.beamlineManager?.firstname || '') +
-          ' ' +
-          instrument.beamlineManager?.lastname}
-      </div>
+      <TableContainer>
+        <Table className={classes.root}>
+          <TableBody>
+            <TableRow key="BeamlinemanagerName">
+              <TableCell align="center">
+                BeamLine Manager of {instrument.name} :{' '}
+                {instrument.beamlineManager?.firstname +
+                  ' ' +
+                  instrument.beamlineManager?.lastname}
+                . Below are the instrument scientists assigned to{' '}
+                {instrument.name}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
       <MaterialTable
         icons={tableIcons}
         columns={assignmentColumns}

--- a/apps/frontend/src/components/instrument/InstrumentTable.tsx
+++ b/apps/frontend/src/components/instrument/InstrumentTable.tsx
@@ -199,7 +199,7 @@ const InstrumentTable = () => {
           createModal={createModal}
           detailPanel={[
             {
-              tooltip: 'Show Scientists',
+              tooltip: 'Show Manager and Scientists',
               render: AssignedScientists,
             },
           ]}


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Add beam line manager details when viewing an instrument in the instrument page.
<!--- Describe your changes in detail -->



<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Manual Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
Closes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/987
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
- apps/frontend/src/components/instrument/InstrumentTable.tsx

<!--- What types of changes does your code introduce? In what place? -->
![image](https://github.com/UserOfficeProject/user-office-core/assets/128331644/ab0a3743-c2f5-4c96-be08-2162e122cdf5)




## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
