### PR TITLE
fix: remove the extra 59 seconds added to the timestamp for call end-time fields

### DIFF
--- a/apps/frontend/src/components/call/CreateUpdateCall.tsx
+++ b/apps/frontend/src/components/call/CreateUpdateCall.tsx
@@ -53,7 +53,8 @@ const CreateUpdateCall = ({ call, close }: CreateUpdateCallProps) => {
     .startOf('day');
   const currentDayEnd = DateTime.now()
     .setZone(timezone || undefined)
-    .endOf('day');
+    .endOf('day')
+    .set({ second: 0, millisecond: 0 });
 
   const getDateTimeFromISO = (value: string) =>
     DateTime.fromISO(value, {


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Adding fix to set seconds and milliseconds to 0 while loading default values for call creation page.

## Motivation and Context

It was observed that while a call is created, an extra 59 seconds and/or 59 milliseconds is being added for all end time fields. Because of which, the call ends are being considered with 1 hour delay while the every hour job for checking the call closure/internal call closure runs. 
This is caused because, while we populate the default values for call start and call end, the call end was defined as currentdate.endOfTheDay(). Therefore, the seconds and milliseconds will be 59.59+00. Even if the user officer changes the hour and minutes(which are the only options available to choose), the seconds and milliseconds remain unchanged.

## How Has This Been Tested

Manually

## Fixes

Fixes https://github.com/UserOfficeProject/issue-tracker/issues/1133

## Changes

apps/frontend/src/components/call/CreateUpdateCall.tsx

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
