### PR TITLE
feat: mass submit completed meeting decisions

### DIFF
--- a/apps/backend/src/datasources/FapDataSource.ts
+++ b/apps/backend/src/datasources/FapDataSource.ts
@@ -152,4 +152,9 @@ export interface FapDataSource {
     reviewerId: number,
     rank: number
   ): Promise<boolean>;
+  submitFapMeetings(
+    callId: number,
+    fapId: number,
+    userId?: number
+  ): Promise<FapProposal[]>;
 }

--- a/apps/backend/src/datasources/mockups/FapDataSource.ts
+++ b/apps/backend/src/datasources/mockups/FapDataSource.ts
@@ -738,4 +738,12 @@ export class FapDataSourceMock implements FapDataSource {
   ): Promise<boolean> {
     throw new Error('Method not implemented.');
   }
+
+  submitFapMeetings(
+    callId: number,
+    fapId: number,
+    userId?: number | undefined
+  ): Promise<FapProposal[]> {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/apps/backend/src/datasources/postgres/FapDataSource.ts
+++ b/apps/backend/src/datasources/postgres/FapDataSource.ts
@@ -1275,4 +1275,55 @@ export default class PostgresFapDataSource implements FapDataSource {
         return true;
       });
   }
+
+  async submitFapMeetings(
+    callId: number,
+    fapId: number,
+    userId?: number
+  ): Promise<FapProposal[]> {
+    const allProposals: FapProposalRecord[] = await database
+      .select('*')
+      .from('fap_proposals')
+      .where('fap_id', fapId)
+      .andWhere('call_id', callId);
+
+    const proposals: FapMeetingDecisionRecord[] = await database
+      .select('fm.*')
+      .from('fap_meeting_decisions as fm')
+      .leftJoin('fap_proposals as fp', function () {
+        this.on('fm.proposal_pk', '=', 'fp.proposal_pk').andOn(
+          'fm.instrument_id',
+          '=',
+          'fp.instrument_id'
+        );
+      })
+      .where('fp.fap_id', fapId)
+      .andWhere('fp.call_id', callId);
+
+    const readyProposals = proposals.filter(
+      (proposal) =>
+        proposal.comment_for_management &&
+        proposal.comment_for_user &&
+        proposal.recommendation
+    );
+    readyProposals.map((proposal) => {
+      this.saveFapMeetingDecision(
+        { ...createFapMeetingDecisionObject(proposal), submitted: true },
+        userId
+      );
+    });
+
+    const incompleteProposals = allProposals.filter(
+      (proposal) =>
+        !readyProposals.find(
+          (readyProp) =>
+            readyProp.proposal_pk === proposal.proposal_pk &&
+            readyProp.instrument_id === proposal.instrument_id
+        )
+    );
+
+    return incompleteProposals.map((proposal) =>
+      createFapProposalObject(proposal)
+    );
+  }
 }

--- a/apps/backend/src/datasources/postgres/FapDataSource.ts
+++ b/apps/backend/src/datasources/postgres/FapDataSource.ts
@@ -1300,18 +1300,21 @@ export default class PostgresFapDataSource implements FapDataSource {
       .where('fp.fap_id', fapId)
       .andWhere('fp.call_id', callId);
 
-    const readyProposals = proposals.filter(
+    const readyProposals: FapMeetingDecisionRecord[] = proposals.filter(
       (proposal) =>
         proposal.comment_for_management &&
         proposal.comment_for_user &&
         proposal.recommendation
     );
-    readyProposals.map((proposal) => {
-      this.saveFapMeetingDecision(
-        { ...createFapMeetingDecisionObject(proposal), submitted: true },
-        userId
-      );
-    });
+
+    await Promise.all(
+      readyProposals.map((proposal) =>
+        this.saveFapMeetingDecision(
+          { ...createFapMeetingDecisionObject(proposal), submitted: true },
+          userId
+        )
+      )
+    );
 
     const incompleteProposals = allProposals.filter(
       (proposal) =>

--- a/apps/backend/src/mutations/FapMutations.ts
+++ b/apps/backend/src/mutations/FapMutations.ts
@@ -41,7 +41,10 @@ import {
   RemoveProposalsFromFapsArgs,
 } from '../resolvers/mutations/AssignProposalsToFapsMutation';
 import { CreateFapArgs } from '../resolvers/mutations/CreateFapMutation';
-import { SaveFapMeetingDecisionInput } from '../resolvers/mutations/FapMeetingDecisionMutation';
+import {
+  SaveFapMeetingDecisionInput,
+  SubmitFapMeetingDecisionsInput,
+} from '../resolvers/mutations/FapMeetingDecisionMutation';
 import { ReorderFapMeetingDecisionProposalsInput } from '../resolvers/mutations/ReorderFapMeetingDecisionProposalsMutation';
 import { SaveReviewerRankArg } from '../resolvers/mutations/SaveReviewerRankMutation';
 import { UpdateFapArgs } from '../resolvers/mutations/UpdateFapMutation';
@@ -768,5 +771,17 @@ export default class FapMutations {
     } catch (error) {
       return rejection('Something went wrong', { args, error });
     }
+  }
+
+  @Authorized([Roles.USER_OFFICER, Roles.FAP_CHAIR, Roles.FAP_SECRETARY])
+  async submitFapMeetings(
+    agent: UserWithRole | null,
+    args: SubmitFapMeetingDecisionsInput
+  ) {
+    return this.dataSource.submitFapMeetings(
+      args.callId,
+      args.fapId,
+      agent?.id
+    );
   }
 }

--- a/apps/backend/src/resolvers/mutations/FapMeetingDecisionMutation.ts
+++ b/apps/backend/src/resolvers/mutations/FapMeetingDecisionMutation.ts
@@ -11,6 +11,7 @@ import {
 import { ResolverContext } from '../../context';
 import { ProposalEndStatus } from '../../models/Proposal';
 import { FapMeetingDecision } from '../types/FapMeetingDecision';
+import { FapProposal } from '../types/FapProposal';
 
 @InputType()
 export class SaveFapMeetingDecisionInput {
@@ -39,6 +40,15 @@ export class SaveFapMeetingDecisionInput {
   public fapId: number;
 }
 
+@InputType()
+export class SubmitFapMeetingDecisionsInput {
+  @Field(() => Int)
+  public fapId: number;
+
+  @Field(() => Int)
+  public callId: number;
+}
+
 @Resolver()
 export class FapMeetingDecisionMutation {
   @Mutation(() => FapMeetingDecision)
@@ -50,6 +60,21 @@ export class FapMeetingDecisionMutation {
     return context.mutations.fap.saveFapMeetingDecision(
       context.user,
       saveFapMeetingDecisionInput
+    );
+  }
+}
+
+@Resolver()
+export class SubmitMeetingDecisionsMutation {
+  @Mutation(() => [FapProposal])
+  submitFapMeetingDecisions(
+    @Arg('SubmitFapMeetingDecisionsInput')
+    submitFapMeetingDecisionInput: SubmitFapMeetingDecisionsInput,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.mutations.fap.submitFapMeetings(
+      context.user,
+      submitFapMeetingDecisionInput
     );
   }
 }

--- a/apps/backend/src/resolvers/types/FapProposal.ts
+++ b/apps/backend/src/resolvers/types/FapProposal.ts
@@ -26,8 +26,8 @@ export class FapProposal {
   @Field(() => Int, { nullable: true })
   public fapTimeAllocation?: number | null;
 
-  @Field(() => Int, { nullable: true })
-  public instrumentId?: number | null;
+  @Field(() => Int)
+  public instrumentId: number | null;
 }
 
 @Resolver(() => FapProposal)

--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -2288,31 +2288,30 @@ context('Fap meeting components tests', () => {
 
       cy.finishedLoading();
 
-      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
-
-      cy.get('[aria-label="View proposal details"]').first().click();
-
-      cy.get('[role="dialog"] > header + div').scrollTo('top');
-
-      cy.setTinyMceContent('commentForUser', 'Test');
-      cy.setTinyMceContent('commentForManagement', 'Test');
-
-      cy.get('[data-cy="proposalFapMeetingRecommendation"]').click();
-      cy.get('[data-value="ACCEPTED"]').click();
-
-      cy.get('[data-cy="is-fap-meeting-submitted"]').click();
-      cy.get('[data-cy="saveAndContinue"]').click();
+      cy.saveFapMeetingDecision({
+        saveFapMeetingDecisionInput: {
+          commentForManagement: 'test',
+          commentForUser: 'test',
+          proposalPk: firstCreatedProposalPk,
+          submitted: true,
+          recommendation: ProposalEndStatus.ACCEPTED,
+          instrumentId: createdInstrumentId,
+          fapId: createdFapId,
+        },
+      });
 
       cy.finishedLoading();
 
       cy.get('[data-cy="submit-all-button"]').click();
 
-      cy.get('@proposal1Id').then((proposalId) => {
-        cy.get('[data-cy="proposal-' + proposalId + '"]');
-      });
+      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
+
+      cy.get('[data-cy="proposal-' + firstCreatedProposalId + '"]').should(
+        'not.exist'
+      );
 
       cy.get('@proposal2Id').then((proposalId) => {
-        cy.get('[data-cy="proposal-' + proposalId + '"]').should('not.exist');
+        cy.get('[data-cy="proposal-' + proposalId + '"]').should('exist');
       });
     });
 
@@ -2688,6 +2687,7 @@ context('Fap meeting components tests', () => {
     });
 
     it('Fap Chair should be able to submit multiple completed Meetings forms', function () {
+      cy.logout();
       cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
         const createdProposal = result.createProposal;
 
@@ -2783,36 +2783,34 @@ context('Fap meeting components tests', () => {
         }
       });
 
-      cy.login('officer');
+      cy.saveFapMeetingDecision({
+        saveFapMeetingDecisionInput: {
+          commentForManagement: 'test',
+          commentForUser: 'test',
+          proposalPk: firstCreatedProposalPk,
+          submitted: true,
+          recommendation: ProposalEndStatus.ACCEPTED,
+          instrumentId: createdInstrumentId,
+          fapId: createdFapId,
+        },
+      });
+
+      cy.login(fapMembers.chair);
+      cy.changeActiveRole(initialDBData.roles.fapChair);
       cy.visit(`/FapPage/${createdFapId}?tab=3`);
-
-      cy.finishedLoading();
-
-      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
-
-      cy.get('[aria-label="View proposal details"]').first().click();
-
-      cy.get('[role="dialog"] > header + div').scrollTo('top');
-
-      cy.setTinyMceContent('commentForUser', 'Test');
-      cy.setTinyMceContent('commentForManagement', 'Test');
-
-      cy.get('[data-cy="proposalFapMeetingRecommendation"]').click();
-      cy.get('[data-value="ACCEPTED"]').click();
-
-      cy.get('[data-cy="is-fap-meeting-submitted"]').click();
-      cy.get('[data-cy="saveAndContinue"]').click();
 
       cy.finishedLoading();
 
       cy.get('[data-cy="submit-all-button"]').click();
 
-      cy.get('@proposal1Id').then((proposalId) => {
-        cy.get('[data-cy="proposal-' + proposalId + '"]');
-      });
+      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
+
+      cy.get('[data-cy="proposal-' + firstCreatedProposalId + '"]').should(
+        'not.exist'
+      );
 
       cy.get('@proposal2Id').then((proposalId) => {
-        cy.get('[data-cy="proposal-' + proposalId + '"]').should('not.exist');
+        cy.get('[data-cy="proposal-' + proposalId + '"]').should('exist');
       });
     });
   });
@@ -2914,6 +2912,7 @@ context('Fap meeting components tests', () => {
     });
 
     it('Fap Secretary should be able to submit multiple completed Meetings forms', function () {
+      cy.logout();
       cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
         const createdProposal = result.createProposal;
 
@@ -3009,36 +3008,36 @@ context('Fap meeting components tests', () => {
         }
       });
 
-      cy.login('officer');
+      cy.saveFapMeetingDecision({
+        saveFapMeetingDecisionInput: {
+          commentForManagement: 'test',
+          commentForUser: 'test',
+          proposalPk: firstCreatedProposalPk,
+          submitted: true,
+          recommendation: ProposalEndStatus.ACCEPTED,
+          instrumentId: createdInstrumentId,
+          fapId: createdFapId,
+        },
+      });
+
+      cy.login(fapMembers.secretary);
+      cy.changeActiveRole(initialDBData.roles.fapSecretary);
       cy.visit(`/FapPage/${createdFapId}?tab=3`);
 
       cy.finishedLoading();
 
       cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
 
-      cy.get('[aria-label="View proposal details"]').first().click();
-
-      cy.get('[role="dialog"] > header + div').scrollTo('top');
-
-      cy.setTinyMceContent('commentForUser', 'Test');
-      cy.setTinyMceContent('commentForManagement', 'Test');
-
-      cy.get('[data-cy="proposalFapMeetingRecommendation"]').click();
-      cy.get('[data-value="ACCEPTED"]').click();
-
-      cy.get('[data-cy="is-fap-meeting-submitted"]').click();
-      cy.get('[data-cy="saveAndContinue"]').click();
-
-      cy.finishedLoading();
-
       cy.get('[data-cy="submit-all-button"]').click();
 
-      cy.get('@proposal1Id').then((proposalId) => {
-        cy.get('[data-cy="proposal-' + proposalId + '"]');
-      });
+      cy.contains('Some Proposals Could not be Submitted');
+
+      cy.get('[data-cy="proposal-' + firstCreatedProposalId + '"]').should(
+        'not.exist'
+      );
 
       cy.get('@proposal2Id').then((proposalId) => {
-        cy.get('[data-cy="proposal-' + proposalId + '"]').should('not.exist');
+        cy.get('[data-cy="proposal-' + proposalId + '"]').should('exist');
       });
     });
   });

--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -2304,6 +2304,8 @@ context('Fap meeting components tests', () => {
 
       cy.get('[data-cy="submit-all-button"]').click();
 
+      cy.contains('Some proposals could not be submitted');
+
       cy.get('[data-cy="proposal-' + firstCreatedProposalId + '"]').should(
         'not.exist'
       );
@@ -2801,6 +2803,8 @@ context('Fap meeting components tests', () => {
 
       cy.get('[data-cy="submit-all-button"]').click();
 
+      cy.contains('Some proposals could not be submitted');
+
       cy.get('[data-cy="proposal-' + firstCreatedProposalId + '"]').should(
         'not.exist'
       );
@@ -3024,7 +3028,7 @@ context('Fap meeting components tests', () => {
 
       cy.get('[data-cy="submit-all-button"]').click();
 
-      cy.contains('Some Proposals Could not be Submitted');
+      cy.contains('Some proposals could not be submitted');
 
       cy.get('[data-cy="proposal-' + firstCreatedProposalId + '"]').should(
         'not.exist'

--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -2201,6 +2201,10 @@ context('Fap meeting components tests', () => {
             proposerId: initialDBData.users.user1.id,
           });
 
+          cy.assignProposalsToInstruments({
+            instrumentIds: [createdInstrumentId],
+            proposalPks: [createdProposal.primaryKey],
+          });
           cy.addProposalTechnicalReview({
             proposalPk: createdProposal.primaryKey,
             status: TechnicalReviewStatus.FEASIBLE,
@@ -2208,11 +2212,6 @@ context('Fap meeting components tests', () => {
             submitted: true,
             reviewerId: 0,
             instrumentId: createdInstrumentId,
-          });
-
-          cy.assignProposalsToInstruments({
-            instrumentIds: [createdInstrumentId],
-            proposalPks: [createdProposal.primaryKey],
           });
 
           cy.assignProposalsToFaps({
@@ -2352,7 +2351,7 @@ context('Fap meeting components tests', () => {
       cy.get('[data-cy="fap-instrument-proposals-table"] tbody tr')
         .first()
         .find('td')
-        .eq(7)
+        .eq(8)
         .should('not.contain.text', '-')
         .should('contain.text', '1');
 
@@ -2687,6 +2686,135 @@ context('Fap meeting components tests', () => {
 
       cy.contains('Availability time updated successfully!');
     });
+
+    it('Fap Chair should be able to submit multiple completed Meetings forms', function () {
+      cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
+        const createdProposal = result.createProposal;
+
+        cy.wrap(createdProposal.proposalId).as('proposal2Id');
+
+        if (createdProposal) {
+          cy.updateProposal({
+            proposalPk: createdProposal.primaryKey,
+            title: proposal2.title,
+            abstract: proposal2.abstract,
+            proposerId: initialDBData.users.user1.id,
+          });
+
+          cy.assignProposalsToInstruments({
+            instrumentIds: [createdInstrumentId],
+            proposalPks: [createdProposal.primaryKey],
+          });
+          cy.addProposalTechnicalReview({
+            proposalPk: createdProposal.primaryKey,
+            status: TechnicalReviewStatus.FEASIBLE,
+            timeAllocation: 5,
+            submitted: true,
+            reviewerId: 0,
+            instrumentId: createdInstrumentId,
+          });
+
+          cy.assignProposalsToFaps({
+            fapInstruments: [
+              { instrumentId: createdInstrumentId, fapId: createdFapId },
+            ],
+            proposalPks: [createdProposal.primaryKey],
+          });
+
+          cy.assignReviewersToFap({
+            fapId: createdFapId,
+            memberIds: [fapMembers.reviewer2.id],
+          });
+          cy.assignFapReviewersToProposal({
+            fapId: createdFapId,
+            memberIds: [fapMembers.reviewer2.id],
+            proposalPk: firstCreatedProposalPk,
+          });
+          cy.assignFapReviewersToProposal({
+            fapId: createdFapId,
+            memberIds: [fapMembers.reviewer.id],
+            proposalPk: createdProposal.primaryKey,
+          });
+          cy.assignFapReviewersToProposal({
+            fapId: createdFapId,
+            memberIds: [fapMembers.reviewer2.id],
+            proposalPk: createdProposal.primaryKey,
+          });
+
+          // Manually changing the proposal status to be shown in the Faps. -------->
+          cy.changeProposalsStatus({
+            statusId: initialDBData.proposalStatuses.fapReview.id,
+            proposalPks: [createdProposal.primaryKey],
+          });
+
+          cy.getProposalReviews({
+            proposalPk: firstCreatedProposalPk,
+          }).then(({ proposalReviews }) => {
+            if (proposalReviews) {
+              proposalReviews.forEach((review, index) => {
+                cy.updateReview({
+                  reviewID: review.id,
+                  comment: faker.random.words(5),
+                  // NOTE: Make first proposal with lower standard deviation. Grades are 2 and 4
+                  grade: index ? 2 : 4,
+                  status: ReviewStatus.SUBMITTED,
+                  fapID: createdFapId,
+                });
+              });
+            }
+          });
+
+          cy.getProposalReviews({
+            proposalPk: createdProposal.primaryKey,
+          }).then(({ proposalReviews }) => {
+            if (proposalReviews) {
+              proposalReviews.forEach((review, index) => {
+                cy.updateReview({
+                  reviewID: review.id,
+                  comment: faker.random.words(5),
+                  // NOTE: Make second proposal with higher standard deviation. Grades are 1 and 5
+                  grade: index ? 1 : 5,
+                  status: ReviewStatus.SUBMITTED,
+                  fapID: createdFapId,
+                });
+              });
+            }
+          });
+        }
+      });
+
+      cy.login('officer');
+      cy.visit(`/FapPage/${createdFapId}?tab=3`);
+
+      cy.finishedLoading();
+
+      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
+
+      cy.get('[aria-label="View proposal details"]').first().click();
+
+      cy.get('[role="dialog"] > header + div').scrollTo('top');
+
+      cy.setTinyMceContent('commentForUser', 'Test');
+      cy.setTinyMceContent('commentForManagement', 'Test');
+
+      cy.get('[data-cy="proposalFapMeetingRecommendation"]').click();
+      cy.get('[data-value="ACCEPTED"]').click();
+
+      cy.get('[data-cy="is-fap-meeting-submitted"]').click();
+      cy.get('[data-cy="saveAndContinue"]').click();
+
+      cy.finishedLoading();
+
+      cy.get('[data-cy="submit-all-button"]').click();
+
+      cy.get('@proposal1Id').then((proposalId) => {
+        cy.get('[data-cy="proposal-' + proposalId + '"]');
+      });
+
+      cy.get('@proposal2Id').then((proposalId) => {
+        cy.get('[data-cy="proposal-' + proposalId + '"]').should('not.exist');
+      });
+    });
   });
 
   describe('Fap Secretary role', () => {
@@ -2783,6 +2911,135 @@ context('Fap meeting components tests', () => {
       cy.get('[data-cy="submit-update-time"]').click();
 
       cy.contains('Availability time updated successfully!');
+    });
+
+    it('Fap Secretary should be able to submit multiple completed Meetings forms', function () {
+      cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
+        const createdProposal = result.createProposal;
+
+        cy.wrap(createdProposal.proposalId).as('proposal2Id');
+
+        if (createdProposal) {
+          cy.updateProposal({
+            proposalPk: createdProposal.primaryKey,
+            title: proposal2.title,
+            abstract: proposal2.abstract,
+            proposerId: initialDBData.users.user1.id,
+          });
+
+          cy.assignProposalsToInstruments({
+            instrumentIds: [createdInstrumentId],
+            proposalPks: [createdProposal.primaryKey],
+          });
+          cy.addProposalTechnicalReview({
+            proposalPk: createdProposal.primaryKey,
+            status: TechnicalReviewStatus.FEASIBLE,
+            timeAllocation: 5,
+            submitted: true,
+            reviewerId: 0,
+            instrumentId: createdInstrumentId,
+          });
+
+          cy.assignProposalsToFaps({
+            fapInstruments: [
+              { instrumentId: createdInstrumentId, fapId: createdFapId },
+            ],
+            proposalPks: [createdProposal.primaryKey],
+          });
+
+          cy.assignReviewersToFap({
+            fapId: createdFapId,
+            memberIds: [fapMembers.reviewer2.id],
+          });
+          cy.assignFapReviewersToProposal({
+            fapId: createdFapId,
+            memberIds: [fapMembers.reviewer2.id],
+            proposalPk: firstCreatedProposalPk,
+          });
+          cy.assignFapReviewersToProposal({
+            fapId: createdFapId,
+            memberIds: [fapMembers.reviewer.id],
+            proposalPk: createdProposal.primaryKey,
+          });
+          cy.assignFapReviewersToProposal({
+            fapId: createdFapId,
+            memberIds: [fapMembers.reviewer2.id],
+            proposalPk: createdProposal.primaryKey,
+          });
+
+          // Manually changing the proposal status to be shown in the Faps. -------->
+          cy.changeProposalsStatus({
+            statusId: initialDBData.proposalStatuses.fapReview.id,
+            proposalPks: [createdProposal.primaryKey],
+          });
+
+          cy.getProposalReviews({
+            proposalPk: firstCreatedProposalPk,
+          }).then(({ proposalReviews }) => {
+            if (proposalReviews) {
+              proposalReviews.forEach((review, index) => {
+                cy.updateReview({
+                  reviewID: review.id,
+                  comment: faker.random.words(5),
+                  // NOTE: Make first proposal with lower standard deviation. Grades are 2 and 4
+                  grade: index ? 2 : 4,
+                  status: ReviewStatus.SUBMITTED,
+                  fapID: createdFapId,
+                });
+              });
+            }
+          });
+
+          cy.getProposalReviews({
+            proposalPk: createdProposal.primaryKey,
+          }).then(({ proposalReviews }) => {
+            if (proposalReviews) {
+              proposalReviews.forEach((review, index) => {
+                cy.updateReview({
+                  reviewID: review.id,
+                  comment: faker.random.words(5),
+                  // NOTE: Make second proposal with higher standard deviation. Grades are 1 and 5
+                  grade: index ? 1 : 5,
+                  status: ReviewStatus.SUBMITTED,
+                  fapID: createdFapId,
+                });
+              });
+            }
+          });
+        }
+      });
+
+      cy.login('officer');
+      cy.visit(`/FapPage/${createdFapId}?tab=3`);
+
+      cy.finishedLoading();
+
+      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
+
+      cy.get('[aria-label="View proposal details"]').first().click();
+
+      cy.get('[role="dialog"] > header + div').scrollTo('top');
+
+      cy.setTinyMceContent('commentForUser', 'Test');
+      cy.setTinyMceContent('commentForManagement', 'Test');
+
+      cy.get('[data-cy="proposalFapMeetingRecommendation"]').click();
+      cy.get('[data-value="ACCEPTED"]').click();
+
+      cy.get('[data-cy="is-fap-meeting-submitted"]').click();
+      cy.get('[data-cy="saveAndContinue"]').click();
+
+      cy.finishedLoading();
+
+      cy.get('[data-cy="submit-all-button"]').click();
+
+      cy.get('@proposal1Id').then((proposalId) => {
+        cy.get('[data-cy="proposal-' + proposalId + '"]');
+      });
+
+      cy.get('@proposal2Id').then((proposalId) => {
+        cy.get('[data-cy="proposal-' + proposalId + '"]').should('not.exist');
+      });
     });
   });
 

--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -2304,8 +2304,6 @@ context('Fap meeting components tests', () => {
 
       cy.get('[data-cy="submit-all-button"]').click();
 
-      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
-
       cy.get('[data-cy="proposal-' + firstCreatedProposalId + '"]').should(
         'not.exist'
       );
@@ -2803,8 +2801,6 @@ context('Fap meeting components tests', () => {
 
       cy.get('[data-cy="submit-all-button"]').click();
 
-      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
-
       cy.get('[data-cy="proposal-' + firstCreatedProposalId + '"]').should(
         'not.exist'
       );
@@ -3025,8 +3021,6 @@ context('Fap meeting components tests', () => {
       cy.visit(`/FapPage/${createdFapId}?tab=3`);
 
       cy.finishedLoading();
-
-      cy.get('[aria-label="Detail panel visibility toggle"]').first().click();
 
       cy.get('[data-cy="submit-all-button"]').click();
 

--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -2187,7 +2187,7 @@ context('Fap meeting components tests', () => {
         );
     });
 
-    it.only('Officer should be able to submit multiple completed Meetings forms', function () {
+    it('Officer should be able to submit multiple completed Meetings forms', function () {
       cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
         const createdProposal = result.createProposal;
 

--- a/apps/frontend/src/components/fap/MeetingComponents/FapInstrumentProposalsTable.tsx
+++ b/apps/frontend/src/components/fap/MeetingComponents/FapInstrumentProposalsTable.tsx
@@ -152,6 +152,16 @@ const FapInstrumentProposalsTable = ({
       field: 'proposal.proposalId',
     },
     {
+      title: 'Fap meeting submitted',
+      render: (rowData: FapProposal) => {
+        const submitted = rowData.proposal.fapMeetingDecisions?.find(
+          (fmd) => fmd.instrumentId === fapInstrument.id
+        )?.submitted;
+
+        return submitted ? 'Yes' : 'No';
+      },
+    },
+    {
       title: 'Principal Investigator',
       render: (rowData: FapProposal) => {
         return getFullUserName(rowData.proposal.proposer);
@@ -208,16 +218,6 @@ const FapInstrumentProposalsTable = ({
         } else {
           return -1;
         }
-      },
-    },
-    {
-      title: 'Fap meeting submitted',
-      render: (rowData: FapProposal) => {
-        const submitted = rowData.proposal.fapMeetingDecisions?.find(
-          (fmd) => fmd.instrumentId === fapInstrument.id
-        )?.submitted;
-
-        return submitted ? 'Yes' : 'No';
       },
     },
     {

--- a/apps/frontend/src/components/fap/MeetingComponents/FapMeetingInstrumentsTable.tsx
+++ b/apps/frontend/src/components/fap/MeetingComponents/FapMeetingInstrumentsTable.tsx
@@ -242,6 +242,7 @@ const FapMeetingInstrumentsTable = ({
                 {proposals[1].map((proposal) => {
                   return (
                     <DialogContentText
+                      data-cy={'proposal-' + proposal}
                       key={'proposal-' + proposal}
                       sx={{ ml: '15px' }}
                     >
@@ -333,6 +334,7 @@ const FapMeetingInstrumentsTable = ({
           });
           setDialogOpen(unSubmittedProposalInstrumentMap);
         }}
+        data-cy="submit-all-button"
       >
         Submit All Completed
       </Button>

--- a/apps/frontend/src/components/fap/MeetingComponents/FapMeetingInstrumentsTable.tsx
+++ b/apps/frontend/src/components/fap/MeetingComponents/FapMeetingInstrumentsTable.tsx
@@ -214,7 +214,7 @@ const FapMeetingInstrumentsTable = ({
             color: 'red',
           }}
         >
-          Some Proposals Could not be Submitted
+          Some proposals could not be submitted
         </DialogTitle>
         <DialogContent>
           <DialogContentText

--- a/apps/frontend/src/graphql/fap/submitFapMeetingDecisions.graphql
+++ b/apps/frontend/src/graphql/fap/submitFapMeetingDecisions.graphql
@@ -1,0 +1,12 @@
+mutation SubmitFapMeetingDecisions(
+  $submitFapMeetingDecisionsInput: SubmitFapMeetingDecisionsInput!
+) {
+  submitFapMeetingDecisions(
+    SubmitFapMeetingDecisionsInput: $submitFapMeetingDecisionsInput
+  ) {
+    instrumentId
+    proposal {
+      proposalId
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1048

## Description
This pull request introduces the feature of mass submitting completed meeting decisions.

## Motivation and Context
This feature was added to allow users to submit multiple completed meeting forms at once, making the process more efficient and less time-consuming.

## Changes
1. Implemented a function in the FapDataSource for submitting Fap meetings.
2. Added a resolver for the new function in FapMutations.
3. Created a new mutation in FapMeetingDecisionMutation to handle the submission of Fap meeting decisions.
4. Updated the FapProposal type.
5. Added a test case for the new feature in FAPs.cy.ts. 

## How Has This Been Tested
This feature has been tested using the end-to-end testing suite, specifically the test case added in FAPs.cy.ts. The tests ensure that multiple completed meeting forms can be successfully submitted at once.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated