### PR TITLE
fix: improve and fix the proposal table view for multi FAP proposals

### DIFF
--- a/apps/backend/db_patches/0151_MultipleFapPerProposal.sql
+++ b/apps/backend/db_patches/0151_MultipleFapPerProposal.sql
@@ -19,12 +19,14 @@ BEGIN
 			ADD COLUMN fap_proposal_id INT REFERENCES fap_proposals (fap_proposal_id) ON UPDATE CASCADE ON DELETE CASCADE;
 			UPDATE fap_assignments
 			SET fap_proposal_id = (SELECT fap_proposal_id FROM fap_proposals WHERE fap_proposals.proposal_pk = fap_assignments.proposal_pk AND fap_proposals.fap_id = fap_assignments.fap_id);
+			DELETE FROM fap_assignments WHERE fap_proposal_id is null;
 			ALTER TABLE fap_assignments ALTER COLUMN fap_proposal_id SET NOT NULL;
 
 			ALTER TABLE fap_reviews 
 			ADD COLUMN fap_proposal_id INT REFERENCES fap_proposals (fap_proposal_id) ON UPDATE CASCADE ON DELETE CASCADE;
 			UPDATE fap_reviews
 			SET fap_proposal_id = (SELECT fap_proposal_id FROM fap_proposals WHERE fap_proposals.proposal_pk = fap_reviews.proposal_pk AND fap_proposals.fap_id = fap_reviews.fap_id);
+			DELETE FROM fap_reviews WHERE fap_proposal_id is null;
 			ALTER TABLE fap_reviews ALTER COLUMN fap_proposal_id SET NOT NULL;
 	
 			-- drop view to allow recreating it

