### PR TITLE
fix: duplicate proposals in stfc instrument sci proposal page

### DIFF
--- a/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
@@ -24,6 +24,38 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
     first?: number,
     offset?: number
   ): Promise<{ totalCount: number; proposals: ProposalView[] }> {
+    const proposals = database
+      .select('proposal_pk')
+      .from('proposal_table_view')
+      .join(
+        'call_has_instruments',
+        'call_has_instruments.call_id',
+        '=',
+        'ptw.call_id'
+      )
+      .join(
+        'instruments',
+        'instruments.instrument_id',
+        '=',
+        'call_has_instruments.instrument_id'
+      )
+      .leftJoin(
+        'instrument_has_scientists',
+        'instrument_has_scientists.instrument_id',
+        '=',
+        'call_has_instruments.instrument_id'
+      )
+      .where(function () {
+        if (user.currentRole?.shortCode === Roles.INTERNAL_REVIEWER) {
+          this.whereRaw('? = ANY(internal_technical_reviewer_ids)', user.id);
+        } else {
+          this.where('instrument_has_scientists.user_id', user.id).orWhere(
+            'instruments.manager_user_id',
+            user.id
+          );
+        }
+      });
+
     const result = database
       .with(
         'ptw',
@@ -39,35 +71,7 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
       )
       .select(['*', database.raw('count(*) OVER() AS full_count')])
       .from('ptw')
-      .join(
-        'call_has_instruments',
-        'call_has_instruments.call_id',
-        '=',
-        'ptw.call_id'
-      )
-      .join(
-        'instruments',
-        'instruments.instrument_id',
-        '=',
-        'call_has_instruments.instrument_id'
-      )
-      .join(
-        'instrument_has_scientists',
-        'instrument_has_scientists.instrument_id',
-        '=',
-        'call_has_instruments.instrument_id'
-      )
-      .where(function () {
-        if (user.currentRole?.shortCode === Roles.INTERNAL_REVIEWER) {
-          this.whereRaw('? = ANY(internal_technical_reviewer_ids)', user.id);
-        } else {
-          this.where('instrument_has_scientists.user_id', user.id).orWhere(
-            'instruments.manager_user_id',
-            user.id
-          );
-        }
-      })
-      .distinct('proposal_pk')
+      .whereIn('proposal_pk', proposals)
       .orderBy('proposal_pk', 'desc')
       .modify((query) => {
         if (filter?.text) {


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1058

## Description
This PR addresses an issue of duplicate proposals appearing in the STFC Instrument Scientist Proposal page.

## Motivation and Context
This change is required to ensure that each proposal appears only once in the STFC Instrument Scientist Proposal page, thus eliminating confusion and improving user experience.

## Changes
update stfc instrument sci data source

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated