### PR TITLE
BREAKING CHANGE: add possibility to disable rabbitmq and standardize env variable naming

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,7 +43,6 @@ jobs:
             https://api.github.com/repos/UserOfficeProject/user-office-factory/branches?per_page=100
           )
 
-
           GHCR_TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
 
           CHECK_IF_IMAGE_EXISTS=$(curl -H "Authorization: Bearer $GHCR_TOKEN" https://ghcr.io/v2/userofficeproject/user-office-factory/tags/list | jq --arg TAG ${{ github.head_ref }} '.tags as $t | $TAG | IN($t[])')
@@ -54,13 +53,11 @@ jobs:
               FACTORY_TAGS=$((FACTORY_TAGS+1))
           fi
 
-
           echo $CHECK_IF_IMAGE_EXISTS
 
           if [[ $CHECK_IF_IMAGE_EXISTS == null  ]]; then 
               FACTORY_TAGS=$((FACTORY_TAGS+1))
           fi
-
 
           FACTORY_TAG=develop
           if [[ $FACTORY_TAGS == "2" ]]; then
@@ -184,8 +181,8 @@ jobs:
       - run: npm run build
         env:
           NODE_ENV: development
-          secret: ${{secrets.secret}}
-          tokenLife: 7d
+          JWT_SECRET: ${{secrets.secret}}
+          JWT_TOKEN_LIFE: 7d
           SPARKPOST_TOKEN: wrong_token_for_test
 
   test_backend:
@@ -214,9 +211,9 @@ jobs:
           DATE_TIME_FORMAT: dd-MM-yyyy HH:mm
           PING_PUBLIC_CRT: dummypingsecret
           DEPENDENCY_CONFIG: e2e
-          secret: dummysecret
+          JWT_SECRET: dummysecret
           NODE_ENV: development
-          tokenLife: 7d
+          JWT_TOKEN_LIFE: 7d
           SPARKPOST_TOKEN: dummytoken
           DATABASE_URL: postgres://duouser:duopassword@127.0.0.1:5432/duo
         run: |
@@ -306,7 +303,7 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/.."
           git clone --depth 1 --branch "${{ needs.resolve_dep.outputs.FACTORY_TAG }}" https://github.com/UserOfficeProject/user-office-factory.git
-     
+
       - name: Run e2e tests stfc
         env:
           USER_OFFICE_BACKEND_DIR: apps/backend
@@ -319,10 +316,10 @@ jobs:
           DATE_TIME_FORMAT: dd-MM-yyyy HH:mm
           PING_PUBLIC_CRT: dummypingsecret
           DEPENDENCY_CONFIG: stfc
-          secret: qMyLZALzs229ybdQXNyzYRdju7X784TH
+          JWT_SECRET: qMyLZALzs229ybdQXNyzYRdju7X784TH
           NODE_ENV: development
-          baseURL: localhost:3000
-          tokenLife: 7d
+          BASE_URL: localhost:3000
+          JWT_TOKEN_LIFE: 7d
           SPARKPOST_TOKEN: dummytoken
           DATABASE_URL: postgres://duouser:duopassword@127.0.0.1:5432/duo
           USER_OFFICE_FACTORY_ENDPOINT: http://localhost:4500/generate
@@ -350,7 +347,7 @@ jobs:
           REPO_DIR_NAME=$(basename $GITHUB_WORKSPACE)
 
           npm run e2e:after:dev:stfc
-  
+
       - name: Run e2e tests
         env:
           USER_OFFICE_BACKEND_DIR: apps/backend
@@ -363,10 +360,10 @@ jobs:
           DATE_TIME_FORMAT: dd-MM-yyyy HH:mm
           PING_PUBLIC_CRT: dummypingsecret
           DEPENDENCY_CONFIG: e2e
-          secret: qMyLZALzs229ybdQXNyzYRdju7X784TH
+          JWT_SECRET: qMyLZALzs229ybdQXNyzYRdju7X784TH
           NODE_ENV: development
-          baseURL: localhost:3000
-          tokenLife: 7d
+          BASE_URL: localhost:3000
+          JWT_TOKEN_LIFE: 7d
           SPARKPOST_TOKEN: dummytoken
           DATABASE_URL: postgres://duouser:duopassword@127.0.0.1:5432/duo
           USER_OFFICE_FACTORY_ENDPOINT: http://localhost:4500/generate
@@ -389,8 +386,6 @@ jobs:
           REPO_DIR_NAME=$(basename $GITHUB_WORKSPACE)
 
           npm run e2e:after:dev -- --dns-result-order=ipv4first
-  
-
 
       - name: Upload cypres screenshots
         if: failure()

--- a/apps/backend/docker-compose-stfc.e2e.yml
+++ b/apps/backend/docker-compose-stfc.e2e.yml
@@ -30,7 +30,7 @@ services:
     depends_on:
       - db
     environment:
-      secret: qMyLZALzs229ybdQXNyzYRdju7X784TH
+      JWT_SECRET: qMyLZALzs229ybdQXNyzYRdju7X784TH
       EXTERNAL_AUTH_TOKEN: abc
       NODE_ENV: development
       DATABASE_CONNECTION_STRING: postgres://duouser:duopassword@db:5432/duo

--- a/apps/backend/example.development.env
+++ b/apps/backend/example.development.env
@@ -25,7 +25,6 @@ ORCID_CLIENT_ID=app-id
 ORCID_CLIENT_SECRET=secret
 
 # UO_Factory
-UO_FEATURE_ENABLE_UO_FACTORY=1
 USER_OFFICE_FACTORY_ENDPOINT=http://localhost:4500/generate
 
 # OAuth
@@ -43,22 +42,25 @@ NODE_ENV=development
 DEPENDENCY_CONFIG=ess
 PING_PUBLIC_CRT=dummypingsecret
 DATABASE_URL=postgres://duouser:duopassword@127.0.0.1:5432/duo
-baseURL=localhost:3000
-tokenLife=7d
-secret=qMyLZALzs229ybdQXNyzYRdju7X784TH
+BASE_URL=localhost:3000
+JWT_TOKEN_LIFE=7d
+JWT_SECRET=qMyLZALzs229ybdQXNyzYRdju7X784TH
 SPARKPOST_TOKEN=insertokenhere
 TZ=Europe/Stockholm
 DATE_FORMAT=dd-MM-yyyy
 DATE_TIME_FORMAT=dd-MM-yyyy HH:mm
 
+# Enable/disable RabbitMQ message broker. If disabled (DISABLE_RABBITMQ_MESSAGE_BROKER=1) there is no need for any of the RABBITMQ_ prefixed variables.
+DISABLE_RABBITMQ_MESSAGE_BROKER=0
+RABBITMQ_HOSTNAME=localhost
+RABBITMQ_USERNAME=guest
+RABBITMQ_PASSWORD=guest
 # Exchange name of the core where the listening queues should be bound.
-CORE_EXCHANGE_NAME=user_office_backend.fanout
-
+RABBITMQ_CORE_EXCHANGE_NAME=user_office_backend.fanout
 # Exchange name of the scheduler where the listening queues should be bound.
-SCHEDULER_EXCHANGE_NAME=user_office_scheduler_backend.fanout
-
+RABBITMQ_SCHEDULER_EXCHANGE_NAME=user_office_scheduler_backend.fanout
 # Queue name that should be bound to the user-office-scheduler-backend exchange
-EVENT_SCHEDULING_QUEUE_NAME=user-office-scheduler-backend.event_scheduling.queue
+RABBITMQ_EVENT_SCHEDULING_QUEUE_NAME=user-office-scheduler-backend.event_scheduling.queue
 
 SCHEDULER_ENDPOINT=http://localhost:4200/graphql
 

--- a/apps/backend/src/middlewares/authorization.ts
+++ b/apps/backend/src/middlewares/authorization.ts
@@ -2,7 +2,7 @@ import jwt from 'express-jwt';
 
 import { JwtAlg } from '../utils/jwt';
 
-const secret = process.env.secret as string;
+const secret = process.env.JWT_SECRET as string;
 
 const authorization = () =>
   jwt({

--- a/apps/backend/src/mutations/UserMutations.spec.ts
+++ b/apps/backend/src/mutations/UserMutations.spec.ts
@@ -18,7 +18,7 @@ import UserMutations from './UserMutations';
 
 jest.mock('../datasources/stfc/UOWSSoapInterface');
 
-const secret = process.env.secret as string;
+const secret = process.env.JWT_SECRET as string;
 
 const goodToken = jsonwebtoken.sign(
   {

--- a/apps/backend/src/utils/helperFunctions.ts
+++ b/apps/backend/src/utils/helperFunctions.ts
@@ -115,3 +115,5 @@ export function getContextKeys(
 }
 
 export const isProduction = process.env.NODE_ENV === 'production';
+export const isRabbitMqDisabled =
+  process.env.DISABLE_RABBITMQ_MESSAGE_BROKER === '1';

--- a/apps/backend/src/utils/jwt.ts
+++ b/apps/backend/src/utils/jwt.ts
@@ -5,8 +5,8 @@ import jsonwebtoken, {
   VerifyOptions,
 } from 'jsonwebtoken';
 
-const secret = process.env.secret as string;
-const expiresIn = process.env.tokenLife as string;
+const secret = process.env.JWT_SECRET as string;
+const expiresIn = process.env.JWT_TOKEN_LIFE as string;
 
 if (!secret) {
   logger.logError(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,12 +70,11 @@ services:
     image: 'ghcr.io/userofficeproject/user-office-backend:develop'
     environment:
       DATABASE_URL: postgres://duouser:duopassword@db:5432/duo
-      secret: qMyLZALzs229ybdQXNyzYRdju7X784TH
-      tokenLife: 7d
-      baseURL: localhost:33000
+      JWT_SECRET: qMyLZALzs229ybdQXNyzYRdju7X784TH
+      JWT_TOKEN_LIFE: 7d
+      BASE_URL: localhost:33000
       SPARKPOST_TOKEN: dummytoken
       NODE_ENV: development
-      UO_FEATURE_DISABLE_EAM: 1
       USER_OFFICE_FACTORY_ENDPOINT: http://factory:4500/generate
       RABBITMQ_HOSTNAME: rabbitmq
       AUTH_DISCOVERY_URL: http://host.docker.internal:5001/.well-known/openid-configuration


### PR DESCRIPTION
## Description
This PR introduces a breaking change that adds the possibility to disable RabbitMQ and standardizes environment variable naming. 

## Motivation and Context
This change is required to give the system more flexibility in handling message queues, particularly in scenarios where RabbitMQ is not needed or not available. The standardization of environment variable naming also improves code readability and maintainability.

## Changes
1. The environment variable naming has been standardized across the application, changing variables like `secret`, `baseURL`, and `tokenLife` to `JWT_SECRET`, `BASE_URL`, and `JWT_TOKEN_LIFE` respectively.
2. A new environment variable `DISABLE_RABBITMQ_MESSAGE_BROKER` has been introduced to control the usage of RabbitMQ.
3. The RabbitMQ handlers in `messageBroker.ts` have been modified to skip posting or listening if RabbitMQ is disabled.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-3832](https://jira.esss.lu.se/browse/SWAP-3832)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated