### PR TITLE
feat: send proposal message upon PROPOSAL_ACCEPTED event

### DIFF
--- a/apps/backend/src/eventHandlers/messageBroker.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.ts
@@ -209,6 +209,7 @@ export async function createPostToRabbitMQHandler() {
       case Event.PROPOSAL_CREATED:
       case Event.PROPOSAL_UPDATED:
       case Event.PROPOSAL_SUBMITTED:
+      case Event.PROPOSAL_ACCEPTED:
       case Event.PROPOSAL_DELETED:
       case Event.PROPOSAL_STATUS_ACTION_EXECUTED: {
         const jsonMessage = await getProposalMessageData(event.proposal);


### PR DESCRIPTION
## Description
This PR introduces a feature to send proposal messages when a proposal is accepted. 

## Motivation and Context
The change is required to ensure that relevant parties are notified and can take appropriate action when a proposal is accepted. This enhances the communication flow within the system.

## Changes
- An event listener for `PROPOSAL_ACCEPTED` event has been added in the `messageBroker.ts` file. 
- Upon the occurrence of this event, `getProposalMessageData` function is called to fetch the necessary message data.
- This data is then sent as a message to the relevant parties.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated