### PR TITLE
fix: included ESS getUsersByUserNumbers implementation

### DIFF
--- a/apps/backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/backend/src/datasources/postgres/UserDataSource.ts
@@ -737,10 +737,15 @@ export default class PostgresUserDataSource implements UserDataSource {
     }
   }
 
-  async getUsersByUserNumbers(id: readonly number[]): Promise<User[]> {
-    logger.logDebug('Method not implemented.', {});
-    const user: User[] = [];
-
-    return user;
+  async getUsersByUserNumbers(ids: readonly number[]): Promise<User[]> {
+    return database
+      .select()
+      .from('users')
+      .whereIn('user_id', ids)
+      .then((userRecords: UserRecord[]) => {
+        return userRecords.map((user) => {
+          return createUserObject(user);
+        });
+      });
   }
 }

--- a/apps/e2e/cypress/e2e/proposals.cy.ts
+++ b/apps/e2e/cypress/e2e/proposals.cy.ts
@@ -143,6 +143,21 @@ context('Proposal tests', () => {
       });
     });
 
+    it('Principal investigator in the proposal table should not be empty', () => {
+      cy.login('officer');
+      cy.visit('/');
+
+      cy.finishedLoading();
+
+      cy.contains('td', newProposalTitle)
+        .parents('tbody tr')
+        .first()
+        .find('td')
+        .eq(4)
+        .should('not.contain.text', '-')
+        .should('contain.text', 'Carl');
+    });
+
     it('Should be able create proposal', () => {
       cy.login('user1', initialDBData.roles.user);
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

- added missing implementation for getUsersByUserNumbers function to adapt PR #469. 
- added test to ensure principal investigator in the proposal userofficer table not to be empty.

## Motivation and Context

After PR #469, the proposal table fails to load user information with ESS config due to missing getUsersByUserNumbers implementation despite all the e2e successes. This PR aims to fix that.

## How Has This Been Tested

- e2e
- manual


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
