### PR TITLE
fix: calls table sorting order of dates

### DIFF
--- a/apps/frontend/src/components/call/CallsTable.tsx
+++ b/apps/frontend/src/components/call/CallsTable.tsx
@@ -92,10 +92,14 @@ const CallsTable = ({ confirm }: WithConfirmProps) => {
     {
       title: `Start Date (${timezone})`,
       field: 'formattedStartCall',
+      customSort: (a: Call, b: Call) =>
+        new Date(a.startCall).getTime() - new Date(b.startCall).getTime(),
     },
     {
       title: `End Date (${timezone})`,
       field: 'formattedEndCall',
+      customSort: (a: Call, b: Call) =>
+        new Date(a.endCall).getTime() - new Date(b.endCall).getTime(),
     },
     {
       title: 'Reference number format',


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Fix the sorting of dates in the calls table by comparing dates instead of strings.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Closes UserOfficeProject/issue-tracker#1010

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
