### PR TITLE
fix: only submitted proposals in fap

### DIFF
--- a/apps/backend/src/datasources/postgres/FapDataSource.ts
+++ b/apps/backend/src/datasources/postgres/FapDataSource.ts
@@ -471,7 +471,8 @@ export default class PostgresFapDataSource implements FapDataSource {
         'p.status_id': 'ps.proposal_status_id',
       })
       .where('sp.fap_id', fapId)
-      .andWhere('ihp.instrument_id', instrumentId);
+      .andWhere('ihp.instrument_id', instrumentId)
+      .andWhere('p.submitted', true);
 
     return fapProposals.map((fapProposal) =>
       createFapProposalObject(fapProposal)


### PR DESCRIPTION
Hotfix so only submitted proposals appear in FAP export

We had a support ticket in where proposals that were expired or in draft were showing up in the FAP data exports. This change makes it so only submitted proposals show up there. 
