### PR TITLE
fix: changed scheduledEventId to be nullable

### DIFF
--- a/apps/backend/src/resolvers/types/Shipment.ts
+++ b/apps/backend/src/resolvers/types/Shipment.ts
@@ -38,7 +38,7 @@ export class Shipment implements Partial<ShipmentOrigin> {
   @Field(() => Int)
   public questionaryId: number;
 
-  @Field(() => Int)
+  @Field(() => Int, { nullable: true })
   public scheduledEventId: number;
 
   @Field(() => Int)

--- a/apps/frontend/src/components/questionary/questionaryComponents/ShipmentBasis/QuestionaryComponentShipmentBasis.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/ShipmentBasis/QuestionaryComponentShipmentBasis.tsx
@@ -180,6 +180,7 @@ const shipmentBasisPreSubmit =
         });
       }
     } else {
+      if (!shipment.scheduledEventId) return returnValue;
       const { createShipment } = await api.createShipment({
         title: title,
         proposalPk: shipment.proposalPk,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

In the Shipment model, the scheduledEventId column is nullable. But in the graphql query `getShipments`, the column is defined as non nullable in the class `Shipment`. Due to this confict, the graphql query is failing. The class has been changed to make the column as nullable and made it aligned as per the table structure. 

## Motivation and Context

Fix graphql query

## How Has This Been Tested

Manually

## Fixes

getShipments() graphql query

## Changes

Changes in class `Shipment`

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
