### PR TITLE
chore: Update cache action to v4

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Cache node_modules
         id: cached-node-modules-root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-root-${{ hashFiles('package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Cache backend node_modules
         id: cached-node-modules-backend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/backend/node_modules
           key: node-modules-backend-${{ hashFiles('apps/backend/package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Cache frontend node_modules
         id: cached-node-modules-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Cache frontend SDK
         id: cached-sdk-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/src/generated
           key: ${{ env.FRONTEND_SDK_KEY }}
@@ -150,28 +150,28 @@ jobs:
 
       - name: Restore node_modules
         id: cached-node-modules-root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-root-${{ hashFiles('package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/backend/node_modules
           key: node-modules-backend-${{ hashFiles('apps/backend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore frontend node_modules
         id: cached-node-modules-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore frontend SDK
         id: cached-sdk-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/src/generated
           key: ${{ env.FRONTEND_SDK_KEY }}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/backend/node_modules
           key: node-modules-backend-${{ hashFiles('apps/backend/package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -254,28 +254,28 @@ jobs:
 
       - name: Restore node_modules
         id: cached-node-modules-root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-root-${{ hashFiles('package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/backend/node_modules
           key: node-modules-backend-${{ hashFiles('apps/backend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore frontend node_modules
         id: cached-node-modules-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore frontend SDK
         id: cached-sdk-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/src/generated
           key: ${{ env.FRONTEND_SDK_KEY }}
@@ -291,7 +291,7 @@ jobs:
       #   env:
       #     CYPRESS_CACHE_FOLDER: cache/Cypress
       #   id: cached-node-modules-e2e
-      #   uses: actions/cache@v3
+      #   uses: actions/cache@v4
       #   with:
       #     path: apps/e2e/node_modules
       #     key: node-modules-${{ hashFiles('apps/e2e/package-lock.json') }}-${{ env.NODE_VERSION }}


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Github actions runners are no longer supporting node 16 https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ and the cache action was running 16 by default so I have just updated it: https://github.com/actions/cache/releases/tag/v4.0.0. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
