### PR TITLE
fix: prevent proposal administration without instrument assigned

### DIFF
--- a/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
+++ b/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
@@ -319,11 +319,15 @@ context('Proposal administration tests', () => {
       cy.get('[data-cy=view-proposal]').click();
       cy.finishedLoading();
 
-      cy.get('[role="dialog"]').contains('Admin').click();
+      cy.get('[role="dialog"]').find('[role="tab"]').contains('Logs').click();
 
       cy.reload();
 
-      cy.get('[data-cy="commentForUser"]').should('exist');
+      cy.get('button[role="tab"]')
+        .contains('Logs')
+        .should('have.attr', 'aria-selected', 'true');
+
+      cy.get('[data-cy="event-logs-table"]').should('exist');
 
       cy.get('[role="dialog"]').contains('Technical review').click();
 

--- a/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
+++ b/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
@@ -97,7 +97,7 @@ context('Proposal administration tests', () => {
       cy.visit('/');
     });
 
-    it.only('Should not be able to administer proposal if not assigned to instrument', function () {
+    it('Should not be able to administer proposal if not assigned to instrument', function () {
       if (!featureFlags.getEnabledFeatures().get(FeatureId.TECHNICAL_REVIEW)) {
         this.skip();
       }

--- a/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
+++ b/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
@@ -97,6 +97,19 @@ context('Proposal administration tests', () => {
       cy.visit('/');
     });
 
+    it.only('Should not be able to administer proposal if not assigned to instrument', function () {
+      if (!featureFlags.getEnabledFeatures().get(FeatureId.TECHNICAL_REVIEW)) {
+        this.skip();
+      }
+
+      cy.contains('Proposals').click();
+
+      cy.get('[data-cy=view-proposal]').click();
+      cy.finishedLoading();
+      cy.get('[role="dialog"]').contains('Admin').click();
+      cy.get('[data-cy="no-instrument-message"]').should('exist');
+    });
+
     it('Should be able to set comment for user/manager and final status', function () {
       if (!featureFlags.getEnabledFeatures().get(FeatureId.TECHNICAL_REVIEW)) {
         this.skip();

--- a/apps/frontend/src/components/proposal/ProposalAdmin.tsx
+++ b/apps/frontend/src/components/proposal/ProposalAdmin.tsx
@@ -88,6 +88,14 @@ const ProposalAdmin = ({ data, setAdministration }: ProposalAdminProps) => {
     setAdministration(administrationValues);
   };
 
+  if (!data.instruments?.length) {
+    return (
+      <div data-cy="no-instrument-message">
+        Proposal has to be assigned to an instrument for administration
+      </div>
+    );
+  }
+
   return (
     <>
       <Typography variant="h6" component="h2" gutterBottom>


### PR DESCRIPTION
## Description
This PR prevents the administration of a proposal without an assigned instrument.

## Motivation and Context
This change was necessary to ensure the proper functioning of the application and prevent users from making changes to proposals that are not yet assigned to an instrument.

## Changes
- Added a condition to check if an instrument is assigned to a proposal before allowing administration. 
- If no instrument is assigned, a message is displayed to inform the user that the proposal has to be assigned to an instrument before it can be administered. 
- Added an end-to-end test to validate this behavior.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4081](https://jira.esss.lu.se/browse/SWAP-4081)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated