### PR TITLE
perf: cache stfc user service requests instead of responses

### DIFF
--- a/apps/backend/src/auth/StfcUserAuthorization.ts
+++ b/apps/backend/src/auth/StfcUserAuthorization.ts
@@ -292,7 +292,7 @@ export class StfcUserAuthorization extends UserAuthorization {
 
     const tokenRequest: Promise<boolean> = client
       .isTokenValid(token)
-      .then((response) => response.return);
+      .then((response) => response?.return);
 
     this.uowsTokenCache.put(token, tokenRequest);
 

--- a/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
@@ -24,8 +24,6 @@ import { ProposalsFilter } from './../../resolvers/queries/ProposalsQuery';
 import PostgresProposalDataSource from './../postgres/ProposalDataSource';
 import { StfcUserDataSource } from './StfcUserDataSource';
 
-const stfcUserDataSource = new StfcUserDataSource();
-
 const fieldMap: { [key: string]: string } = {
   finalStatus: 'final_status',
   callShortCode: 'call_short_code',

--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -1,5 +1,3 @@
-import { logger } from '@user-office-software/duo-logger';
-
 import { Country } from '../../models/Country';
 import { Institution } from '../../models/Institution';
 import { Role, Roles } from '../../models/Role';
@@ -116,7 +114,7 @@ export class StfcUserDataSource implements UserDataSource {
   >(
     StfcUserDataSource.userDetailsCacheMaxElements,
     StfcUserDataSource.userDetailsCacheSecondsToLive
-  ).enableStatsLogging('uowsBasicUserDetailsCache', 30);
+  ).enableStatsLogging('uowsBasicUserDetailsCache');
 
   private uowsSearchableBasicUserDetailsCache = new Cache<
     Promise<StfcBasicPersonDetails | undefined>
@@ -161,7 +159,6 @@ export class StfcUserDataSource implements UserDataSource {
     }
 
     if (cacheMisses.length > 0) {
-      logger.logInfo('Making users request', { users: cacheMisses.length });
       const uowsRequest = searchableOnly
         ? client.getSearchableBasicPeopleDetailsFromUserNumbers(
             token,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Instead of caching responses from the STFC users service, cache the requests. This way if a piece of external data is being requested, and additional requests for it come in while that first one is being made, we don't have to make repeated requests to the external service.

When loading the user officer homepage with empty caches in my local setup, this reduced the number of queries made to get user data from 155 to 56.

I also removed an unnecessary & unused initialisation of the STFC users datsource, which caused unnecessary duplicate cache statistics to be logged. I believe this must have come from merge conflict resolution some time after I got rid of them in #820

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We use a comparitively slow external service to provide user data, and cache responses to improve performance. However, if a piece of data has expired from the caches, it can potentially be requested in multiple places for one or several queries at the same time, resulting in us making unnecessary requests at the same time for the same data. During periods of high load we've often made more simultaneous requests than the external service can handle, resulting in degraded performance or requests failing altogether.

## How Has This Been Tested

A bit of general browsing the site locally, and running queries against logs to check that query loads on the external service are reduced. Otherwise I'm just relying on the test suite in this PR since it's internal refactoring.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Part of https://github.com/UserOfficeProject/issue-tracker/issues/1197
<!--- Does this fix a user story, if so add a reference here -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
