### PR TITLE
fix: instrument picker instrument selection

### DIFF
--- a/apps/backend/src/models/questionTypes/InstrumentPicker.ts
+++ b/apps/backend/src/models/questionTypes/InstrumentPicker.ts
@@ -108,6 +108,15 @@ export const instrumentPickerDefinition: Question<DataType.INSTRUMENT_PICKER> =
         return;
       }
 
+      const instrumentDataSource = container.resolve<InstrumentDataSource>(
+        Tokens.InstrumentDataSource
+      );
+
+      // Remove previously assigned instruments
+      await instrumentDataSource.removeProposalsFromInstrument([
+        proposal.primaryKey,
+      ]);
+
       // Assign the Proposals to Instruments
       await instrumentMutations.assignProposalsToInstrumentsInternal(null, {
         instrumentIds,

--- a/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
@@ -216,7 +216,7 @@ export function QuestionaryComponentInstrumentPicker(
             value={
               Array.isArray(stateValue)
                 ? stateValue?.filter((i) => i).map((i) => i.instrumentId) || []
-                : stateValue?.instrumentId || '0'
+                : [stateValue?.instrumentId] || ['0']
             }
             onChange={handleOnChange}
             multiple={config.isMultipleSelect}


### PR DESCRIPTION
## Description
This PR fixes the issue with instrument selection in the instrument picker.

## Motivation and Context
The change is required to correct the behavior of the instrument picker, which was not properly removing previously assigned instruments before assigning new ones. This was causing confusion and errors in instrument assignments.

## Changes
- Introduced a call to `removeProposalsFromInstrument` function in `InstrumentPicker.ts` to remove previously assigned instruments before new assignment.
- Adjusted the value format of the selection in `QuestionaryComponentInstrumentPicker.tsx` to ensure correct instrument selection in the picker.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated