### PR TITLE
fix: resolve scientist proposal page next page button is greyed out and disabled problem #1160

### DIFF
--- a/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -82,6 +82,9 @@ type QueryParameters = {
   };
   searchText?: string | undefined;
 };
+
+const currentPage = 0;
+
 const getFilterReviewer = (selected: string | ReviewerFilter) =>
   selected === ReviewerFilter.ME ? ReviewerFilter.ME : ReviewerFilter.ALL;
 
@@ -257,7 +260,6 @@ const ProposalTableInstrumentScientist = ({
 }: {
   confirm: WithConfirmType;
 }) => {
-  const currentPage = 0;
   const [rowsPerPage, setRowsPerPage] = useState(20);
   const [selectedProposals, setSelectedProposals] = useState<
     ProposalViewData[]
@@ -374,13 +376,7 @@ const ProposalTableInstrumentScientist = ({
     return () => {
       isMounted = false;
     };
-  }, [
-    currentPage,
-    rowsPerPage,
-    preselectedProposalsData,
-    queryParameters,
-    totalCount,
-  ]);
+  }, [rowsPerPage, preselectedProposalsData, queryParameters, totalCount]);
 
   useEffect(() => {
     if (urlQueryParams.selection.length > 0) {

--- a/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -257,7 +257,7 @@ const ProposalTableInstrumentScientist = ({
 }: {
   confirm: WithConfirmType;
 }) => {
-  const [currentPage] = useState(0);
+  const currentPage = 0;
   const [rowsPerPage, setRowsPerPage] = useState(20);
   const [selectedProposals, setSelectedProposals] = useState<
     ProposalViewData[]

--- a/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -257,7 +257,7 @@ const ProposalTableInstrumentScientist = ({
 }: {
   confirm: WithConfirmType;
 }) => {
-  const [currentPage, setCurrentPage] = useState(0);
+  const [currentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(20);
   const [selectedProposals, setSelectedProposals] = useState<
     ProposalViewData[]
@@ -362,13 +362,11 @@ const ProposalTableInstrumentScientist = ({
 
   useEffect(() => {
     let isMounted = true;
-    let endSlice = rowsPerPage * (currentPage + 1);
-    endSlice = endSlice == 0 ? PREFETCH_SIZE + 1 : endSlice; // Final page of a loaded section would produce the slice (x, 0) without this
     if (isMounted) {
       setTableData(
         preselectedProposalsData.slice(
           (currentPage * rowsPerPage) % PREFETCH_SIZE,
-          endSlice
+          totalCount
         )
       );
     }
@@ -376,7 +374,13 @@ const ProposalTableInstrumentScientist = ({
     return () => {
       isMounted = false;
     };
-  }, [currentPage, rowsPerPage, preselectedProposalsData, queryParameters]);
+  }, [
+    currentPage,
+    rowsPerPage,
+    preselectedProposalsData,
+    queryParameters,
+    totalCount,
+  ]);
 
   useEffect(() => {
     if (urlQueryParams.selection.length > 0) {
@@ -875,7 +879,6 @@ const ProposalTableInstrumentScientist = ({
               },
             });
           }
-          setCurrentPage(page);
         }}
         columns={columns}
         data={proposalDataWithIdAndRowActions}


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1160

This is a hotfix to resolve the problem of the next page button is greyed out and disabled, so scientists can only view 5, 10 or 20 proposals (using the "rows per page" dropdown) and cannot view more.