### PR TITLE
fix: proposal export doesn't include all selected proposals

### DIFF
--- a/apps/frontend/src/components/proposal/ProposalTableOfficer.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableOfficer.tsx
@@ -973,10 +973,10 @@ const ProposalTableOfficer = ({
           {
             icon: ExportIcon,
             tooltip: 'Export proposals in Excel',
-            onClick: (event, rowData): void => {
+            onClick: (): void => {
               downloadXLSXProposal(
-                (rowData as ProposalViewData[]).map((row) => row.primaryKey),
-                (rowData as ProposalViewData[])[0].title
+                selectedProposals?.map((row) => row.primaryKey),
+                selectedProposals?.[0].title
               );
             },
             position: 'toolbarOnSelect',


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1083

## Description

Instead of row data, the export function is changed to consider all the selected proposals.

## Motivation and Context

When you select a list of proposals and "Export proposals in Excel", it will only include the first 20 proposals in the exported spreadsheet. All proposals need to show in the spreadsheet for it to be useful and to avoid repetition.

## How Has This Been Tested

Manually

## Fixes

https://github.com/UserOfficeProject/issue-tracker/issues/1083

## Changes

apps/frontend/src/components/proposal/ProposalTableOfficer.tsx

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
