### PR TITLE
fix: user search for instrument scientist and internal reviewer

### DIFF
--- a/apps/frontend/src/components/instrument/CreateUpdateInstrument.tsx
+++ b/apps/frontend/src/components/instrument/CreateUpdateInstrument.tsx
@@ -75,7 +75,12 @@ const CreateUpdateInstrument = ({
         .getUsers({ filter: value, userRole: UserRole.INSTRUMENT_SCIENTIST })
         .then((data) => {
           if (data.users?.totalCount == 0) {
-            setFieldError('surname', 'No users found with that surname');
+            setFieldError(
+              'surname',
+              'No ' +
+                i18n.format(t('instrumentSci'), 'plural') +
+                ' found with that surname'
+            );
           } else {
             setUsersData(data.users?.users || []);
           }

--- a/apps/frontend/src/components/instrument/CreateUpdateInstrument.tsx
+++ b/apps/frontend/src/components/instrument/CreateUpdateInstrument.tsx
@@ -72,7 +72,7 @@ const CreateUpdateInstrument = ({
 
     try {
       await api()
-        .getUsers({ filter: value })
+        .getUsers({ filter: value, userRole: UserRole.INSTRUMENT_SCIENTIST })
         .then((data) => {
           if (data.users?.totalCount == 0) {
             setFieldError('surname', 'No users found with that surname');

--- a/apps/frontend/src/components/internalReview/CreateUpdateInternalReview.tsx
+++ b/apps/frontend/src/components/internalReview/CreateUpdateInternalReview.tsx
@@ -82,7 +82,7 @@ const CreateUpdateInternalReview = ({
 
     try {
       await api()
-        .getUsers({ filter: value })
+        .getUsers({ filter: value, userRole: UserRole.INTERNAL_REVIEWER })
         .then((data) => {
           if (data.users?.totalCount == 0) {
             setFieldError('surname', 'No users found with that surname');

--- a/apps/frontend/src/components/internalReview/CreateUpdateInternalReview.tsx
+++ b/apps/frontend/src/components/internalReview/CreateUpdateInternalReview.tsx
@@ -85,7 +85,10 @@ const CreateUpdateInternalReview = ({
         .getUsers({ filter: value, userRole: UserRole.INTERNAL_REVIEWER })
         .then((data) => {
           if (data.users?.totalCount == 0) {
-            setFieldError('surname', 'No users found with that surname');
+            setFieldError(
+              'surname',
+              'No Internal Reviewers found with that surname'
+            );
           } else {
             setUsersData(data.users?.users || []);
           }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Add missing user role filters when searching for internal reviewers / instrument scientists. 

## Motivation and Context

It is possible to add internal reviewer / instrument scientist for a proposal / instrument without having the proper role. 

## How Has This Been Tested

Manual test & e2e

## Fixes

Add missing roles for the user lookup.

## Changes

Code changes in frontend.

## Depends on

N/A

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] I have added tests to cover my changes.
- [ x] All relevant doc has been updated