--- a/apps/backend/db_patches/0156_ImproveProposalTableViewForMultiFaps.sql
+++ b/apps/backend/db_patches/0156_ImproveProposalTableViewForMultiFaps.sql
@@ -1,0 +1,107 @@
+DO
+$$
+BEGIN
+	IF register_patch('0156_ImproveProposalTableViewForMultiFaps.sql', 'martintrajanovski', 'Improve proposal table view for multi FAP proposals', '2024-05-29') THEN
+	BEGIN	
+			-- drop view to allow recreating it
+    	DROP VIEW proposal_table_view;
+
+    	-- re-create newest view query with order by
+		  CREATE VIEW proposal_table_view AS
+			SELECT
+				p.proposal_pk,
+				p.title,
+				p.proposer_id AS principal_investigator,
+				p.status_id AS proposal_status_id,
+				ps.name AS proposal_status_name,
+				ps.description AS proposal_status_description,
+				p.proposal_id,
+				p.final_status,
+				p.notified,
+				p.questionary_id,
+				p.submitted,
+				t.technical_reviews,
+				ihp.instruments,
+				fp.faps,
+				fp.fap_instruments,
+				c.call_short_code,
+				c.allocation_time_unit,
+				c.call_id,
+				c.proposal_workflow_id
+			FROM proposals p
+			LEFT JOIN proposal_statuses ps ON ps.proposal_status_id = p.status_id
+			LEFT JOIN call c ON c.call_id = p.call_id
+			LEFT JOIN (
+				SELECT
+					fp_1.proposal_pk,
+					jsonb_agg(
+						jsonb_build_object(
+							'id', f.fap_id,
+							'code', f.code
+						) ORDER BY fp_1.fap_proposal_id ASC
+					) AS faps,
+					jsonb_agg(
+						jsonb_build_object(
+							'instrumentId', fp_1.instrument_id,
+							'fapId', f.fap_id
+						)
+					) AS fap_instruments
+				FROM fap_proposals fp_1
+				JOIN faps f ON f.fap_id = fp_1.fap_id
+				GROUP BY fp_1.proposal_pk
+			) fp ON fp.proposal_pk = p.proposal_pk
+			LEFT JOIN (
+				SELECT
+					t_1.proposal_pk,
+					jsonb_agg(
+						jsonb_build_object(
+							'id', t_1.technical_review_id,
+							'timeAllocation', t_1.time_allocation,
+							'technicalReviewAssignee', (
+								SELECT jsonb_build_object(
+									'id', u.user_id,
+									'firstname', u.firstname,
+									'lastname', u.lastname
+								)
+								FROM users u
+								WHERE u.user_id = t_1.technical_review_assignee_id
+							),
+							'status', t_1.status,
+							'submitted', t_1.submitted,
+							'internalReviewers', (
+								SELECT jsonb_agg(jsonb_build_object('id', ir.reviewer_id))
+								FROM internal_reviews ir
+								WHERE ir.technical_review_id = t_1.technical_review_id
+							)
+						) ORDER BY t_1.technical_review_id ASC
+					) AS technical_reviews
+				FROM technical_review t_1
+				GROUP BY t_1.proposal_pk
+			) t ON t.proposal_pk = p.proposal_pk
+			LEFT JOIN (
+				SELECT
+					ihp_1.proposal_pk,
+					jsonb_agg(
+						jsonb_build_object(
+							'id', ihp_1.instrument_id,
+							'name', i.name,
+							'managerUserId', i.manager_user_id,
+							'managementTimeAllocation', ihp_1.management_time_allocation,
+							'scientists', (
+								SELECT jsonb_agg(jsonb_build_object('id', ihs.user_id))
+								FROM instrument_has_scientists ihs
+								WHERE ihs.instrument_id = ihp_1.instrument_id
+							)
+						) ORDER BY ihp_1.instrument_has_proposals_id ASC
+					) AS instruments
+				FROM instrument_has_proposals ihp_1
+				JOIN instruments i ON i.instrument_id = ihp_1.instrument_id
+				GROUP BY ihp_1.proposal_pk
+			) ihp ON ihp.proposal_pk = p.proposal_pk
+			ORDER BY p.proposal_pk;
+
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
@@ -200,7 +200,7 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
             return {
               ...technicalReview,
               technicalReviewAssignee: {
-                id: technicalReview.id,
+                id: technicalReview.technicalReviewAssignee.id,
                 firstname: firstName,
                 lastname: lastName,
               },

--- a/apps/backend/src/resolvers/types/ProposalView.ts
+++ b/apps/backend/src/resolvers/types/ProposalView.ts
@@ -24,7 +24,7 @@ export class FapInstrument {
   @Field(() => Int, { nullable: true })
   fapId: number | null;
 
-  @Field(() => Int)
+  @Field(() => Int, { nullable: true })
   instrumentId: number;
 }
 
@@ -78,7 +78,7 @@ export class ProposalViewTechnicalReview {
   @Field(() => Int, { nullable: true })
   timeAllocation: number;
 
-  @Field(() => ProposalViewTechnicalReviewAssignee)
+  @Field(() => ProposalViewTechnicalReviewAssignee, { nullable: true })
   technicalReviewAssignee: ProposalViewTechnicalReviewAssignee;
 }
 

--- a/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -427,7 +427,7 @@ const ProposalTableInstrumentScientist = ({
     const isCurrentUserTechnicalReviewAssignee =
       isInstrumentScientist &&
       rowData.technicalReviews
-        ?.map((tr) => tr.technicalReviewAssignee.id)
+        ?.map((tr) => tr.technicalReviewAssignee?.id)
         .includes(user.id);
 
     const showView =


### PR DESCRIPTION
## Description
This PR improves and fixes the proposal table view for multi FAP proposals.

## Motivation and Context
The change is required to enhance the proposal table view for multi FAP proposals by providing a more efficient and structured way to display complex data related to different FAPs associated with each proposal. It also fixes the incorrect assignment of technical review assignee ID.

## Changes
1. A new database patch is introduced to improve the proposal table view for multi FAP proposals. This patch creates a new view with a better structure to handle proposals associated with multiple FAPs.

2. The StfcProposalDataSource file has been updated to correct the assignment of the technical review assignee ID.

3. The ProposalView file has been updated to make the fields `instrumentId` and `technicalReviewAssignee` nullable, providing flexibility and preventing potential errors when these fields are not available.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated