### PR TITLE
Display PI name and country in meeting component fap instrument proposal table

### DIFF
--- a/apps/backend/src/datasources/mockups/UserDataSource.ts
+++ b/apps/backend/src/datasources/mockups/UserDataSource.ts
@@ -23,7 +23,8 @@ export const basicDummyUser = new BasicUserDetails(
   'boss',
   new Date('2019-07-17 08:25:12.23043+00'),
   false,
-  'test@email.com'
+  'test@email.com',
+  ''
 );
 
 export const basicDummyUserNotOnProposal = new BasicUserDetails(
@@ -36,7 +37,8 @@ export const basicDummyUserNotOnProposal = new BasicUserDetails(
   'boss',
   new Date('2019-07-17 08:25:12.23043+00'),
   false,
-  'test@email.com'
+  'test@email.com',
+  ''
 );
 
 export const dummyUserOfficer = new User(
@@ -246,7 +248,8 @@ export class UserDataSourceMock implements UserDataSource {
       'Manager',
       new Date('2019-07-17 08:25:12.23043+00'),
       false,
-      'test@email.com'
+      'test@email.com',
+      ''
     );
   }
 

--- a/apps/backend/src/datasources/postgres/AdminDataSource.ts
+++ b/apps/backend/src/datasources/postgres/AdminDataSource.ts
@@ -272,7 +272,7 @@ export default class PostgresAdminDataSource implements AdminDataSource {
       .from('users as u')
       .join('institutions as i', { 'u.institution_id': 'i.institution_id' })
       .where('u.institution_id', id)
-      .then((users: Array<UserRecord & InstitutionRecord>) =>
+      .then((users: Array<UserRecord & InstitutionRecord & CountryRecord>) =>
         users.map((user) => createBasicUserObject(user))
       );
   }

--- a/apps/backend/src/datasources/postgres/FapDataSource.ts
+++ b/apps/backend/src/datasources/postgres/FapDataSource.ts
@@ -49,6 +49,7 @@ import {
   createBasicUserObject,
   FapSecretariesRecord,
   InstitutionRecord,
+  CountryRecord,
 } from './records';
 
 @injectable()
@@ -315,7 +316,10 @@ export default class PostgresFapDataSource implements FapDataSource {
     proposalPk: number,
     callId: number
   ): Promise<BasicUserDetails[]> {
-    const fapProposalReviewers: Array<UserRecord & InstitutionRecord> =
+    const fapProposalReviewers: Array<
+      // eslint-disable-next-line prettier/prettier
+      UserRecord & InstitutionRecord & CountryRecord > =
+      // eslint-disable-next-line prettier/prettier
       await database
         .select(['users.*', 'institutions.*']) // Adjusted here
         .from('fap_reviews as sr')

--- a/apps/backend/src/datasources/postgres/InstrumentDataSource.ts
+++ b/apps/backend/src/datasources/postgres/InstrumentDataSource.ts
@@ -23,6 +23,7 @@ import {
   InstrumentWithManagementTimeRecord,
   InstitutionRecord,
   FapProposalRecord,
+  CountryRecord,
 } from './records';
 
 @injectable()
@@ -537,11 +538,15 @@ export default class PostgresInstrumentDataSource
       })
       .join('institutions as i', { 'u.institution_id': 'i.institution_id' })
       .where('ihs.instrument_id', instrumentId)
-      .then((usersRecord: Array<UserRecord & InstitutionRecord>) => {
-        const users = usersRecord.map((user) => createBasicUserObject(user));
+      .then(
+        (
+          usersRecord: Array<UserRecord & InstitutionRecord & CountryRecord>
+        ) => {
+          const users = usersRecord.map((user) => createBasicUserObject(user));
 
-        return users;
-      });
+          return users;
+        }
+      );
   }
 
   async setAvailabilityTimeOnInstrument(

--- a/apps/backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/backend/src/datasources/postgres/UserDataSource.ts
@@ -237,7 +237,7 @@ export default class PostgresUserDataSource implements UserDataSource {
       .join('institutions as i', { 'u.institution_id': 'i.institution_id' })
       .where('user_id', id)
       .first()
-      .then((user: UserRecord & InstitutionRecord) =>
+      .then((user: UserRecord & InstitutionRecord & CountryRecord) =>
         createBasicUserObject(user)
       );
   }
@@ -259,7 +259,7 @@ export default class PostgresUserDataSource implements UserDataSource {
         }
       })
       .first()
-      .then((user: UserRecord & InstitutionRecord) =>
+      .then((user: UserRecord & InstitutionRecord & CountryRecord) =>
         !!user ? createBasicUserObject(user) : null
       );
   }
@@ -456,14 +456,18 @@ export default class PostgresUserDataSource implements UserDataSource {
           query.orderBy(orderBy, orderDirection);
         }
       })
-      .then((usersRecord: Array<UserRecord & InstitutionRecord>) => {
-        const users = usersRecord.map((user) => createBasicUserObject(user));
+      .then(
+        (
+          usersRecord: Array<UserRecord & InstitutionRecord & CountryRecord>
+        ) => {
+          const users = usersRecord.map((user) => createBasicUserObject(user));
 
-        return {
-          totalCount: usersRecord[0] ? usersRecord[0].full_count : 0,
-          users,
-        };
-      });
+          return {
+            totalCount: usersRecord[0] ? usersRecord[0].full_count : 0,
+            users,
+          };
+        }
+      );
   }
 
   async getPreviousCollaborators(
@@ -515,14 +519,18 @@ export default class PostgresUserDataSource implements UserDataSource {
           query.whereNotIn('users.user_id', subtractUsers);
         }
       })
-      .then((usersRecord: Array<UserRecord & InstitutionRecord>) => {
-        const users = usersRecord.map((user) => createBasicUserObject(user));
+      .then(
+        (
+          usersRecord: Array<UserRecord & InstitutionRecord & CountryRecord>
+        ) => {
+          const users = usersRecord.map((user) => createBasicUserObject(user));
 
-        return {
-          totalCount: usersRecord[0] ? usersRecord[0].full_count : 0,
-          users,
-        };
-      });
+          return {
+            totalCount: usersRecord[0] ? usersRecord[0].full_count : 0,
+            users,
+          };
+        }
+      );
   }
 
   async getMostRecentCollaborators(id: number): Promise<number[]> {
@@ -649,7 +657,7 @@ export default class PostgresUserDataSource implements UserDataSource {
       .join('proposal_user as pc', { 'u.user_id': 'pc.user_id' })
       .join('proposals as p', { 'p.proposal_pk': 'pc.proposal_pk' })
       .where('p.proposal_pk', id)
-      .then((users: Array<UserRecord & InstitutionRecord>) =>
+      .then((users: Array<UserRecord & InstitutionRecord & CountryRecord>) =>
         users.map((user) => createBasicUserObject(user))
       );
   }

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -933,7 +933,9 @@ export const createUserObject = (user: UserRecord) => {
   );
 };
 
-export const createBasicUserObject = (user: UserRecord & InstitutionRecord) => {
+export const createBasicUserObject = (
+  user: UserRecord & InstitutionRecord & CountryRecord
+) => {
   return new BasicUserDetails(
     user.user_id,
     user.firstname,
@@ -944,7 +946,8 @@ export const createBasicUserObject = (user: UserRecord & InstitutionRecord) => {
     user.position,
     user.created_at,
     user.placeholder,
-    user.email
+    user.email,
+    user.country
   );
 };
 

--- a/apps/backend/src/datasources/stfc/StfcInstrumentDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcInstrumentDataSource.ts
@@ -4,6 +4,7 @@ import { BasicUserDetails } from '../../models/User';
 import database from '../postgres/database';
 import PostgresInstrumentDataSource from '../postgres/InstrumentDataSource';
 import {
+  CountryRecord,
   InstitutionRecord,
   UserRecord,
   createBasicUserObject,
@@ -28,11 +29,15 @@ export default class StfcInstrumentDataSource extends PostgresInstrumentDataSour
       })
       .join('institutions as i', { 'u.institution_id': 'i.institution_id' })
       .where('ihs.instrument_id', instrumentId)
-      .then((usersRecord: Array<UserRecord & InstitutionRecord>) => {
-        const users = usersRecord.map((user) => createBasicUserObject(user));
+      .then(
+        (
+          usersRecord: Array<UserRecord & InstitutionRecord & CountryRecord>
+        ) => {
+          const users = usersRecord.map((user) => createBasicUserObject(user));
 
-        return users;
-      });
+          return users;
+        }
+      );
 
     const userNumbers = users.map((user) => user.id.toString());
     const stfcUsers = await stfcUserDataSource.getStfcBasicPeopleByUserNumbers(

--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -70,7 +70,8 @@ export function toEssBasicUserDetails(
     '',
     new Date(),
     false,
-    stfcUser.email ?? ''
+    stfcUser.email ?? '',
+    stfcUser.country ?? ''
   );
 }
 

--- a/apps/backend/src/models/User.ts
+++ b/apps/backend/src/models/User.ts
@@ -93,7 +93,8 @@ export class BasicUserDetails {
     public position: string,
     public created: Date,
     public placeholder: boolean,
-    public email: string
+    public email: string,
+    public country: string
   ) {}
 }
 

--- a/apps/backend/src/queries/UserQueries.ts
+++ b/apps/backend/src/queries/UserQueries.ts
@@ -66,7 +66,8 @@ export default class UserQueries {
         user.position,
         user.created,
         user.placeholder,
-        user.email
+        user.email,
+        user.country
       );
     } else {
       return null;
@@ -94,7 +95,8 @@ export default class UserQueries {
       user.position,
       user.created,
       user.placeholder,
-      user.email
+      user.email,
+      user.country
     );
   }
 

--- a/apps/backend/src/resolvers/types/BasicUserDetails.ts
+++ b/apps/backend/src/resolvers/types/BasicUserDetails.ts
@@ -41,6 +41,9 @@ export class BasicUserDetails implements Partial<BasicUserDetailsOrigin> {
 
   @Field(() => Date, { nullable: true })
   public created?: Date;
+
+  @Field()
+  public country: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/frontend/src/components/fap/MeetingComponents/FapInstrumentProposalsTable.tsx
+++ b/apps/frontend/src/components/fap/MeetingComponents/FapInstrumentProposalsTable.tsx
@@ -33,6 +33,7 @@ import {
   standardDeviation,
 } from 'utils/mathFunctions';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
+import { getFullUserName } from 'utils/user';
 
 import FapMeetingProposalViewModal from './ProposalViewModal/FapMeetingProposalViewModal';
 
@@ -119,6 +120,7 @@ const FapInstrumentProposalsTable = ({
     setInstrumentProposalsData,
     refreshInstrumentProposalsData,
   } = useFapProposalsByInstrument(fapInstrument.id, fapId, selectedCall?.id);
+
   const classes = useStyles();
   const theme = useTheme();
   const isFapReviewer = useCheckAccess([UserRole.FAP_REVIEWER]);
@@ -148,7 +150,13 @@ const FapInstrumentProposalsTable = ({
       title: 'ID',
       field: 'proposal.proposalId',
     },
-    { title: 'Status', field: 'proposal.status.name' },
+    {
+      title: 'Principal Investigator',
+      render: (rowData: FapProposal) => {
+        return getFullUserName(rowData.proposal.proposer);
+      },
+    },
+    { title: 'Country', field: 'proposal.proposer.country' },
     {
       title: 'Average score',
       field: 'proposalAverageScore',

--- a/apps/frontend/src/components/visit/CreateVisitRegistration.tsx
+++ b/apps/frontend/src/components/visit/CreateVisitRegistration.tsx
@@ -34,6 +34,7 @@ function createRegistrationStub(
       placeholder: false,
       position: '',
       email: '',
+      country: '',
     },
     questionary: {
       isCompleted: false,

--- a/apps/frontend/src/graphql/fap/getFapProposalsByInstrument.graphql
+++ b/apps/frontend/src/graphql/fap/getFapProposalsByInstrument.graphql
@@ -13,6 +13,12 @@ query fapProposalsByInstrument(
       primaryKey
       title
       proposalId
+      proposer {
+        id
+        firstname
+        lastname
+        country
+      }
       status {
         ...proposalStatus
       }

--- a/apps/frontend/src/graphql/user/fragment.basicUserInformation.graphql
+++ b/apps/frontend/src/graphql/user/fragment.basicUserInformation.graphql
@@ -9,4 +9,5 @@ fragment basicUserDetails on BasicUserDetails {
   created
   placeholder
   email
+  country
 }


### PR DESCRIPTION

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Adding PI name and country in the meeting component proposal table view as shown below

![image](https://github.com/UserOfficeProject/user-office-core/assets/128331644/b80a1a68-f0fb-4475-90f7-09178968a27f)

<!--- Describe your changes in detail -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
https://github.com/UserOfficeProject/issue-tracker/issues/1053
## Changes

<!--- What types of changes does your code introduce? In what place? -->

- apps/backend/src/datasources/mockups/UserDataSource.ts
- apps/backend/src/datasources/postgres/AdminDataSource.ts
- apps/backend/src/datasources/postgres/FapDataSource.ts
- apps/backend/src/datasources/postgres/InstrumentDataSource.ts
- apps/backend/src/datasources/postgres/UserDataSource.ts
- apps/backend/src/datasources/postgres/records.ts
- apps/backend/src/datasources/stfc/StfcInstrumentDataSource.ts
- apps/backend/src/datasources/stfc/StfcUserDataSource.ts
- apps/backend/src/models/User.ts
- apps/backend/src/queries/UserQueries.ts
- apps/backend/src/resolvers/types/BasicUserDetails.ts
- apps/frontend/src/components/fap/MeetingComponents/FapInstrumentProposalsTable.tsx
- apps/frontend/src/components/visit/CreateVisitRegistration.tsx
- apps/frontend/src/graphql/fap/getFapProposalsByInstrument.graphql
- apps/frontend/src/graphql/fap/getFapProposalsByInstrument.graphql
- apps/frontend/src/graphql/user/fragment.basicUserInformation.graphql

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
