### PR TITLE
fix: insert all available user information at creation time

### DIFF
--- a/apps/backend/src/auth/OAuthAuthorization.ts
+++ b/apps/backend/src/auth/OAuthAuthorization.ts
@@ -162,7 +162,7 @@ export class OAuthAuthorization extends UserAuthorization {
       return updatedUser;
     } else {
       const newUser = await this.userDataSource.create(
-        'unspecified',
+        (userInfo.title as string) ?? 'unspecified',
         userInfo.given_name,
         undefined,
         userInfo.family_name,
@@ -171,12 +171,12 @@ export class OAuthAuthorization extends UserAuthorization {
         userInfo.sub,
         tokenSet.refresh_token ?? '',
         client.issuer.metadata.issuer,
-        'unspecified',
+        userInfo.gender ?? 'unspecified',
         1,
         new Date(),
-        1,
+        institutionId ?? 1,
         '',
-        '',
+        (userInfo.position as string) ?? '',
         userInfo.email,
         '',
         undefined


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Some user attributes are only updated after the second login of the user (first login will create the user in the users table, the second login will update the existing record).

## Motivation and Context

It is confusing that some user attributes will only be set after the second login. 

## How Has This Been Tested

Manual testing + e2e.

## Fixes

Synchronize the inserted / updated user attributes. 

## Changes

Update upsert method in OAuthAuthorization.ts.

## Depends on

N/A


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] I have added tests to cover my changes.
- [ x] All relevant doc has been updated
