### PR TITLE
feat: make all pages with tables to expand full-width

### DIFF
--- a/apps/frontend/src/components/call/CallPage.tsx
+++ b/apps/frontend/src/components/call/CallPage.tsx
@@ -6,7 +6,7 @@ import CallsTable from './CallsTable';
 
 const CallPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <CallsTable />
       </StyledPaper>

--- a/apps/frontend/src/components/experiment/ExperimentPage.tsx
+++ b/apps/frontend/src/components/experiment/ExperimentPage.tsx
@@ -7,7 +7,7 @@ import ExperimentTable from './ExperimentTable';
 
 function ExperimentPage() {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper data-cy="officer-scheduled-events-table">
         <ExperimentFilterBar />
         <ExperimentTable />

--- a/apps/frontend/src/components/fap/FapPage.tsx
+++ b/apps/frontend/src/components/fap/FapPage.tsx
@@ -25,7 +25,7 @@ const FapPage = () => {
 
   if (loading) {
     return (
-      <StyledContainer>
+      <StyledContainer maxWidth={false}>
         <StyledPaper>
           <UOLoader style={{ marginLeft: '50%', marginTop: '100px' }} />
         </StyledPaper>
@@ -35,7 +35,7 @@ const FapPage = () => {
 
   if (!fap) {
     return (
-      <StyledContainer>
+      <StyledContainer maxWidth={false}>
         <StyledPaper>Fap not found</StyledPaper>
       </StyledContainer>
     );
@@ -97,7 +97,7 @@ const FapPage = () => {
   }
 
   return (
-    <StyledContainer maxWidth="xl">
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={tabs.map((tab) => tab.name)}>
           {tabs.map((tab, index) => (

--- a/apps/frontend/src/components/fap/FapsPage.tsx
+++ b/apps/frontend/src/components/fap/FapsPage.tsx
@@ -6,7 +6,7 @@ import FapsTable from './FapsTable';
 
 const FapsPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <FapsTable />
       </StyledPaper>

--- a/apps/frontend/src/components/institution/InstitutionPage.tsx
+++ b/apps/frontend/src/components/institution/InstitutionPage.tsx
@@ -6,7 +6,7 @@ import InstitutionTable from './InstitutionTable';
 
 const InstrumentsPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <InstitutionTable />
       </StyledPaper>

--- a/apps/frontend/src/components/instrument/InstrumentsPage.tsx
+++ b/apps/frontend/src/components/instrument/InstrumentsPage.tsx
@@ -6,7 +6,7 @@ import InstrumentTable from './InstrumentTable';
 
 const InstrumentsPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <InstrumentTable />
       </StyledPaper>

--- a/apps/frontend/src/components/pages/HelpPage.tsx
+++ b/apps/frontend/src/components/pages/HelpPage.tsx
@@ -11,13 +11,11 @@ const HelpPage = () => {
   );
 
   return (
-    <React.Fragment>
-      <StyledContainer>
-        <StyledPaper>
-          {loadingHelpContent ? null : parse(helpPageContent)}
-        </StyledPaper>
-      </StyledContainer>
-    </React.Fragment>
+    <StyledContainer maxWidth={false}>
+      <StyledPaper>
+        {loadingHelpContent ? null : parse(helpPageContent)}
+      </StyledPaper>
+    </StyledContainer>
   );
 };
 

--- a/apps/frontend/src/components/pages/OverviewPage.tsx
+++ b/apps/frontend/src/components/pages/OverviewPage.tsx
@@ -49,7 +49,7 @@ export default function OverviewPage(props: { userRole: UserRole }) {
   }
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       {props.userRole !== UserRole.INSTRUMENT_SCIENTIST && (
         <StyledPaper margin={[0, 0, 2, 0]}>
           {loadingContent ? (

--- a/apps/frontend/src/components/pages/PageEditor.tsx
+++ b/apps/frontend/src/components/pages/PageEditor.tsx
@@ -8,7 +8,7 @@ import PageInputBox from './PageInputBox';
 
 export default function PageEditor() {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs
           tabNames={[

--- a/apps/frontend/src/components/proposalBooking/InstrSciUpcomingExperimentTimesTable.tsx
+++ b/apps/frontend/src/components/proposalBooking/InstrSciUpcomingExperimentTimesTable.tsx
@@ -27,7 +27,7 @@ export default function InstrSciUpcomingExperimentTimesTable() {
     });
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <InstrumentFilter
           shouldShowAll

--- a/apps/frontend/src/components/proposalBooking/UserExperimentsTable.tsx
+++ b/apps/frontend/src/components/proposalBooking/UserExperimentsTable.tsx
@@ -12,7 +12,7 @@ export default function UserExperimentTimesTable() {
     });
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <ExperimentsTable
           isLoading={loading}

--- a/apps/frontend/src/components/sample/SampleSafetyPage.tsx
+++ b/apps/frontend/src/components/sample/SampleSafetyPage.tsx
@@ -236,7 +236,7 @@ function SampleSafetyPage() {
           }}
         />
       )}
-      <StyledContainer>
+      <StyledContainer maxWidth={false}>
         <StyledPaper>
           <Grid container spacing={2}>
             <Grid item sm={3} xs={12}>

--- a/apps/frontend/src/components/settings/apiAccessTokens/ApiAccessTokensPage.tsx
+++ b/apps/frontend/src/components/settings/apiAccessTokens/ApiAccessTokensPage.tsx
@@ -6,7 +6,7 @@ import ApiAccessTokensTable from './ApiAccessTokensTable';
 
 const ApiAccessTokensPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <ApiAccessTokensTable />
       </StyledPaper>

--- a/apps/frontend/src/components/settings/appSettings/AppSettingsPage.tsx
+++ b/apps/frontend/src/components/settings/appSettings/AppSettingsPage.tsx
@@ -6,7 +6,7 @@ import AppSettingsTable from './AppSettingsTable';
 
 const AppSettingsPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <AppSettingsTable />
       </StyledPaper>

--- a/apps/frontend/src/components/settings/features/FeaturesPage.tsx
+++ b/apps/frontend/src/components/settings/features/FeaturesPage.tsx
@@ -6,7 +6,7 @@ import FeaturesTable from './FeaturesTable';
 
 const FeaturesPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <FeaturesTable />
       </StyledPaper>

--- a/apps/frontend/src/components/settings/proposalStatus/ProposalStatusesPage.tsx
+++ b/apps/frontend/src/components/settings/proposalStatus/ProposalStatusesPage.tsx
@@ -6,7 +6,7 @@ import ProposalStatusesTable from './ProposalStatusesTable';
 
 const ProposalStatusesPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <ProposalStatusesTable />
       </StyledPaper>

--- a/apps/frontend/src/components/settings/proposalWorkflow/ProposalWorkflowsPage.tsx
+++ b/apps/frontend/src/components/settings/proposalWorkflow/ProposalWorkflowsPage.tsx
@@ -6,7 +6,7 @@ import ProposalWorkflowsTable from './ProposalWorkflowsTable';
 
 const ProposalWorkflowsPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <ProposalWorkflowsTable />
       </StyledPaper>

--- a/apps/frontend/src/components/settings/unitList/UnitTablePage.tsx
+++ b/apps/frontend/src/components/settings/unitList/UnitTablePage.tsx
@@ -6,7 +6,7 @@ import UnitTable from './UnitTable';
 
 const UnitTablePage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <UnitTable />
       </StyledPaper>

--- a/apps/frontend/src/components/technique/TechniquesPage.tsx
+++ b/apps/frontend/src/components/technique/TechniquesPage.tsx
@@ -6,7 +6,7 @@ import TechniqueTable from './TechniqueTable';
 
 const TechniquesPage = () => {
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <TechniqueTable />
       </StyledPaper>

--- a/apps/frontend/src/components/template/EsiPage.tsx
+++ b/apps/frontend/src/components/template/EsiPage.tsx
@@ -11,7 +11,7 @@ export default function ProposalEsiPage() {
   const itemCountLabel = 'Proposal safety reviews';
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <DefaultTemplatesTable

--- a/apps/frontend/src/components/template/FeedbackTemplatesPage.tsx
+++ b/apps/frontend/src/components/template/FeedbackTemplatesPage.tsx
@@ -14,7 +14,7 @@ export default function FeedbackTemplatesPage() {
   const TableComponent = withMarkTemplateAsActiveAction(DefaultTemplatesTable);
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <TableComponent

--- a/apps/frontend/src/components/template/GenericTemplatesPage.tsx
+++ b/apps/frontend/src/components/template/GenericTemplatesPage.tsx
@@ -14,7 +14,7 @@ export default function GenericTemplatesPage() {
     rowData.questionaryCount === 0;
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <DefaultTemplatesTable

--- a/apps/frontend/src/components/template/PdfTemplatesPage.tsx
+++ b/apps/frontend/src/components/template/PdfTemplatesPage.tsx
@@ -11,7 +11,7 @@ export default function PdfTemplatesPage() {
   const api = useDataApi();
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <PdfTemplatesTable

--- a/apps/frontend/src/components/template/ProposalTemplatesPage.tsx
+++ b/apps/frontend/src/components/template/ProposalTemplatesPage.tsx
@@ -10,7 +10,7 @@ export default function ProposalTemplatesPage() {
   const api = useDataApi();
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <ProposalTemplatesTable

--- a/apps/frontend/src/components/template/QuestionsPage.tsx
+++ b/apps/frontend/src/components/template/QuestionsPage.tsx
@@ -87,7 +87,7 @@ function QuestionsPage() {
   };
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <QuestionsTableFilter
           onChange={(filter) => {

--- a/apps/frontend/src/components/template/SampleEsiPage.tsx
+++ b/apps/frontend/src/components/template/SampleEsiPage.tsx
@@ -11,7 +11,7 @@ export default function SampleEsiPage() {
   const itemCountLabel = '# Sample ESIs';
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <DefaultTemplatesTable

--- a/apps/frontend/src/components/template/SampleTemplatesPage.tsx
+++ b/apps/frontend/src/components/template/SampleTemplatesPage.tsx
@@ -14,7 +14,7 @@ export default function SampleEsiPage() {
     rowData.questionaryCount === 0;
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <DefaultTemplatesTable

--- a/apps/frontend/src/components/template/ShipmentTemplatesPage.tsx
+++ b/apps/frontend/src/components/template/ShipmentTemplatesPage.tsx
@@ -14,7 +14,7 @@ export default function SampleEsiPage() {
   const TableComponent = withMarkTemplateAsActiveAction(DefaultTemplatesTable);
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <TableComponent

--- a/apps/frontend/src/components/template/VisitTemplatesPage.tsx
+++ b/apps/frontend/src/components/template/VisitTemplatesPage.tsx
@@ -14,7 +14,7 @@ export default function SampleEsiPage() {
   const TableComponent = withMarkTemplateAsActiveAction(DefaultTemplatesTable);
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper>
         <SimpleTabs tabNames={['Current', 'Archived']}>
           <TableComponent

--- a/apps/frontend/src/components/user/PeoplePage.tsx
+++ b/apps/frontend/src/components/user/PeoplePage.tsx
@@ -20,7 +20,7 @@ export default function PeoplePage() {
   }
 
   return (
-    <StyledContainer>
+    <StyledContainer maxWidth={false}>
       <StyledPaper data-cy="people-table">
         <PeopleTable
           title="Users"


### PR DESCRIPTION
## Description
This PR extends the width of all pages with tables to full-width.

## Motivation and Context
The change is required to enhance the user experience by providing a more spacious and clear view of the table data, thereby improving readability and data comprehension.

## Changes
- Modified the `StyledContainer` component's `maxWidth` property to `false` across multiple pages. This change allows the container to take up the full available width.
- This modification has been applied to pages like `CallPage.tsx`, `ExperimentPage.tsx`, `FapPage.tsx`, `InstitutionPage.tsx`, `InstrumentsPage.tsx`, `HelpPage.tsx`, `OverviewPage.tsx`, `PageEditor.tsx`, `SampleSafetyPage.tsx`, `ApiAccessTokensPage.tsx`, `AppSettingsPage.tsx`, `FeaturesPage.tsx`, `ProposalStatusesPage.tsx`, `ProposalWorkflowsPage.tsx`, `UnitTablePage.tsx`, `EsiPage.tsx`, and `FeedbackTemplatesPage.tsx`.
- This ensures a consistent user experience across the application.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4100](https://jira.esss.lu.se/browse/SWAP-4100)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated