### PR TITLE
fix: api keys can get fap proposals

### DIFF
--- a/apps/backend/src/queries/FapQueries.ts
+++ b/apps/backend/src/queries/FapQueries.ts
@@ -67,6 +67,7 @@ export default class FapQueries {
     { fapId, callId }: { fapId: number; callId: number | null }
   ) {
     if (
+      agent?.isApiAccessToken ||
       this.userAuth.isUserOfficer(agent) ||
       (await this.userAuth.isMemberOfFap(agent, fapId))
     ) {


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1078

## Description

Allows users with API keys to fetch FAP proposals, which is an explicit option when selecting API key permissions.

## Motivation and Context

This makes actual API key behaviour more closely align its expected behaviour.

## How Has This Been Tested

Tested manually

## Changes

 - `apps/backend/src/queries/FapQueries.ts` Adds check for API key use to `getFapProposals`
