### PR TITLE
fix: auto FAP assignment when instrument is assigned to multiple calls

### DIFF
--- a/apps/backend/src/mutations/FapMutations.ts
+++ b/apps/backend/src/mutations/FapMutations.ts
@@ -263,14 +263,18 @@ export default class FapMutations {
       );
 
     const callIds = [...new Set(proposals.map((proposal) => proposal.callId))];
-    const fapInstruments = callHasInstruments
-      .filter((callHasInstrument) => callHasInstrument.fapId)
-      .map((callHasInstrument) => ({
-        fapId: callHasInstrument.fapId,
-        instrumentId: callHasInstrument.instrumentId,
-      }));
 
     for (const callId of callIds) {
+      const fapInstruments = callHasInstruments
+        .filter(
+          (callHasInstrument) =>
+            callHasInstrument.fapId && callHasInstrument.callId === callId
+        )
+        .map((callHasInstrument) => ({
+          fapId: callHasInstrument.fapId,
+          instrumentId: callHasInstrument.instrumentId,
+        }));
+
       if (fapInstruments.length) {
         await this.assignProposalsToFapsInternal(agent, {
           proposalPks: proposals

--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -2868,4 +2868,52 @@ context('Automatic Fap assignment to Proposal', () => {
       }
     });
   });
+
+  it('Proposal should be automatically assigned to the right FAP, when multiple Instruments are assigned to a Proposal', () => {
+    cy.createInstrument(instrument2).then((result) => {
+      if (result.createInstrument) {
+        cy.assignInstrumentToCall({
+          callId: initialDBData.call.id,
+          instrumentFapIds: [
+            {
+              instrumentId: result.createInstrument.id,
+              fapId: createdFapId,
+            },
+          ],
+        });
+        cy.assignInstrumentToCall({
+          callId: createdCallId,
+          instrumentFapIds: [
+            {
+              instrumentId: firstAutoAssignmentInstrumentId,
+              fapId: createdFapId,
+            },
+          ],
+        });
+
+        cy.assignProposalsToInstruments({
+          proposalPks: [firstAutoAssignProposalPk],
+          instrumentIds: [
+            result.createInstrument.id,
+            firstAutoAssignmentInstrumentId,
+          ],
+        });
+
+        cy.login('officer');
+        cy.visit('/Proposals');
+
+        cy.contains('td', firstAutoAssignProposalId)
+          .closest('tr')
+          .find(`td:contains(${initialDBData.fap.code})`)
+          .invoke('text')
+          .then((text) => {
+            const firstFapCount = text.split(initialDBData.fap.code).length - 1;
+            const secondFapCount = text.split(fap1.code).length - 1;
+
+            expect(firstFapCount).to.eq(1);
+            expect(secondFapCount).to.eq(1);
+          });
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description
This PR aims to fix the issue of automatic FAP assignment when an instrument is assigned to multiple calls.

## Motivation and Context
This change is required to ensure the correct FAP is automatically assigned to a proposal when multiple instruments are assigned to a proposal. This is crucial for maintaining consistency and correctness in our data.

## Changes
- Modified the logic in `FapMutations.ts` to correctly filter and map FAP instruments based on the callId.
- Added a new test case in `FAPs.cy.ts` to verify that a proposal is automatically assigned to the correct FAP when multiple instruments are assigned to a proposal.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4098](https://jira.esss.lu.se/browse/SWAP-4098)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated