### PR TITLE
fix: allow blank reviews on stfc fap export

### DIFF
--- a/apps/backend/src/factory/xlsx/stfc/StfcFapDataRow.ts
+++ b/apps/backend/src/factory/xlsx/stfc/StfcFapDataRow.ts
@@ -58,7 +58,7 @@ export async function getStfcDataRow(
 export function populateStfcRow(row: RowObj) {
   const individualReviews = row.reviews?.flatMap((rev) => [
     rev.grade,
-    stripHtml(rev.comment).result,
+    rev.comment && stripHtml(rev.comment).result,
   ]);
 
   return [


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1038

## Description
This PR allows blank reviews in the STFC FAP export.

## Motivation and Context
This change is required to handle cases where an STFC FAP export contains reviews that are blank. 

## Changes
- Updated the `populateStfcRow` function in the `StfcFapDataRow.ts` file. Now it first checks if a review comment exists before attempting to strip HTML from it. This prevents errors when a review comment is blank.

## How Has This Been Tested?




- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated