### PR TITLE
fix(css): make ellipsis visible when using external auth

### DIFF
--- a/apps/frontend/src/components/common/CenteredAlert.tsx
+++ b/apps/frontend/src/components/common/CenteredAlert.tsx
@@ -23,6 +23,9 @@ const useStyles = makeStyles(() => ({
       paddingLeft: '40px',
       paddingRight: '10px',
     },
+    '& .MuiAlert-message': {
+      overflow: 'visible',
+    },
   },
 }));
 


### PR DESCRIPTION
The default mui alert message overflow value is auto, which hid the ellipsis with a scrollbar

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

I tweaked my local frontend instance so that successful external auth wouldn't redirect you to a different page. Adding this CSS change had the following effect in browser:
![ellipsis](https://github.com/UserOfficeProject/user-office-core/assets/2938284/87e38117-675b-444b-a6d6-3497fae2da18)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Closes UserOfficeProject/issue-tracker#927
<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
