### PR TITLE
fix: prevent multiple instances of the StfcUserDataSource being created

### DIFF
--- a/apps/backend/src/datasources/stfc/StfcInstrumentDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcInstrumentDataSource.ts
@@ -1,5 +1,6 @@
-import { injectable } from 'tsyringe';
+import { container, injectable } from 'tsyringe';
 
+import { Tokens } from '../../config/Tokens';
 import { BasicUserDetails } from '../../models/User';
 import database from '../postgres/database';
 import PostgresInstrumentDataSource from '../postgres/InstrumentDataSource';
@@ -14,10 +15,12 @@ import {
   toEssBasicUserDetails,
 } from './StfcUserDataSource';
 
-const stfcUserDataSource = new StfcUserDataSource();
-
 @injectable()
 export default class StfcInstrumentDataSource extends PostgresInstrumentDataSource {
+  protected stfcUserDataSource: StfcUserDataSource = container.resolve(
+    Tokens.UserDataSource
+  ) as StfcUserDataSource;
+
   async getInstrumentScientists(
     instrumentId: number
   ): Promise<BasicUserDetails[]> {
@@ -41,7 +44,9 @@ export default class StfcInstrumentDataSource extends PostgresInstrumentDataSour
 
     const userNumbers = users.map((user) => user.id.toString());
     const stfcUsers =
-      await stfcUserDataSource.getStfcBasicPeopleByUserNumbers(userNumbers);
+      await this.stfcUserDataSource.getStfcBasicPeopleByUserNumbers(
+        userNumbers
+      );
 
     const usersDetails = stfcUsers
       ? stfcUsers.map((person) => toEssBasicUserDetails(person))

--- a/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
@@ -1,5 +1,6 @@
-import { injectable } from 'tsyringe';
+import { container, injectable } from 'tsyringe';
 
+import { Tokens } from '../../config/Tokens';
 import { Call } from '../../models/Call';
 import { Proposal } from '../../models/Proposal';
 import { ProposalView } from '../../models/ProposalView';
@@ -19,10 +20,12 @@ import { ProposalsFilter } from './../../resolvers/queries/ProposalsQuery';
 import PostgresProposalDataSource from './../postgres/ProposalDataSource';
 import { StfcUserDataSource } from './StfcUserDataSource';
 
-const stfcUserDataSource = new StfcUserDataSource();
-
 @injectable()
 export default class StfcProposalDataSource extends PostgresProposalDataSource {
+  protected stfcUserDataSource: StfcUserDataSource = container.resolve(
+    Tokens.UserDataSource
+  ) as StfcUserDataSource;
+
   async getInstrumentScientistProposals(
     user: UserWithRole,
     filter?: ProposalsFilter,
@@ -178,7 +181,7 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
     );
 
     const technicalReviewersDetails =
-      await stfcUserDataSource.getStfcBasicPeopleByUserNumbers(
+      await this.stfcUserDataSource.getStfcBasicPeopleByUserNumbers(
         technicalReviewers,
         false
       );

--- a/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
@@ -35,7 +35,7 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
     const stfcUserIds: number[] = filter?.text
       ? [
           ...(
-            await stfcUserDataSource.getUsers({ filter: filter.text })
+            await this.stfcUserDataSource.getUsers({ filter: filter.text })
           ).users.map((user) => user.id),
         ]
       : [];
@@ -179,7 +179,7 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
     const stfcUserIds: number[] = searchText
       ? [
           ...(
-            await stfcUserDataSource.getUsers({ filter: searchText })
+            await this.stfcUserDataSource.getUsers({ filter: searchText })
           ).users.map((ids) => ids.id),
         ]
       : [];

--- a/apps/backend/src/datasources/stfc/StfcTechniqueDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcTechniqueDataSource.ts
@@ -1,5 +1,6 @@
-import { injectable } from 'tsyringe';
+import { container, injectable } from 'tsyringe';
 
+import { Tokens } from '../../config/Tokens';
 import { BasicUserDetails } from '../../models/User';
 import database from '../postgres/database';
 import {
@@ -13,9 +14,12 @@ import {
   StfcUserDataSource,
   toEssBasicUserDetails,
 } from './StfcUserDataSource';
-const stfcUserDataSource = new StfcUserDataSource();
+
 @injectable()
 export default class StfcTechniqueDataSource extends PostgresTechniqueDataSource {
+  protected stfcUserDataSource: StfcUserDataSource = container.resolve(
+    Tokens.UserDataSource
+  ) as StfcUserDataSource;
   async getTechniqueScientists(
     techniqueId: number
   ): Promise<BasicUserDetails[]> {
@@ -37,7 +41,9 @@ export default class StfcTechniqueDataSource extends PostgresTechniqueDataSource
 
     const userNumbers = users.map((user) => user.id.toString());
     const stfcUsers =
-      await stfcUserDataSource.getStfcBasicPeopleByUserNumbers(userNumbers);
+      await this.stfcUserDataSource.getStfcBasicPeopleByUserNumbers(
+        userNumbers
+      );
 
     const usersDetails = stfcUsers
       ? stfcUsers.map((person) => toEssBasicUserDetails(person))

--- a/apps/backend/src/factory/xlsx/stfc/StfcFapDataRow.ts
+++ b/apps/backend/src/factory/xlsx/stfc/StfcFapDataRow.ts
@@ -1,13 +1,13 @@
 import { stripHtml } from 'string-strip-html';
+import { container } from 'tsyringe';
 
+import { Tokens } from '../../../config/Tokens';
 import { StfcUserDataSource } from '../../../datasources/stfc/StfcUserDataSource';
 import { QuestionaryStep } from '../../../models/Questionary';
 import { Review } from '../../../models/Review';
 import { CallRowObj } from '../callFaps';
 import { RowObj } from '../fap';
 import { getDataRow } from '../FapDataRow';
-
-const stfcUserDataSource = new StfcUserDataSource();
 
 export async function getStfcDataRow(
   proposalPk: number,
@@ -25,6 +25,10 @@ export async function getStfcDataRow(
   proposalAnswers: QuestionaryStep[] | null,
   reviews: Review[] | null
 ) {
+  const stfcUserDataSource: StfcUserDataSource = container.resolve(
+    Tokens.UserDataSource
+  ) as StfcUserDataSource;
+
   const individualReviews = reviews
     ? await Promise.all(
         reviews.map(async (rev) => {


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In STFC we use an external service to get user details, and cache results to improve performance. I noticed that we're logging statistics for multiple parallel instances of these, which means we're not getting the full benefit of those caches, as different parts of the app may be requesting the same data from the slow external source instead of using already requested and cached data.

## How Has This Been Tested

I browsed to local pages where the updated data sources would be used and they seemed to load fine. Other than that I'm just relying on the test suite to check for regressions.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Closes UserOfficeProject/issue-tracker#1188

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
