### PR TITLE
fix: add preview to the allowed paths in the traefik ruleset

### DIFF
--- a/apps/frontend/src/components/template/PdfTemplateDefaultData.tsx
+++ b/apps/frontend/src/components/template/PdfTemplateDefaultData.tsx
@@ -4,13 +4,13 @@ export const body = `<html lang="en">
 
   <!-- Bootstrap CSS -->
   <link
-    href="http://localhost:4501/static/css/bootstrap.min.css"
+    href="http://localhost:4500/static/css/bootstrap.min.css"
     rel="stylesheet"
     integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9"
     crossorigin="anonymous"
   />
 
-  <link href="http://localhost:4501/fonts/segoeui" rel="stylesheet">
+  <link href="http://localhost:4500/fonts/segoeui" rel="stylesheet">
 
   <style>
     body {
@@ -53,7 +53,7 @@ export const body = `<html lang="en">
       content: ' – ';
     }
   </style>
-  <script src="http://localhost:4501/static/js/paged.polyfill.min.js"></script>
+  <script src="http://localhost:4500/static/js/paged.polyfill.min.js"></script>
 </head>
 
 <body>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     labels:
       - 'traefik.enable=true'
       - 'traefik.http.services.backend.loadbalancer.server.port=4000'
-      - 'traefik.http.routers.backend.rule=(Host(`localhost`) && PathPrefix(`/api`, `/downloads`, `/files`, `/download`, `/uploads`, `/graphql`))'
+      - 'traefik.http.routers.backend.rule=(Host(`localhost`) && PathPrefix(`/api`, `/preview`, `/downloads`, `/files`, `/download`, `/uploads`, `/graphql`))'
     depends_on:
       - duo-development-authorization-server
       - db


### PR DESCRIPTION
## Description

Added /preview to the allowed paths in the traefik ruleset and fixed the pdf preview issue. Also changed port from 4501 to 4500 in the default pdf template, since the factory usually runs in 4500.

## Motivation and Context

Using docker-compose, the preview pdf was not working, bcoz the path /preview was not whitelisted in the traefik. 

## How Has This Been Tested

Manually

## Fixes

PDF Preview issue

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
