### PR TITLE
fix: predefined delete message issue fixed

### DIFF
--- a/apps/e2e/cypress/e2e/predefinedMessages.cy.ts
+++ b/apps/e2e/cypress/e2e/predefinedMessages.cy.ts
@@ -151,4 +151,88 @@ context('Predefined messages tests', () => {
       .first()
       .should('have.value', '');
   });
+
+  it.only('User officer should be able to delete the selected predefined message and create new one without closing the popup', () => {
+    cy.login('officer');
+    cy.visit('/');
+
+    cy.contains(initialDBData.proposal.title)
+      .parent()
+      .find('[data-cy="view-proposal"]')
+      .click();
+
+    cy.get('[role="dialog"] [role="tab"]').contains('Admin').click();
+
+    cy.get(
+      '[data-cy="commentForUser"] [data-cy="select-predefined-message"]'
+    ).click();
+
+    cy.get(
+      '[aria-labelledby="predefined-messages-modal"] [data-cy="message-title"] input'
+    )
+      .clear()
+      .type(messageTitle);
+
+    cy.get(
+      '[aria-labelledby="predefined-messages-modal"] [data-cy="message"] textarea'
+    )
+      .first()
+      .clear()
+      .type(message);
+
+    cy.get('[data-cy="save-and-use-message"]').click();
+
+    cy.notification({
+      variant: 'success',
+      text: 'Message created successfully',
+    });
+
+    cy.get('[data-cy="commentForUser"] textarea')
+      .first()
+      .should('have.value', message);
+
+    cy.get(
+      '[data-cy="commentForUser"] [data-cy="select-predefined-message"]'
+    ).click();
+
+    cy.get('[data-cy="delete-message"]').click();
+    cy.get('[data-cy="confirm-ok"]').click();
+    cy.notification({
+      variant: 'success',
+      text: 'Message deleted successfully',
+    });
+
+    cy.get(
+      '[aria-labelledby="predefined-messages-modal"] [data-cy="message-title"] input'
+    ).should('have.value', '');
+
+    cy.get(
+      '[aria-labelledby="predefined-messages-modal"] [data-cy="message"] textarea'
+    )
+      .first()
+      .should('have.value', '');
+
+    const newMessageTitle = faker.random.words();
+    const newMessage = faker.random.words();
+
+    cy.get(
+      '[aria-labelledby="predefined-messages-modal"] [data-cy="message-title"] input'
+    )
+      .clear()
+      .type(newMessageTitle);
+
+    cy.get(
+      '[aria-labelledby="predefined-messages-modal"] [data-cy="message"] textarea'
+    )
+      .first()
+      .clear()
+      .type(newMessage);
+
+    cy.get('[data-cy="save-and-use-message"]').click();
+
+    cy.notification({
+      variant: 'success',
+      text: 'Message created successfully',
+    });
+  });
 });

--- a/apps/frontend/src/components/common/predefinedMessages/PredefinedMessagesModal.tsx
+++ b/apps/frontend/src/components/common/predefinedMessages/PredefinedMessagesModal.tsx
@@ -111,13 +111,7 @@ const PredefinedMessagesModal = ({
     setFieldValue('predefinedMessageId', selectedItem);
   };
 
-  const handlePredefinedMessageDelete = async (
-    setFieldValue: (
-      field: string,
-      value: number | string,
-      shouldValidate?: boolean | undefined
-    ) => void
-  ) => {
+  const handlePredefinedMessageDelete = async () => {
     confirm(
       async () => {
         if (!initialValues.predefinedMessageId) {
@@ -134,9 +128,8 @@ const PredefinedMessagesModal = ({
           (predefinedMessage) =>
             predefinedMessage.id !== initialValues.predefinedMessageId
         );
+
         setPredefinedMessages(newPredefinedMessagesArray);
-        setFieldValue('message', '');
-        setFieldValue('title', '');
       },
       {
         title: 'Please confirm',
@@ -195,7 +188,7 @@ const PredefinedMessagesModal = ({
             }
           }}
         >
-          {({ isSubmitting, setFieldValue, dirty }) => (
+          {({ isSubmitting, setFieldValue, dirty, resetForm }) => (
             <Form
               onChange={() => {
                 if (dirty) {
@@ -259,7 +252,17 @@ const PredefinedMessagesModal = ({
                   color="error"
                   disabled={isSubmitting || !initialValues.predefinedMessageId}
                   startIcon={<DeleteIcon />}
-                  onClick={() => handlePredefinedMessageDelete(setFieldValue)}
+                  onClick={() => {
+                    handlePredefinedMessageDelete();
+
+                    resetForm({
+                      values: {
+                        predefinedMessageId: null,
+                        title: '',
+                        message: '',
+                      },
+                    });
+                  }}
                   data-cy="delete-message"
                 >
                   Delete


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Fixed Predefined message window delete and create, by resetting the form value properly during deletion

## Motivation and Context

When deleting the predefined message, the form was not clearing. Bcoz of which, the creation thrown error due to the deleted message's id not getting cleared

## How Has This Been Tested

Attached e2e
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [*] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
