### PR TITLE
fix: database patch fix to cleanup old fap_assignments and fap_reviews that are not related to any fap_proposal

### DIFF
--- a/apps/backend/db_patches/0151_MultipleFapPerProposal.sql
+++ b/apps/backend/db_patches/0151_MultipleFapPerProposal.sql
@@ -19,12 +19,14 @@ BEGIN
 			ADD COLUMN fap_proposal_id INT REFERENCES fap_proposals (fap_proposal_id) ON UPDATE CASCADE ON DELETE CASCADE;
 			UPDATE fap_assignments
 			SET fap_proposal_id = (SELECT fap_proposal_id FROM fap_proposals WHERE fap_proposals.proposal_pk = fap_assignments.proposal_pk AND fap_proposals.fap_id = fap_assignments.fap_id);
+			DELETE FROM fap_assignments WHERE fap_proposal_id is null;
 			ALTER TABLE fap_assignments ALTER COLUMN fap_proposal_id SET NOT NULL;
 
 			ALTER TABLE fap_reviews 
 			ADD COLUMN fap_proposal_id INT REFERENCES fap_proposals (fap_proposal_id) ON UPDATE CASCADE ON DELETE CASCADE;
 			UPDATE fap_reviews
 			SET fap_proposal_id = (SELECT fap_proposal_id FROM fap_proposals WHERE fap_proposals.proposal_pk = fap_reviews.proposal_pk AND fap_proposals.fap_id = fap_reviews.fap_id);
+			DELETE FROM fap_reviews WHERE fap_proposal_id is null;
 			ALTER TABLE fap_reviews ALTER COLUMN fap_proposal_id SET NOT NULL;
 	
 			-- drop view to allow recreating it


### PR DESCRIPTION
## Description
This PR introduces a database patch to clean up stale `fap_assignments` and `fap_reviews` that are not linked to any `fap_proposal`.

## Motivation and Context
This change is required to maintain data integrity and avoid orphan records in `fap_assignments` and `fap_reviews` tables, which can lead to confusion and potential errors in future data operations.

## Changes
1. The `fap_assignments` table is updated to set `fap_proposal_id` for existing records. Any records that do not have a corresponding `fap_proposal` are deleted.
2. The `fap_reviews` table is updated similarly, setting `fap_proposal_id` for existing records and deleting any records that do not have a corresponding `fap_proposal`.
3. The `fap_proposal_id` column in both tables is then set to NOT NULL to enforce data integrity moving forward.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated