### PR TITLE
981 display summary of scored proposals

### DIFF
--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -608,6 +608,8 @@ context('Fap reviews tests', () => {
 
       cy.finishedLoading();
 
+      cy.contains('0 / 1').should('be.visible');
+
       cy.get('[aria-label="Detail panel visibility toggle"]').click();
 
       cy.contains(fapMembers.reviewer.lastName)
@@ -629,6 +631,10 @@ context('Fap reviews tests', () => {
 
       cy.get('[data-cy="save-grade"]').should('be.disabled');
       cy.get('[data-cy="submit-grade"]').should('be.disabled');
+
+      cy.visit(`/FapPage/${createdFapId}?tab=2`);
+      cy.finishedLoading();
+      cy.contains('1 / 1').should('be.visible');
     });
   });
 

--- a/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
@@ -96,11 +96,11 @@ const FapProposalColumns: Column<FapProposalType>[] = [
     title: 'Reviews',
     render: (rowData) => {
       const totalReviews = rowData.assignments?.length;
-      const gradedReviews = rowData.assignments?.filter(
+      const gradedProposals = rowData.assignments?.filter(
         (assignment) =>
           assignment.review !== null && assignment.review.grade !== null
       );
-      const countReviews = gradedReviews?.length || 0;
+      const countReviews = gradedProposals?.length || 0;
 
       return totalReviews === 0 ? '-' : `${countReviews} / ${totalReviews}`;
     },

--- a/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
@@ -93,6 +93,19 @@ const FapProposalColumns: Column<FapProposalType>[] = [
     emptyValue: '-',
   },
   {
+    title: 'Reviews',
+    render: (rowData) => {
+      const totalReviews = rowData.assignments?.length;
+      const gradedReviews = rowData.assignments?.filter(
+        (assignment) =>
+          assignment.review !== null && assignment.review.grade !== null
+      );
+      const countReviews = gradedReviews?.length || 0;
+
+      return totalReviews === 0 ? '-' : `${countReviews} / ${totalReviews}`;
+    },
+  },
+  {
     title: 'Average grade',
     render: (rowData) => {
       const avgGrade = average(


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Closes [981](https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/981)
<!--- Describe your changes in detail -->
Added a `Reviews` column in the `FAP Proposals and Assignments` table which displays the number of proposals reviewed out of total number of proposals to review.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Initially, the system required to click the `Show Reviews` drop down to check if proposals were graded or not. Having this feature makes it easier for FAP members to quickly check if there are any outstading proposals that require grading especially for calls like ISIS which require two reviewers per proposal.

![image](https://github.com/UserOfficeProject/user-office-core/assets/69144386/3649e809-5b72-4ac6-b841-bdf6398bc954)


## How Has This Been Tested
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
