### PR TITLE
fix: add missing attributes for img tags in TinyMCE editors

### DIFF
--- a/apps/backend/src/models/questionTypes/RichTextInput.ts
+++ b/apps/backend/src/models/questionTypes/RichTextInput.ts
@@ -74,7 +74,7 @@ export const sanitizerConfigWithImages: IOptions = {
     span: ['style', 'class'],
     p: ['style'],
     div: ['style'],
-    img: ['src', 'alt', 'data-mce-src'],
+    img: ['src', 'alt', 'data-mce-src', 'width', 'height'],
   },
 };
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Image width/height attributes are removed from img tags in TinyMCE Rich Text answers (when images are allowed in template configuration). 

## Motivation and Context

Fix the issue described above.  

## How Has This Been Tested

Manual tests. 

## Fixes

Add missing attributes to the proper html sanitizer.

## Changes

Add missing attributes to the proper html sanitizer.

## Depends on

N/A

## Tests included/Docs Updated?


- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
