### PR TITLE
fix: correct email invite feature typo

### DIFF
--- a/apps/backend/db_patches/0150_UpdateEmailInviteFeature.sql
+++ b/apps/backend/db_patches/0150_UpdateEmailInviteFeature.sql
@@ -1,0 +1,11 @@
+DO
+$$
+BEGIN
+    IF register_patch('UpdateEmailInviteFeature.sql', 'Scott Hurley', 'Update Email Invite Feature', '2024-03-18') THEN
+
+    UPDATE features SET description='Email invitation functionality' WHERE feature_id = 'EMAIL_INVITE';
+
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
Closes: UserOfficeProject/issue-tracker/issues/999

## Description

Adds a db patch to correct the description of the `EMAIL_INVITE` feature.

## Motivation and Context

Fixes a minor typo.

## How Has This Been Tested

Tested manually