### PR TITLE
feat: add internal review create/update/delete events to eli mail han…

### DIFF
--- a/apps/backend/src/events/applicationEvents.ts
+++ b/apps/backend/src/events/applicationEvents.ts
@@ -2,6 +2,7 @@ import { Call } from '../models/Call';
 import { Fap, FapProposal } from '../models/Fap';
 import { FapMeetingDecision } from '../models/FapMeetingDecision';
 import { Instrument, InstrumentsHasProposals } from '../models/Instrument';
+import { InternalReview } from '../models/InternalReview';
 import { Proposal, ProposalPks, Proposals } from '../models/Proposal';
 import { QuestionaryStep } from '../models/Questionary';
 import { Review } from '../models/Review';
@@ -355,6 +356,21 @@ interface ProposalAssignedToTechniquesEvent extends GeneralEvent {
   boolean: boolean;
 }
 
+interface InternalReviewCreated extends GeneralEvent {
+  type: Event.INTERNAL_REVIEW_CREATED;
+  internalreview: InternalReview;
+}
+
+interface InternalReviewUpdated extends GeneralEvent {
+  type: Event.INTERNAL_REVIEW_UPDATED;
+  internalreview: InternalReview;
+}
+
+interface InternalReviewDeleted extends GeneralEvent {
+  type: Event.INTERNAL_REVIEW_DELETED;
+  internalreview: InternalReview;
+}
+
 export type ApplicationEvent =
   | ProposalAcceptedEvent
   | ProposalUpdatedEvent
@@ -421,4 +437,7 @@ export type ApplicationEvent =
   | TechniqueDeletedEvent
   | InstrumentsAssignedToTechniqueEvent
   | InstrumentsRemovedFromTechniqueEvent
-  | ProposalAssignedToTechniquesEvent;
+  | ProposalAssignedToTechniquesEvent
+  | InternalReviewCreated
+  | InternalReviewUpdated
+  | InternalReviewDeleted;


### PR DESCRIPTION
Add internal review create/update/delete events to eli mail handler

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Add INTERNAL_REVIEW_CREATED, UPDATED, DELETED events to app events and eli email handler. 

## Motivation and Context

At ELI we would like to notify the internal reviewers on internal review changes. 

## How Has This Been Tested

Manual tests.

## Fixes

N/A

## Changes

eli mail handler, application events

## Depends on

N/A

## Tests included/Docs Updated?

- [x ] I have added tests to cover my changes.
- [ x] All relevant doc has been updated
