### PR TITLE
fix: fixing tests and inputs after validation upgrade

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -15,7 +15,7 @@
         "@user-office-software/duo-localisation": "^1.2.0",
         "@user-office-software/duo-logger": "^2.1.1",
         "@user-office-software/duo-message-broker": "^1.6.0",
-        "@user-office-software/duo-validation": "^4.0.4",
+        "@user-office-software/duo-validation": "^5.0.0",
         "@user-office-software/openid": "^1.4.0",
         "await-to-js": "^2.1.1",
         "bcryptjs": "^2.4.3",
@@ -3076,9 +3076,9 @@
       }
     },
     "node_modules/@user-office-software/duo-validation": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-4.0.4.tgz",
-      "integrity": "sha512-e42tI8eu+pZTqImraLYG73pqQtmQWDd0oMkogmoZppm2Bx8if/aZkeeLcT/imggL0QUbmYV7FOb7HWIQ/8t1dQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.1.tgz",
+      "integrity": "sha512-o9fB332zV+MJzzPQJsUPDyolo/ygR77SjAyLaEItnws5ze7+EiH9Mqwec7t2pnXFEajHlg7VrAUoK0bsXxLd6A==",
       "dependencies": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -15,7 +15,7 @@
         "@user-office-software/duo-localisation": "^1.2.0",
         "@user-office-software/duo-logger": "^2.1.1",
         "@user-office-software/duo-message-broker": "^1.6.0",
-        "@user-office-software/duo-validation": "^5.0.0",
+        "@user-office-software/duo-validation": "5.0.0",
         "@user-office-software/openid": "^1.4.0",
         "await-to-js": "^2.1.1",
         "bcryptjs": "^2.4.3",
@@ -3076,9 +3076,9 @@
       }
     },
     "node_modules/@user-office-software/duo-validation": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.1.tgz",
-      "integrity": "sha512-o9fB332zV+MJzzPQJsUPDyolo/ygR77SjAyLaEItnws5ze7+EiH9Mqwec7t2pnXFEajHlg7VrAUoK0bsXxLd6A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.0.tgz",
+      "integrity": "sha512-RPnoP0Qm9KneC+CusxexOyPPw8ERUGAm6gSrXYMAnUNeUu/IfnJzK4cNpF8CiLAylPcB3ihpjv/dsi6xECoykw==",
       "dependencies": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -39,7 +39,7 @@
     "@user-office-software/duo-localisation": "^1.2.0",
     "@user-office-software/duo-logger": "^2.1.1",
     "@user-office-software/duo-message-broker": "^1.6.0",
-    "@user-office-software/duo-validation": "^4.0.4",
+    "@user-office-software/duo-validation": "^5.0.0",
     "@user-office-software/openid": "^1.4.0",
     "await-to-js": "^2.1.1",
     "bcryptjs": "^2.4.3",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -39,7 +39,7 @@
     "@user-office-software/duo-localisation": "^1.2.0",
     "@user-office-software/duo-logger": "^2.1.1",
     "@user-office-software/duo-message-broker": "^1.6.0",
-    "@user-office-software/duo-validation": "^5.0.0",
+    "@user-office-software/duo-validation": "5.0.0",
     "@user-office-software/openid": "^1.4.0",
     "await-to-js": "^2.1.1",
     "bcryptjs": "^2.4.3",

