### PR TITLE
removed parameter instrumentId has been put back to avoid graphql error

### DIFF
--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -487,6 +487,20 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
         if (filter?.callId) {
           query.where('proposals.call_id', filter.callId);
         }
+
+        if (filter?.instrumentId) {
+          query
+            .leftJoin(
+              'instrument_has_proposals',
+              'instrument_has_proposals.proposal_pk',
+              'proposals.proposal_pk'
+            )
+            .where(
+              'instrument_has_proposals.instrument_id',
+              filter.instrumentId
+            );
+        }
+
         if (filter?.instrumentFilter?.instrumentId) {
           query
             .leftJoin(

--- a/apps/backend/src/resolvers/queries/ProposalsQuery.ts
+++ b/apps/backend/src/resolvers/queries/ProposalsQuery.ts
@@ -57,6 +57,9 @@ export class ProposalsFilter {
   @Field(() => Int, { nullable: true })
   public callId?: number;
 
+  @Field(() => Int, { nullable: true })
+  public instrumentId?: number;
+
   @Field(() => InstrumentFilterInput, { nullable: true })
   public instrumentFilter?: InstrumentFilterInput;
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

In the proposals query, the instrumentId param has been removed off. Bcoz of which, continuous errors have been logged. This should be bcoz of the external integrations. The param has been brought back.

## Motivation and Context

Fixing errors in integratin
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
