### PR TITLE
fix(stfc): prevent errors when an external user number doesn't exist

### DIFF
--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -75,6 +75,24 @@ export function toEssBasicUserDetails(
   );
 }
 
+function essBasicUserDetailsForMissingUser(
+  userNumber: number
+): BasicUserDetails {
+  return new BasicUserDetails(
+    userNumber,
+    'Missing',
+    'User ' + userNumber,
+    'Missing',
+    '',
+    1,
+    '',
+    new Date(),
+    true,
+    '',
+    ''
+  );
+}
+
 function toEssUser(stfcUser: StfcBasicPersonDetails): User {
   return new User(
     Number(stfcUser.userNumber),
@@ -238,7 +256,9 @@ export class StfcUserDataSource implements UserDataSource {
   async getBasicUserInfo(id: number): Promise<BasicUserDetails | null> {
     return this.getStfcBasicPersonByUserNumber(String(id)).then(
       (stfcBasicPerson) =>
-        stfcBasicPerson ? toEssBasicUserDetails(stfcBasicPerson) : null
+        stfcBasicPerson
+          ? toEssBasicUserDetails(stfcBasicPerson)
+          : essBasicUserDetailsForMissingUser(id)
     );
   }
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->

Returns a dummy user from the STFC user data source when the user number can't be found in our external user service.

Currently in draft until I've had a review meeting to check we want to go with this approach.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The UOP is incredibly config driven. While this makes it flexible to support multiple templates and facilities, it means there's an overwhelming amount of config that needs setting up in local environments if we want other software to interact with it in a way that is a fair approximation of our production environment.

I've been looking at creating a postgres image that imports a dump of our prod database, providing access to all the same questions, calls, templates, faps... that we have on prod.

An issue I found while testing this is that many user numbers that exist in our prod environment don't in our local one. When UOP encounters a missing user, it returns null for secretaries, investigators, instrument scientists... where there should never be null, causing the site to become non functional. 

I can't think of a good way to decouple non existent user numbers from the rest of the data without losing vast quantities or creating mismatches. What we can do instead, is return a dummy user that clearly states it's not a real one.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Part of https://github.com/UserOfficeProject/issue-tracker/issues/343
<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->
This could go in before them, but this is to use the database from:

https://github.com/isisbusapps/local-db/pull/45
https://github.com/isisbusapps/docker-orchestration/pull/598

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
