### PR TITLE
Fix call_ended event firing

### DIFF
--- a/apps/backend/src/datasources/postgres/CallDataSource.test.ts
+++ b/apps/backend/src/datasources/postgres/CallDataSource.test.ts
@@ -9,9 +9,12 @@ import { Proposal } from '../../models/Proposal';
 import { dummyCallFactory } from '../mockups/CallDataSource';
 import CallDataSource from './CallDataSource';
 import database from './database';
-import { createCallObject, createProposalObject } from './records';
+import { CallRecord, createCallObject, createProposalObject } from './records';
 
 const callDataSource = new CallDataSource();
+
+const tomorrow = new Date(new Date().setDate(new Date().getDate() + 1));
+const yesterday = new Date(new Date().setDate(new Date().getDate() - 1));
 
 async function getProposalsInCall(callId: number): Promise<Proposal[]> {
   const proposals = await database
@@ -22,42 +25,40 @@ async function getProposalsInCall(callId: number): Promise<Proposal[]> {
   return proposals.map((p) => createProposalObject(p));
 }
 
-async function createCall(format?: string): Promise<Call> {
-  const call = await database('call')
-    .modify((query) => {
-      if (format) {
-        query.insert({
-          call_id: -999,
-          call_short_code: '[IT] call',
-          start_call: new Date(),
-          end_call: new Date(),
-          start_review: new Date(),
-          end_review: new Date(),
-          start_notify: new Date(),
-          end_notify: new Date(),
-          cycle_comment: '',
-          survey_comment: '',
-          start_cycle: new Date(),
-          end_cycle: new Date(),
-          reference_number_format: format,
-        });
-      } else {
-        query.insert({
-          call_id: -999,
-          call_short_code: '[IT] call',
-          start_call: new Date(),
-          end_call: new Date(),
-          start_review: new Date(),
-          end_review: new Date(),
-          start_notify: new Date(),
-          end_notify: new Date(),
-          cycle_comment: '',
-          survey_comment: '',
-          start_cycle: new Date(),
-          end_cycle: new Date(),
-        });
-      }
-    })
+async function createCall(args: {
+  format?: string;
+  callEnded?: boolean;
+  callEndedInternal?: boolean;
+  endCall?: Date;
+  endCallInternal?: Date;
+}): Promise<Call> {
+  const call: CallRecord[] = await database('call')
+    .insert({
+      call_id: -999,
+      call_short_code: '[IT] call',
+      start_call: yesterday,
+      start_review: yesterday,
+      end_review: tomorrow,
+      start_notify: yesterday,
+      end_notify: tomorrow,
+      start_cycle: yesterday,
+      end_cycle: tomorrow,
+      cycle_comment: '',
+      survey_comment: '',
+      ...(args.format && { reference_number_format: args.format }),
+      ...(args.callEnded && { call_ended: args.callEnded }),
+      ...(args.callEndedInternal && {
+        call_ended_internal: args.callEndedInternal,
+      }),
+      ...((args.endCall && { end_call: args.endCall }) || {
+        end_call: tomorrow,
+      }),
+      ...((args.endCallInternal && {
+        end_call_internal: args.endCallInternal,
+      }) || {
+        end_call_internal: tomorrow,
+      }),
+    } as CallRecord)
     .returning('*');
 
   return createCallObject(call[0]);
@@ -140,9 +141,9 @@ afterAll(async () => {
   await database.destroy();
 });
 
-describe('Call update', () => {
+describe('Call update with reference numbers', () => {
   test('When updated with a reference number format after one did not exist, all proposals in the call are updated to use the new format', async () => {
-    const call = await createCall();
+    const call = await createCall({});
     const expectedRefNums: string[] = [];
     for (let i = 0; i < 1000; i++) {
       await createSubmittedProposal(call.id, i, i);
@@ -165,7 +166,7 @@ describe('Call update', () => {
   });
 
   test('When updated with a reference number format after one already existed, all proposals in the call are updated to use the new format', async () => {
-    const call = await createCall('192{digits:4}');
+    const call = await createCall({ format: '192{digits:4}' });
     const expectedRefNums: string[] = [];
     for (let i = 0; i < 100; i++) {
       await createSubmittedProposal(call.id, i, i);
@@ -188,7 +189,7 @@ describe('Call update', () => {
   });
 
   test('When a reference number format is removed, proposals retain their reference numbers', async () => {
-    const call = await createCall('211{digits:4}');
+    const call = await createCall({ format: '211{digits:4}' });
     const expectedRefNums: string[] = [];
     for (let i = 0; i < 100; i++) {
       const refNum = '211' + String(i).padStart(4, '0');
@@ -212,7 +213,7 @@ describe('Call update', () => {
   });
 
   test('When a reference number format is removed, proposals retain their sequence numbers', async () => {
-    const call = await createCall('211{digits:4}');
+    const call = await createCall({ format: '211{digits:4}' });
     const p1 = await createSubmittedProposal(call.id, 123, 123);
     const p2 = await createSubmittedProposal(call.id, 456, 456);
     const p3 = await createSubmittedProposal(call.id, 789, 789);
@@ -245,7 +246,7 @@ describe('Call update', () => {
   });
 
   test('In a call with 1000 proposals, when the format is changed, all proposals are correctly updated', async () => {
-    const call = await createCall('192{digits:4}');
+    const call = await createCall({ format: '192{digits:4}' });
     const expectedRefNums: string[] = [];
     await BluePromise.mapSeries(new Array(1000), async function (_prop, index) {
       expectedRefNums.push('221' + String(index).padStart(5, '0'));
@@ -268,5 +269,85 @@ describe('Call update', () => {
     );
 
     expect(invalidProposals.length).toBe(0);
+  });
+});
+
+describe('Call update with call ended flags', () => {
+  test('When a call is updated with a future call end date, the call ended flag is changed to false', async () => {
+    const initialValues = { callEnded: true, endCall: yesterday };
+    const call = await createCall(initialValues);
+    expect(call).toEqual(expect.objectContaining(initialValues));
+
+    expect(
+      await callDataSource.update({
+        id: call.id,
+        endCall: tomorrow,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        endCall: tomorrow,
+        callEnded: !initialValues.callEnded,
+      })
+    );
+  });
+
+  test('When a call is updated with a future internal call end date, the internal call ended flag is changed to false', async () => {
+    const initialValues = {
+      callEndedInternal: true,
+      endCallInternal: yesterday,
+    };
+    const call = await createCall(initialValues);
+    expect(call).toEqual(expect.objectContaining(initialValues));
+
+    expect(
+      await callDataSource.update({
+        id: call.id,
+        endCallInternal: tomorrow,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        endCallInternal: tomorrow,
+        callEndedInternal: !initialValues.callEndedInternal,
+      })
+    );
+  });
+
+  test('When a call is updated with a past call end date, the call ended flag is left as its previous value', async () => {
+    const initialValues = { callEnded: false, endCall: tomorrow };
+    const call = await createCall(initialValues);
+    expect(call).toEqual(expect.objectContaining(initialValues));
+
+    expect(
+      await callDataSource.update({
+        id: call.id,
+        endCall: yesterday,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        endCall: yesterday,
+        callEnded: initialValues.callEnded,
+      })
+    );
+  });
+
+  test('When a call is updated with a past internal call end date, the internal call ended flag is left as its previous value', async () => {
+    const initialValues = {
+      callEndedInternal: false,
+      endCallInternal: tomorrow,
+    };
+    const call = await createCall(initialValues);
+    expect(call).toEqual(expect.objectContaining(initialValues));
+
+    expect(
+      await callDataSource.update({
+        id: call.id,
+        endCallInternal: yesterday,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        endCallInternal: yesterday,
+        callEndedInternal: initialValues.callEndedInternal,
+      })
+    );
   });
 });

--- a/apps/backend/src/datasources/postgres/CallDataSource.test.ts
+++ b/apps/backend/src/datasources/postgres/CallDataSource.test.ts
@@ -25,13 +25,15 @@ async function getProposalsInCall(callId: number): Promise<Proposal[]> {
   return proposals.map((p) => createProposalObject(p));
 }
 
-async function createCall(args: {
-  format?: string;
-  callEnded?: boolean;
-  callEndedInternal?: boolean;
-  endCall?: Date;
-  endCallInternal?: Date;
-}): Promise<Call> {
+async function createCall(
+  args: {
+    format?: string;
+    callEnded?: boolean;
+    callEndedInternal?: boolean;
+    endCall?: Date;
+    endCallInternal?: Date;
+  } = {}
+): Promise<Call> {
   const call: CallRecord[] = await database('call')
     .insert({
       call_id: -999,
@@ -143,7 +145,7 @@ afterAll(async () => {
 
 describe('Call update with reference numbers', () => {
   test('When updated with a reference number format after one did not exist, all proposals in the call are updated to use the new format', async () => {
-    const call = await createCall({});
+    const call = await createCall();
     const expectedRefNums: string[] = [];
     for (let i = 0; i < 1000; i++) {
       await createSubmittedProposal(call.id, i, i);

--- a/apps/backend/src/datasources/postgres/CallDataSource.test.ts
+++ b/apps/backend/src/datasources/postgres/CallDataSource.test.ts
@@ -13,8 +13,13 @@ import { CallRecord, createCallObject, createProposalObject } from './records';
 
 const callDataSource = new CallDataSource();
 
-const tomorrow = new Date(new Date().setDate(new Date().getDate() + 1));
-const yesterday = new Date(new Date().setDate(new Date().getDate() - 1));
+const today = new Date();
+
+const tomorrow = new Date(today);
+tomorrow.setDate(tomorrow.getDate() + 1);
+
+const yesterday = new Date(today);
+yesterday.setDate(yesterday.getDate() - 1);
 
 async function getProposalsInCall(callId: number): Promise<Proposal[]> {
   const proposals = await database

--- a/apps/backend/src/datasources/postgres/CallDataSource.ts
+++ b/apps/backend/src/datasources/postgres/CallDataSource.ts
@@ -290,6 +290,34 @@ export default class PostgresCallDataSource implements CallDataSource {
           }
         }
 
+        /*
+         Work out whether the call_ended and call_ended_internal flags need updating.
+        */
+        const determineCallEndedFlag = (
+          newFlagValue: boolean | undefined,
+          previousFlagValue: boolean | undefined,
+          endCall: Date | undefined
+        ) => {
+          // Use the new value if explicitly passed in.
+          if (newFlagValue) {
+            return newFlagValue;
+          }
+
+          /*
+           If the call end date has been changed to the future, set to false.
+          */
+          if (endCall && endCall.getTime() > currentDate.getTime()) {
+            return false;
+          }
+
+          /*
+           Where the date has been changed to the past, leave the flag unchanged from
+           its previous value. If it's false, the call end event will fire for this
+           call and update the flags, and if true it indicates an old call being updated).
+          */
+          return previousFlagValue;
+        };
+
         const callUpdate = await database
           .update(
             {
@@ -310,24 +338,16 @@ export default class PostgresCallDataSource implements CallDataSource {
               submission_message: args.submissionMessage,
               survey_comment: args.surveyComment,
               proposal_workflow_id: args.proposalWorkflowId,
-              /*
-               If the call is updated with future end dates, set the ended flags as
-               false. If updated with past dates, leave the flags unchanged from the
-               existing values (if the existing values are false, the call end events
-               will fire for this call and update the flags, and if true it indicates
-               an old call being updated).
-              */
-              call_ended: args.callEnded
-                ? args.callEnded
-                : args.endCall && args.endCall.getTime() > currentDate.getTime()
-                ? false
-                : preUpdateCall.call_ended,
-              call_ended_internal: args.callEndedInternal
-                ? args.callEndedInternal
-                : args.endCallInternal &&
-                  args.endCallInternal.getTime() > currentDate.getTime()
-                ? false
-                : preUpdateCall.call_ended_internal,
+              call_ended: determineCallEndedFlag(
+                args.callEnded,
+                preUpdateCall.call_ended,
+                args.endCall
+              ),
+              call_ended_internal: determineCallEndedFlag(
+                args.callEndedInternal,
+                preUpdateCall.call_ended_internal,
+                args.endCallInternal
+              ),
               call_review_ended: args.callReviewEnded,
               call_fap_review_ended: args.callFapReviewEnded,
               template_id: args.templateId,

--- a/apps/backend/src/datasources/postgres/CallDataSource.ts
+++ b/apps/backend/src/datasources/postgres/CallDataSource.ts
@@ -310,14 +310,24 @@ export default class PostgresCallDataSource implements CallDataSource {
               submission_message: args.submissionMessage,
               survey_comment: args.surveyComment,
               proposal_workflow_id: args.proposalWorkflowId,
-              call_ended:
-                preUpdateCall.call_ended &&
-                args.endCall &&
-                args.endCall.getTime() < currentDate.getTime(),
-              call_ended_internal: args.endCallInternal
-                ? preUpdateCall.call_ended_internal &&
-                  args.endCallInternal.getTime() < currentDate.getTime()
-                : args.callEndedInternal,
+              /*
+               If the call is updated with future end dates, set the ended flags as
+               false. If updated with past dates, leave the flags unchanged from the
+               existing values (if the existing values are false, the call end events
+               will fire for this call and update the flags, and if true it indicates
+               an old call being updated).
+              */
+              call_ended: args.callEnded
+                ? args.callEnded
+                : args.endCall && args.endCall.getTime() > currentDate.getTime()
+                ? false
+                : preUpdateCall.call_ended,
+              call_ended_internal: args.callEndedInternal
+                ? args.callEndedInternal
+                : args.endCallInternal &&
+                  args.endCallInternal.getTime() > currentDate.getTime()
+                ? false
+                : preUpdateCall.call_ended_internal,
               call_review_ended: args.callReviewEnded,
               call_fap_review_ended: args.callFapReviewEnded,
               template_id: args.templateId,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Closes UserOfficeProject/user-office-project-issue-tracker#937

This fixes logic for updating a call's `call_ended` and `call_ended_internal` flags. These flags are only used for determining whether to fire the `CALL_ENDED` and `CALL_ENDED_INTERNAL` events respectively. We find calls where call ended = false, set the flag to true, then fire the event. The previous logic would mean that the values were always left false, so the events would keep firing at each check and we'd notice them in the STFC logs.

The new logic says that:
- The flag can be explicitly set to true or false
- When a call is updated with a future call end date, the call ended flag is changed to false.
  - If the call was closed (flag was true), this ensures the event will still fire now that it's open.
  - If the call was open, nothing changes.
- When a call is updated with a past call end date, the call ended flag is left as its previous value
  - If the call was closed (flag was true), do nothing as it's an old call being updated.
  - If the call was open (flag was false), do nothing. At the next `CALL_ENDED` check, the event needs to detect this call, update the boolean to true, and fire the event.

## Motivation and Context

Our calls at STFC don't close and therefore the call_ended event fires every hour

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- Manual testing
- Integration tests added

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

Fix logic for updating call_ended and call_ended_internal flags.

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
