### PR TITLE
fix: cascade proposal deletion to fap proposals table

### DIFF
--- a/apps/backend/db_patches/0153_AlterFapProposals.sql
+++ b/apps/backend/db_patches/0153_AlterFapProposals.sql
@@ -1,0 +1,13 @@
+DO
+$$
+BEGIN
+    IF register_patch('0153_AlterFapProposals.sql','Farai Mutambara', 'Implementing deleting proposal on fap_proposals', '2024-04-10') THEN
+
+      ALTER TABLE fap_proposals
+        DROP CONSTRAINT IF EXISTS fap_proposals_proposal_pk_fkey,
+        ADD CONSTRAINT fap_proposals_proposal_pk_fkey FOREIGN KEY (proposal_pk) REFERENCES proposals(proposal_pk) ON DELETE CASCADE;
+
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
This fix the issue where we are failing to delete proposals which are in draft . 

<!--- Describe your changes in detail -->

## Motivation and Context
We are now using the instrument picker which automatically populate the `fap_proposals` table and we need to cascade deletion to the mentioned table .
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Manual
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
 https://github.com/UserOfficeProject/issue-tracker/issues/1056
<!--- Does this fix a user story, if so add a reference here -->

## Changes
Added files:
1. 0153_AlterFapProposals.sql
<!--- What types of changes does your code introduce? In what place? -->


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
