### PR TITLE
fix: update dependencyConfigDefault.ts to use autoupdate of db_pacthes

### DIFF
--- a/apps/backend/src/config/dependencyConfigDefault.ts
+++ b/apps/backend/src/config/dependencyConfigDefault.ts
@@ -6,7 +6,7 @@ import {
 
 import 'reflect-metadata';
 import { OAuthAuthorization } from '../auth/OAuthAuthorization';
-import PostgresAdminDataSource from '../datasources/postgres/AdminDataSource';
+import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
 import PostgresCallDataSource from '../datasources/postgres/CallDataSource';
 import PostgresEventLogsDataSource from '../datasources/postgres/EventLogsDataSource';
 import PostgresFapDataSource from '../datasources/postgres/FapDataSource';
@@ -51,7 +51,7 @@ async function skipEmailHandler(event: ApplicationEvent) {
   logger.logInfo('Skip email sending', { event });
 }
 
-mapClass(Tokens.AdminDataSource, PostgresAdminDataSource);
+mapClass(Tokens.AdminDataSource, PostgresAdminDataSourceWithAutoUpgrade);
 mapClass(Tokens.CallDataSource, PostgresCallDataSource);
 mapClass(Tokens.EventLogsDataSource, PostgresEventLogsDataSource);
 mapClass(Tokens.FeedbackDataSource, PostgresFeedbackDataSource);


### PR DESCRIPTION
## Description
This PR updates the `dependencyConfigDefault.ts` to use auto-upgrade of database patches.

## Motivation and Context
The change is required to automate the database patching process. It simplifies the patch management by automatically applying the necessary updates.

## Changes
- Replaced `PostgresAdminDataSource` with `PostgresAdminDataSourceWithAutoUpgrade` in `dependencyConfigDefault.ts`.
- Updated the token mapping for `AdminDataSource` to use `PostgresAdminDataSourceWithAutoUpgrade`.

These changes ensure that the system uses the version of `AdminDataSource` that supports automatic database patch upgrades, reducing manual intervention and potential errors.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated