### PR TITLE
test: allow mutliple test runners to upload cypress screenshots

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -228,17 +228,24 @@ jobs:
       fail-fast: false
       matrix:
         pattern:
-          [
-            "cypress/e2e/[a-e]*.ts",
-            "cypress/e2e/[f-h]*.ts",
-            "cypress/e2e/[i-o]*.ts",
-            "cypress/e2e/p[a-m]*.ts",
-            "cypress/e2e/p[n-z]*.ts",
-            "cypress/e2e/[r-s]*.ts",
-            "cypress/e2e/t*.ts",
-            "cypress/e2e/[u-z]*.ts",
-            "cypress/e2e/[A-Z]*.ts",
-          ]
+          - id: ae
+            files: cypress/e2e/[a-e]*.ts
+          - id: fh
+            files: cypress/e2e/[f-h]*.ts
+          - id: io
+            files: cypress/e2e/[i-o]*.ts
+          - id: p-am
+            files: cypress/e2e/p[a-m]*.ts
+          - id: p-nz
+            files: cypress/e2e/p[n-z]*.ts
+          - id: rs
+            files: cypress/e2e/[r-s]*.ts
+          - id: t
+            files: cypress/e2e/t*.ts
+          - id: uz
+            files: cypress/e2e/[u-z]*.ts
+          - id: AZ
+            files: cypress/e2e/[A-Z]*.ts
 
     steps:
       - uses: actions/checkout@v4
@@ -325,7 +332,7 @@ jobs:
           USER_OFFICE_FACTORY_TAG: ${{ needs.resolve_dep.outputs.FACTORY_TAG }}
           SCHEMA_URL: http://localhost:4000/graphql
           SVC_ACC_TOKEN: ${{ secrets.SVC_ACC_TOKEN }}
-          CYPRES_SPEC_PATTERN: ${{ matrix.pattern }}
+          CYPRES_SPEC_PATTERN: ${{ matrix.pattern.files }}
           BUILD_TAG: ${{ github.sha }}
           CYPRESS_CACHE_FOLDER: .cache/Cypress
           EXTERNAL_AUTH_TOKEN: abc
@@ -369,7 +376,7 @@ jobs:
           USER_OFFICE_FACTORY_TAG: ${{ needs.resolve_dep.outputs.FACTORY_TAG }}
           SCHEMA_URL: http://localhost:4000/graphql
           SVC_ACC_TOKEN: ${{ secrets.SVC_ACC_TOKEN }}
-          CYPRES_SPEC_PATTERN: ${{ matrix.pattern }}
+          CYPRES_SPEC_PATTERN: ${{ matrix.pattern.files }}
           BUILD_TAG: ${{ github.sha }}
           CYPRESS_CACHE_FOLDER: .cache/Cypress
           EAM_API_URL: https://ios.esss.lu.se
@@ -390,5 +397,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: cypress-screenshots
+          name: cypress-screenshots-${{ matrix.pattern.id }}
           path: apps/e2e/cypress/screenshots


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->

Swaps the array of cypress patterns for an array of objects so we can append a neat identifier to the name of the uploaded screenshot archive. This way we when multiple sections of the e2e tests fail, all of them should be able to upload screenshots. At present only the first to fail can, and subsequent failures complain that 

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

Syntax was taken from https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#example-using-a-multi-dimension-matrix


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

In this PR's first run of the tests enough were flaky and failed to give multiple screenshot archive uploads using the new ID's

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Closes UserOfficeProject/issue-tracker#1199
<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
