### PR TITLE
fix: genericTemplate deletion error

### DIFF
--- a/apps/frontend/src/components/proposal/ProposalContainer.tsx
+++ b/apps/frontend/src/components/proposal/ProposalContainer.tsx
@@ -72,7 +72,10 @@ export default function ProposalContainer(props: ProposalContainerProps) {
       case GENERIC_TEMPLATE_EVENT.ITEMS_MODIFIED:
         if (action.newItems) {
           if (state.proposal.genericTemplates) {
-            const questionIds = action.newItems.map((value) => value.id);
+            const modifiedTemplates = action.newItems.filter(
+              (value) => !state.deletedTemplates.includes(value.id)
+            );
+            const questionIds = modifiedTemplates.map((value) => value.id);
             draftState.proposal.genericTemplates = [
               ...state.proposal.genericTemplates.filter(
                 (value) =>
@@ -81,17 +84,17 @@ export default function ProposalContainer(props: ProposalContainerProps) {
                       id === value.id || state.deletedTemplates.includes(id)
                   )
               ),
-              ...action.newItems,
+              ...modifiedTemplates,
             ];
             //if new templates have been created add them to the list of created templates
             if (
-              action.newItems.length > state.proposal.genericTemplates.length
+              modifiedTemplates.length > state.proposal.genericTemplates.length
             ) {
               draftState.createdTemplates = [
                 ...state.createdTemplates,
                 ...questionIds.slice(
                   -(
-                    action.newItems.length -
+                    modifiedTemplates.length -
                     state.proposal.genericTemplates.length
                   )
                 ),

--- a/apps/frontend/src/models/questionary/useEventHandlers.ts
+++ b/apps/frontend/src/models/questionary/useEventHandlers.ts
@@ -63,6 +63,7 @@ export default function useEventHandlers(templateGroupId: TemplateGroupId) {
           if (state.isDirty) {
             if (confirmNavigation()) {
               await handleReset();
+              dispatch({ type: 'CLEAR_DELETE_LIST' });
               dispatch({ type: 'GO_STEP_BACK' });
             } else {
               // do nothing


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Fixes https://github.com/UserOfficeProject/issue-tracker/issues/906

## Motivation and Context

After deleting an answer/template from a subtemplate question, the state of deleted templates is not getting updated correctly for some scenarios. Because of which we get an error 'Can not delete genericTemplate because of insufficient permissions' when we try to submit the form after adding another answer or going to previous page and coming back. 
Another issue was that, if we have 2 subtemplate questions, after an answer deletion from any of the subtemplate, when we try to add another answer to one of the sub templates, then whole data from second sub template disappears. 

## How Has This Been Tested

Manually

## Changes

Update to not consider deletedtemplates again while reinitializing the form.
apps/frontend/src/components/proposal/ProposalContainer.tsx

Clearing the list of unsaved deletedtemplates while going back to previous page.
apps/frontend/src/models/questionary/useEventHandlers.ts

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
