### PR TITLE
fix: prevent workflow errors when proposal_deleted event is fired

### DIFF
--- a/apps/backend/src/workflowEngine/index.ts
+++ b/apps/backend/src/workflowEngine/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '@user-office-software/duo-logger';
 import { container } from 'tsyringe';
 
 import CallDataSource from '../datasources/postgres/CallDataSource';
@@ -200,6 +201,15 @@ export const markProposalsEventAsDoneAndCallWorkflowEngine = async (
   eventType: Event,
   proposalPks: number[]
 ) => {
+  if (eventType === Event.PROPOSAL_DELETED) {
+    logger.logInfo(
+      `${eventType} event triggered and workflow engine cannot continue because the referenced proposal/s are removed`,
+      { proposalPks }
+    );
+
+    return;
+  }
+
   const allProposalEvents = await proposalDataSource.markEventAsDoneOnProposals(
     eventType,
     proposalPks


### PR DESCRIPTION
## Description
This PR introduces a fix to prevent workflow errors when the `proposal_deleted` event is triggered.

## Motivation and Context
This change is necessary to handle the scenario when a proposal gets deleted. Previously, the deletion of a proposal was causing workflow errors. This PR aims to prevent those errors and maintain the integrity and smooth operation of the workflow engine.

## Changes
- Introduced a check for the `proposal_deleted` event in the workflow engine. If this event is triggered, the workflow engine will log an informative message and cease further operation. This prevents any errors that might occur due to the deletion of the proposal.
- Imported and used the logger from '@user-office-software/duo-logger' to log the information when the `proposal_deleted` event is triggered.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4056](https://jira.esss.lu.se/browse/SWAP-4056)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated