### PR TITLE
fix: remove none instrument picker option

### DIFF
--- a/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
@@ -228,7 +228,6 @@ export function QuestionaryComponentInstrumentPicker(
             data-natural-key={naturalKey}
             data-cy="dropdown-ul"
           >
-            {!config.isMultipleSelect && <MenuItem value={0}>None</MenuItem>}
             {config.instruments.map((instrument) => {
               return (
                 <SelectMenuItem


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1158

As agreed in sprint planning, this is a hotfix to remove the `None` option from the instrument picker dropdown.