--- a/apps/backend/src/resolvers/mutations/AdministrationProposalMutation.ts
+++ b/apps/backend/src/resolvers/mutations/AdministrationProposalMutation.ts
@@ -33,11 +33,8 @@ export class AdministrationProposalArgs {
   @Field(() => String, { nullable: true })
   public commentForManagement?: string;
 
-  @Field(() => ProposalEndStatus, { nullable: true })
-  public finalStatus?: ProposalEndStatus;
-
-  @Field(() => Int, { nullable: true })
-  public statusId?: number;
+  @Field(() => ProposalEndStatus)
+  public finalStatus: ProposalEndStatus;
 
   @Field(() => [ManagementTimeAllocationsInput])
   public managementTimeAllocations: ManagementTimeAllocationsInput[];

--- a/apps/e2e/cypress/e2e/experiments.cy.ts
+++ b/apps/e2e/cypress/e2e/experiments.cy.ts
@@ -1,4 +1,7 @@
-import { FeatureId } from '@user-office-software-libs/shared-types';
+import {
+  FeatureId,
+  ProposalEndStatus,
+} from '@user-office-software-libs/shared-types';
 
 import featureFlags from '../support/featureFlags';
 import initialDBData from '../support/initialDBData';
@@ -17,7 +20,7 @@ context('Experiments tests', () => {
 
     cy.updateProposalManagementDecision({
       proposalPk: initialDBData.proposal.id,
-      statusId: 1,
+      finalStatus: ProposalEndStatus.ACCEPTED,
       managementTimeAllocations: [
         { instrumentId: initialDBData.instrument1.id, value: 5 },
       ],

--- a/apps/e2e/cypress/e2e/proposalEsi.cy.ts
+++ b/apps/e2e/cypress/e2e/proposalEsi.cy.ts
@@ -1,5 +1,8 @@
 import { faker } from '@faker-js/faker';
-import { FeatureId } from '@user-office-software-libs/shared-types';
+import {
+  FeatureId,
+  ProposalEndStatus,
+} from '@user-office-software-libs/shared-types';
 
 import featureFlags from '../support/featureFlags';
 import initialDBData from '../support/initialDBData';
@@ -8,7 +11,7 @@ const coProposer = initialDBData.users.user2;
 const visitor = initialDBData.users.user3;
 const PI = initialDBData.users.user1;
 const existingProposalId = initialDBData.proposal.id;
-const acceptedStatusId = 1;
+const acceptedStatus = ProposalEndStatus.ACCEPTED;
 const existingScheduledEventId = initialDBData.scheduledEvents.upcoming.id;
 
 const proposalEsiIconCyTag = 'finish-safety-input-form-icon';
@@ -40,7 +43,7 @@ context('visits tests', () => {
     });
     cy.updateProposalManagementDecision({
       proposalPk: existingProposalId,
-      statusId: acceptedStatusId,
+      finalStatus: acceptedStatus,
       managementTimeAllocations: [
         { instrumentId: initialDBData.instrument1.id, value: 5 },
       ],

--- a/apps/e2e/cypress/e2e/shipments.cy.ts
+++ b/apps/e2e/cypress/e2e/shipments.cy.ts
@@ -1,5 +1,8 @@
 import { faker } from '@faker-js/faker';
-import { FeatureId } from '@user-office-software-libs/shared-types';
+import {
+  FeatureId,
+  ProposalEndStatus,
+} from '@user-office-software-libs/shared-types';
 
 import featureFlags from '../support/featureFlags';
 import initialDBData from '../support/initialDBData';
@@ -28,6 +31,7 @@ context('Shipments tests', () => {
     });
     cy.updateProposalManagementDecision({
       proposalPk: existingProposal.id,
+      finalStatus: ProposalEndStatus.ACCEPTED,
       managementDecisionSubmitted: true,
       managementTimeAllocations: [
         { instrumentId: initialDBData.instrument1.id, value: 5 },

--- a/apps/e2e/cypress/e2e/visits.cy.ts
+++ b/apps/e2e/cypress/e2e/visits.cy.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import {
   FeatureId,
+  ProposalEndStatus,
   TemplateGroupId,
 } from '@user-office-software-libs/shared-types';
 import { DateTime } from 'luxon';
@@ -14,7 +15,7 @@ context('visits tests', () => {
   const coProposer = initialDBData.users.user2;
   const visitor = initialDBData.users.user3;
   const PI = initialDBData.users.user1;
-  const acceptedStatusId = 1;
+  const acceptedStatus = ProposalEndStatus.ACCEPTED;
   const existingProposalId = initialDBData.proposal.id;
   const existingScheduledEventId = initialDBData.scheduledEvents.upcoming.id;
 
@@ -35,7 +36,7 @@ context('visits tests', () => {
     });
     cy.updateProposalManagementDecision({
       proposalPk: existingProposalId,
-      statusId: acceptedStatusId,
+      finalStatus: acceptedStatus,
       managementTimeAllocations: [
         { instrumentId: initialDBData.instrument1.id, value: 5 },
       ],

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "@types/yup": "^0.29.13",
         "@uiw/react-codemirror": "^4.21.7",
         "@user-office-software/duo-localisation": "^1.2.0",
-        "@user-office-software/duo-validation": "^4.0.4",
+        "@user-office-software/duo-validation": "^5.0.0",
         "clsx": "^1.1.1",
         "formik": "^2.2.9",
         "formik-mui": "^4.0.0-alpha.3",
@@ -5061,9 +5061,9 @@
       "integrity": "sha512-9axYsEtg5rr7FDibUTIaGxd1+sRpvreytLuhEQBZdzA+MXL5TxZcDGAqSQarrTklHP4mcJTWvDzyMV/yCKmYOw=="
     },
     "node_modules/@user-office-software/duo-validation": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-4.0.4.tgz",
-      "integrity": "sha512-e42tI8eu+pZTqImraLYG73pqQtmQWDd0oMkogmoZppm2Bx8if/aZkeeLcT/imggL0QUbmYV7FOb7HWIQ/8t1dQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.1.tgz",
+      "integrity": "sha512-o9fB332zV+MJzzPQJsUPDyolo/ygR77SjAyLaEItnws5ze7+EiH9Mqwec7t2pnXFEajHlg7VrAUoK0bsXxLd6A==",
       "dependencies": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",
@@ -16757,9 +16757,9 @@
       "integrity": "sha512-9axYsEtg5rr7FDibUTIaGxd1+sRpvreytLuhEQBZdzA+MXL5TxZcDGAqSQarrTklHP4mcJTWvDzyMV/yCKmYOw=="
     },
     "@user-office-software/duo-validation": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-4.0.4.tgz",
-      "integrity": "sha512-e42tI8eu+pZTqImraLYG73pqQtmQWDd0oMkogmoZppm2Bx8if/aZkeeLcT/imggL0QUbmYV7FOb7HWIQ/8t1dQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.1.tgz",
+      "integrity": "sha512-o9fB332zV+MJzzPQJsUPDyolo/ygR77SjAyLaEItnws5ze7+EiH9Mqwec7t2pnXFEajHlg7VrAUoK0bsXxLd6A==",
       "requires": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "@types/yup": "^0.29.13",
         "@uiw/react-codemirror": "^4.21.7",
         "@user-office-software/duo-localisation": "^1.2.0",
-        "@user-office-software/duo-validation": "^5.0.0",
+        "@user-office-software/duo-validation": "5.0.0",
         "clsx": "^1.1.1",
         "formik": "^2.2.9",
         "formik-mui": "^4.0.0-alpha.3",
@@ -5061,9 +5061,9 @@
       "integrity": "sha512-9axYsEtg5rr7FDibUTIaGxd1+sRpvreytLuhEQBZdzA+MXL5TxZcDGAqSQarrTklHP4mcJTWvDzyMV/yCKmYOw=="
     },
     "node_modules/@user-office-software/duo-validation": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.1.tgz",
-      "integrity": "sha512-o9fB332zV+MJzzPQJsUPDyolo/ygR77SjAyLaEItnws5ze7+EiH9Mqwec7t2pnXFEajHlg7VrAUoK0bsXxLd6A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.0.tgz",
+      "integrity": "sha512-RPnoP0Qm9KneC+CusxexOyPPw8ERUGAm6gSrXYMAnUNeUu/IfnJzK4cNpF8CiLAylPcB3ihpjv/dsi6xECoykw==",
       "dependencies": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",
@@ -16757,9 +16757,9 @@
       "integrity": "sha512-9axYsEtg5rr7FDibUTIaGxd1+sRpvreytLuhEQBZdzA+MXL5TxZcDGAqSQarrTklHP4mcJTWvDzyMV/yCKmYOw=="
     },
     "@user-office-software/duo-validation": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.1.tgz",
-      "integrity": "sha512-o9fB332zV+MJzzPQJsUPDyolo/ygR77SjAyLaEItnws5ze7+EiH9Mqwec7t2pnXFEajHlg7VrAUoK0bsXxLd6A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.0.0.tgz",
+      "integrity": "sha512-RPnoP0Qm9KneC+CusxexOyPPw8ERUGAm6gSrXYMAnUNeUu/IfnJzK4cNpF8CiLAylPcB3ihpjv/dsi6xECoykw==",
       "requires": {
         "luxon": "^2.5.0",
         "sanitize-html": "^2.7.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -34,7 +34,7 @@
     "@types/yup": "^0.29.13",
     "@uiw/react-codemirror": "^4.21.7",
     "@user-office-software/duo-localisation": "^1.2.0",
-    "@user-office-software/duo-validation": "^5.0.0",
+    "@user-office-software/duo-validation": "5.0.0",
     "clsx": "^1.1.1",
     "formik": "^2.2.9",
     "formik-mui": "^4.0.0-alpha.3",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -34,7 +34,7 @@
     "@types/yup": "^0.29.13",
     "@uiw/react-codemirror": "^4.21.7",
     "@user-office-software/duo-localisation": "^1.2.0",
-    "@user-office-software/duo-validation": "^4.0.4",
+    "@user-office-software/duo-validation": "^5.0.0",
     "clsx": "^1.1.1",
     "formik": "^2.2.9",
     "formik-mui": "^4.0.0-alpha.3",

--- a/apps/frontend/src/graphql/proposal/administrationProposal.graphql
+++ b/apps/frontend/src/graphql/proposal/administrationProposal.graphql
@@ -1,7 +1,6 @@
 mutation administrationProposal(
   $proposalPk: Int!
-  $finalStatus: ProposalEndStatus
-  $statusId: Int
+  $finalStatus: ProposalEndStatus!
   $commentForUser: String
   $commentForManagement: String
   $managementTimeAllocations: [ManagementTimeAllocationsInput!]!
@@ -10,7 +9,6 @@ mutation administrationProposal(
   administrationProposal(
     proposalPk: $proposalPk
     finalStatus: $finalStatus
-    statusId: $statusId
     commentForUser: $commentForUser
     commentForManagement: $commentForManagement
     managementTimeAllocations: $managementTimeAllocations


### PR DESCRIPTION
## Description
This PR upgrades the duo-validation package version and adjusts the related backend and frontend code accordingly.

## Motivation and Context
The change was necessary due to the upgrade of the duo-validation package from version 4.0.4 to 5.0.0. This upgrade introduced breaking changes that required adjustments in the backend and frontend code. The upgrade enhances the validation mechanisms, improving the overall quality and reliability of the application.

## Changes
1. Upgraded duo-validation in both package.json and package-lock.json files from version 4.0.4 to 5.0.0.
2. Removed statusId field from AdministrationProposalArgs class and replaced it with finalStatus field of type ProposalEndStatus.
3. Adjusted the tests and inputs in various files to comply with the changes introduced by the duo-validation upgrade. The affected files include experiments.cy.ts, proposalEsi.cy.ts, shipments.cy.ts, and visits.cy.ts.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated