### PR TITLE
fix: handle undefined preferred_username in OAuthAuthorization

### DIFF
--- a/apps/backend/src/auth/OAuthAuthorization.ts
+++ b/apps/backend/src/auth/OAuthAuthorization.ts
@@ -154,7 +154,7 @@ export class OAuthAuthorization extends UserAuthorization {
         oidcSub: userInfo.sub,
         institutionId: institutionId ?? user.institutionId,
         position: userInfo.position as string,
-        preferredname: userInfo.preferred_username,
+        preferredname: userInfo.preferred_username ?? '',
         telephone: userInfo.phone_number,
         user_title: userInfo.title as string,
       });
@@ -167,7 +167,7 @@ export class OAuthAuthorization extends UserAuthorization {
         undefined,
         userInfo.family_name,
         userInfo.email,
-        userInfo.preferred_username,
+        userInfo.preferred_username ?? '',
         userInfo.sub,
         tokenSet.refresh_token ?? '',
         client.issuer.metadata.issuer,

--- a/apps/backend/src/auth/OAuthAuthorization.ts
+++ b/apps/backend/src/auth/OAuthAuthorization.ts
@@ -154,7 +154,7 @@ export class OAuthAuthorization extends UserAuthorization {
         oidcSub: userInfo.sub,
         institutionId: institutionId ?? user.institutionId,
         position: userInfo.position as string,
-        preferredname: userInfo.preferred_username ?? '',
+        preferredname: userInfo.preferred_username,
         telephone: userInfo.phone_number,
         user_title: userInfo.title as string,
       });


### PR DESCRIPTION
## Description
This PR resolves the issue of handling undefined `preferred_username` in `OAuthAuthorization`.

## Motivation and Context
The change was required because the code was breaking when `preferred_username` was undefined. This PR provides a solution to this problem by setting a default value.

## Changes
The changes introduced in this PR are:
- A default value is set for `preferred_username` in the event that it is undefined. The default value is an empty string.
- This change is implemented in two places within the `OAuthAuthorization` class where `preferred_username` is being utilized.

The above changes ensure the smooth functioning of the code even when `preferred_username` is undefined.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated