### PR TITLE
chore: handle case when no attachments are found in zip middleware and display appropriate message

### DIFF
--- a/apps/backend/src/middlewares/factory/zip.ts
+++ b/apps/backend/src/middlewares/factory/zip.ts
@@ -51,6 +51,12 @@ router.get(`/${ZIPType.ATTACHMENT}/:proposal_pks`, async (req, res, next) => {
     if (!data) {
       throw new Error('Could not get attachments');
     }
+
+    const attachments = data.flatMap(({ attachments }) => attachments);
+    if (attachments.length === 0) {
+      return res.status(404).send('NO_ATTACHMENTS');
+    }
+
     downloadService.callFactoryService<ProposalAttachmentData, MetaBase>(
       DownloadType.ZIP,
       ZIPType.ATTACHMENT,

--- a/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
+++ b/apps/e2e/cypress/e2e/proposalAdministration.cy.ts
@@ -443,6 +443,9 @@ context('Proposal administration tests', () => {
         'attachment'
       );
 
+      cy.get('[role="alert"]').should('exist');
+      cy.get('[role="alert"]').contains('No attachments found');
+
       cy.contains(proposalFixedName)
         .parent()
         .find('input[type="checkbox"]')
@@ -463,6 +466,9 @@ context('Proposal administration tests', () => {
       cy.get('[data-cy="preparing-download-dialog-item"]').contains(
         '2 selected items'
       );
+
+      cy.get('[role="alert"]').should('exist');
+      cy.get('[role="alert"]').contains('No attachments found');
     });
 
     it('Downloaded proposal filename format is RB_SURNAME_YYYY', function () {

--- a/apps/frontend/src/context/DownloadContextProvider.tsx
+++ b/apps/frontend/src/context/DownloadContextProvider.tsx
@@ -252,7 +252,12 @@ export const DownloadContextProvider = ({
         await promptDownload(response);
       })
       .catch((error) => {
-        if (error !== 'EXTERNAL_TOKEN_INVALID' && error.name !== 'AbortError') {
+        if (error === 'NO_ATTACHMENTS') {
+          enqueueSnackbar('No attachments found', { variant: 'info' });
+        } else if (
+          error !== 'EXTERNAL_TOKEN_INVALID' &&
+          error.name !== 'AbortError'
+        ) {
           enqueueSnackbar('Failed to download file', { variant: 'error' });
         }
       })


### PR DESCRIPTION
## Description
This PR handles the case when no attachments are found in zip middleware and displays an appropriate message.

## Motivation and Context
This change was required to provide clear feedback to the user when no attachments are found. It helps in improving the user experience by avoiding confusion that could arise from the absence of an appropriate response.

## Changes
1. Added a check in `zip.ts` middleware to return a 404 status and 'NO_ATTACHMENTS' message when no attachments are found.
2. Modified `proposalAdministration.cy.ts` to ensure that the 'No attachments found' alert is displayed when no attachments are present.
3. Updated `DownloadContextProvider.tsx` to enqueue a snackbar message 'No attachments found' when the error 'NO_ATTACHMENTS' is caught.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Issue

[https://github.com/UserOfficeProject/issue-tracker/issues/1112](https://github.com/UserOfficeProject/issue-tracker/issues/1112)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated