### PR TITLE
fix: question fails to show with removed dependency

### DIFF
--- a/apps/frontend/src/components/questionary/questionaryComponents/QuestionDependencyList.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/QuestionDependencyList.tsx
@@ -31,8 +31,9 @@ const QuestionDependencyList = ({
   form,
 }: QuestionDependencyListProps) => {
   const field: QuestionTemplateRelation = form.values;
+  const defaultOperator = DependenciesLogicOperator.AND;
   const [logicOperator, setLogicOperator] = useState<DependenciesLogicOperator>(
-    field.dependenciesOperator || DependenciesLogicOperator.AND
+    field.dependenciesOperator || defaultOperator
   );
 
   useEffect(() => {
@@ -147,6 +148,10 @@ const QuestionDependencyList = ({
                     <IconButton
                       onClick={(): void => {
                         remove(i);
+
+                        if (field.dependencies.length === 1) {
+                          setLogicOperator(defaultOperator);
+                        }
                       }}
                     >
                       <ClearIcon />

--- a/apps/frontend/src/models/questionary/QuestionaryFunctions.ts
+++ b/apps/frontend/src/models/questionary/QuestionaryFunctions.ts
@@ -87,7 +87,7 @@ export function areDependenciesSatisfied(
   fieldId: string
 ) {
   const field = getFieldById(questionary, fieldId);
-  if (!field || !field.dependencies) {
+  if (!field || !field.dependencies || field.dependencies.length === 0) {
     return true;
   }
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

- Fix a bug where if you add an OR dependency to a question, and then remove it, it will not show up in a proposal or questionary preview. This was because with either an OR or AND dependency, it was still checking whether an empty list of dependencies were completed, but passing for AND and failing for OR. Made the check skip if the dependency list if empty.
- After the last dependency is removed from a question, reset the operator to AND. Thought this would be nice for consistency since we default to AND when first adding.

## Motivation and Context


<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Manual testing questionary preview and creating a proposal. Checking database operator value.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
Fixes https://github.com/UserOfficeProject/issue-tracker/issues/1006
<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
