### PR TITLE
fix: instrument picker not removing instruments from proposal

### DIFF
--- a/apps/backend/src/models/questionTypes/InstrumentPicker.ts
+++ b/apps/backend/src/models/questionTypes/InstrumentPicker.ts
@@ -98,10 +98,10 @@ export const instrumentPickerDefinition: Question<DataType.INSTRUMENT_PICKER> =
       }
 
       const { value } = JSON.parse(answer.value);
-      const instrumentIds = value
+      const instrumentIds: number[] | null = value
         ? Array.isArray(value)
-          ? value.map((i) => i.instrumentId)
-          : [value.instrumentId]
+          ? value.map((i) => parseInt(i.instrumentId))
+          : [parseInt(value.instrumentId)]
         : null;
 
       if (!instrumentIds?.length) {

--- a/apps/backend/src/mutations/InstrumentMutations.ts
+++ b/apps/backend/src/mutations/InstrumentMutations.ts
@@ -175,17 +175,16 @@ export default class InstrumentMutations {
       }
 
       for await (const proposalPk of args.proposalPks) {
+        // all instruments currently on a proposal
         const proposalInstruments =
           await this.dataSource.getInstrumentsByProposalPk(proposalPk);
 
+        // Instruments on the proposal to remove
         const proposalInstrumentsToRemove = proposalInstruments.filter(
           (i) => !args.instrumentIds.includes(i.id)
         );
 
-        if (
-          proposalInstrumentsToRemove.length &&
-          proposalInstruments.length !== proposalInstrumentsToRemove.length
-        ) {
+        if (proposalInstrumentsToRemove.length) {
           await Promise.all(
             proposalInstrumentsToRemove.map((i) => {
               return this.dataSource.removeProposalsFromInstrument(

--- a/apps/e2e/cypress/e2e/proposals.cy.ts
+++ b/apps/e2e/cypress/e2e/proposals.cy.ts
@@ -1542,6 +1542,7 @@ context('Proposal tests', () => {
       cy.contains('Proposals').click();
       cy.contains(title).parent().contains(instrument2.name);
       cy.contains(title).parent().find('[aria-label="View proposal"]').click();
+      cy.contains('td', instrument1.name).should('not.exist');
       cy.contains('td', instrument2.name).should('exist');
     });
 

--- a/apps/e2e/cypress/e2e/proposals.cy.ts
+++ b/apps/e2e/cypress/e2e/proposals.cy.ts
@@ -1542,7 +1542,7 @@ context('Proposal tests', () => {
       cy.contains('Proposals').click();
       cy.contains(title).parent().contains(instrument2.name);
       cy.contains(title).parent().find('[aria-label="View proposal"]').click();
-      cy.contains('td', instrument1.name).should('not.exist');
+      cy.contains('td', instrument.name).should('not.exist');
       cy.contains('td', instrument2.name).should('exist');
     });
 

--- a/apps/e2e/cypress/e2e/proposals.cy.ts
+++ b/apps/e2e/cypress/e2e/proposals.cy.ts
@@ -1490,6 +1490,61 @@ context('Proposal tests', () => {
       cy.contains('td', instrument.name).should('exist');
     });
 
+    it('Instrument should be automatically un assigned to the proposal when a new instrument is selected', () => {
+      cy.login('user1', initialDBData.roles.user);
+      cy.visit('/');
+      cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
+      cy.get('[data-cy=principal-investigator] input').should(
+        'contain.value',
+        'Carl'
+      );
+      cy.finishedLoading();
+      cy.contains('New Proposal').click();
+      cy.get('[data-cy=call-list]').find('li:first-child').click();
+      cy.get('[data-cy=title] input').type(title).should('have.value', title);
+      cy.get('[data-cy=abstract] textarea')
+        .first()
+        .type(abstract)
+        .should('have.value', abstract);
+      cy.get('[data-cy="save-and-continue-button"]').focus().click();
+      cy.finishedLoading();
+      cy.get('[data-natural-key^="instrument_picker"]').click();
+      cy.get('[role="option"]').contains('Instrument 1').click();
+      cy.get('[data-cy="save-and-continue-button"]').focus().click();
+      cy.finishedLoading();
+      cy.notification({ variant: 'success', text: 'Saved' });
+      cy.login('officer');
+      cy.visit('/');
+      cy.contains('Proposals').click();
+      cy.contains(title).parent().contains(instrument.name);
+      cy.contains(title).parent().find('[aria-label="View proposal"]').click();
+      cy.contains('td', instrument.name).should('exist');
+
+      cy.login('user1', initialDBData.roles.user);
+      cy.visit('/');
+      cy.contains('Dashboard').click();
+      cy.contains(title)
+        .parent()
+        .find('[aria-label="Edit proposal"]')
+        .should('exist')
+        .click();
+      cy.contains('Back').click();
+      cy.finishedLoading();
+      cy.get('[data-natural-key^="instrument_picker"]').click();
+      cy.get('[role="option"]').contains('Instrument 2').click();
+      cy.get('[data-cy="save-and-continue-button"]').focus().click();
+      cy.finishedLoading();
+      cy.notification({ variant: 'success', text: 'Saved' });
+
+      cy.login('officer');
+      cy.visit('/');
+      cy.contains('Proposals').click();
+      cy.contains(title).parent().contains(instrument2.name);
+      cy.contains(title).parent().find('[aria-label="View proposal"]').click();
+      cy.contains('td', instrument2.name).should('exist');
+    });
+
     it('Multiple instruments should be automatically assigned to the proposal', () => {
       cy.updateQuestionTemplateRelationSettings({
         questionId: instrumentPickerQuestionId,

--- a/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
@@ -216,7 +216,7 @@ export function QuestionaryComponentInstrumentPicker(
             value={
               Array.isArray(stateValue)
                 ? stateValue?.filter((i) => i).map((i) => i.instrumentId) || []
-                : stateValue?.instrumentId || '0'
+                : [stateValue?.instrumentId] || ['0']
             }
             onChange={handleOnChange}
             multiple={config.isMultipleSelect}

--- a/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
@@ -216,7 +216,7 @@ export function QuestionaryComponentInstrumentPicker(
             value={
               Array.isArray(stateValue)
                 ? stateValue?.filter((i) => i).map((i) => i.instrumentId) || []
-                : [stateValue?.instrumentId] || ['0']
+                : stateValue?.instrumentId ? [stateValue.instrumentId] : []
             }
             onChange={handleOnChange}
             multiple={config.isMultipleSelect}

--- a/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
@@ -216,7 +216,9 @@ export function QuestionaryComponentInstrumentPicker(
             value={
               Array.isArray(stateValue)
                 ? stateValue?.filter((i) => i).map((i) => i.instrumentId) || []
-                : stateValue?.instrumentId ? [stateValue.instrumentId] : []
+                : stateValue?.instrumentId
+                  ? [stateValue.instrumentId]
+                  : []
             }
             onChange={handleOnChange}
             multiple={config.isMultipleSelect}


### PR DESCRIPTION
closes: UserOfficeProject/issue-tracker#1170

HOTFIX

## Description
This PR fixes an issue where the instrument picker was not properly removing instruments from a proposal.

## Motivation and Context
The current behavior of the instrument picker led to a problem where removed instruments were still appearing in the proposal, causing confusion and potential inaccuracies in the proposal data. This change is required to ensure that when an instrument is removed, it is reflected correctly in the proposal.

## Changes
- Added code to identify instruments on a proposal that need to be removed based on the updated selection in the instrument picker.
- Modified the condition to trigger the removal of instruments from a proposal, ensuring it occurs whenever there are instruments to remove.
- Adjusted the value assignment in the instrument picker component to handle single and multiple selections consistently, ensuring the correct data type is used.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated