### PR TITLE
perf: fetch less data on the get faps query

### DIFF
--- a/apps/frontend/src/components/fap/FapsTable.tsx
+++ b/apps/frontend/src/components/fap/FapsTable.tsx
@@ -11,14 +11,14 @@ import SuperMaterialTable from 'components/common/SuperMaterialTable';
 import FapStatusFilter, { FapStatus } from 'components/fap/FapStatusFilter';
 import AddFap from 'components/fap/General/AddFap';
 import { UserContext } from 'context/UserContextProvider';
-import { Fap, UserRole } from 'generated/sdk';
+import { Fap, FapMinimalFragment, UserRole } from 'generated/sdk';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
 import { useFapsData } from 'hooks/fap/useFapsData';
 import { tableIcons } from 'utils/materialIcons';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 import { FunctionType } from 'utils/utilTypes';
 
-const columns: Column<Fap>[] = [
+const columns: Column<FapMinimalFragment>[] = [
   {
     title: 'Code',
     field: 'code',
@@ -105,9 +105,9 @@ const FapsTable = () => {
   };
 
   const createModal = (
-    onUpdate: FunctionType<void, [Fap | null]>,
-    onCreate: FunctionType<void, [Fap | null]>,
-    editFap: Fap | null
+    onUpdate: FunctionType<void, [FapMinimalFragment | null]>,
+    onCreate: FunctionType<void, [FapMinimalFragment | null]>,
+    editFap: FapMinimalFragment | null
   ) => {
     if (!!editFap) {
       setEditFapID(editFap.id);
@@ -116,7 +116,7 @@ const FapsTable = () => {
     } else {
       return (
         <AddFap
-          close={(fapAdded: Fap | null | undefined) => {
+          close={(fapAdded: FapMinimalFragment | null | undefined) => {
             setTimeout(() => {
               navigate(`/FapPage/${fapAdded?.id}`);
             });

--- a/apps/frontend/src/graphql/fap/fragment.fapMinimal.graphql
+++ b/apps/frontend/src/graphql/fap/fragment.fapMinimal.graphql
@@ -1,0 +1,7 @@
+fragment fapMinimal on Fap {
+  id
+  code
+  description
+  active
+  proposalCurrentCount
+}

--- a/apps/frontend/src/graphql/fap/getFaps.graphql
+++ b/apps/frontend/src/graphql/fap/getFaps.graphql
@@ -1,8 +1,0 @@
-query getFaps($filter: FapsFilter) {
-  faps(filter: $filter) {
-    faps {
-      ...fap
-    }
-    totalCount
-  }
-}

--- a/apps/frontend/src/graphql/fap/getFapsMinimal.graphql
+++ b/apps/frontend/src/graphql/fap/getFapsMinimal.graphql
@@ -1,0 +1,8 @@
+query getFapsMinimal($filter: FapsFilter) {
+  faps(filter: $filter) {
+    faps {
+      ...fapMinimal
+    }
+    totalCount
+  }
+}

--- a/apps/frontend/src/graphql/fap/getMemberFaps.graphql
+++ b/apps/frontend/src/graphql/fap/getMemberFaps.graphql
@@ -1,7 +1,7 @@
 query getUserFaps {
   me {
     faps {
-      ...fap
+      ...fapMinimal
     }
   }
 }

--- a/apps/frontend/src/hooks/fap/useFapsData.ts
+++ b/apps/frontend/src/hooks/fap/useFapsData.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, Dispatch, SetStateAction } from 'react';
 
-import { Fap, UserRole } from 'generated/sdk';
+import { FapMinimalFragment, UserRole } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 
 export function useFapsData({
@@ -15,14 +15,14 @@ export function useFapsData({
   callIds?: number[];
 }): {
   loadingFaps: boolean;
-  faps: Fap[];
-  setFapsWithLoading: Dispatch<SetStateAction<Fap[]>>;
+  faps: FapMinimalFragment[];
+  setFapsWithLoading: Dispatch<SetStateAction<FapMinimalFragment[]>>;
 } {
   const api = useDataApi();
-  const [faps, setFaps] = useState<Fap[]>([]);
+  const [faps, setFaps] = useState<FapMinimalFragment[]>([]);
   const [loadingFaps, setLoadingFaps] = useState(true);
 
-  const setFapsWithLoading = (data: SetStateAction<Fap[]>) => {
+  const setFapsWithLoading = (data: SetStateAction<FapMinimalFragment[]>) => {
     setLoadingFaps(true);
     setFaps(data);
     setLoadingFaps(false);
@@ -35,7 +35,7 @@ export function useFapsData({
 
     if (role === UserRole.USER_OFFICER) {
       api()
-        .getFaps({
+        .getFapsMinimal({
           filter: {
             filter,
             active,
@@ -51,7 +51,7 @@ export function useFapsData({
             setFaps(
               data.faps.faps.map((fap) => {
                 return {
-                  ...fap,
+                  ...(fap as FapMinimalFragment),
                 };
               })
             );
@@ -70,7 +70,7 @@ export function useFapsData({
             setFaps(
               data.me.faps.map((fap) => {
                 return {
-                  ...fap,
+                  ...(fap as FapMinimalFragment),
                 };
               })
             );


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1098


## Description
This PR optimizes the 'get faps' query by fetching only the necessary data, improving the performance of the application. For the first pass at this issue, I saw that the `useFapsData` hook is only ever used to get a very small amount of FAP data so I have modified it to only request a much smaller subset of FAP data. In the future if we may a query that gets all the FAP data but I think we should then implement a separate query for that that get exactly the data it needs. 

Here is a table of what `useFapsData` used to fetch and what of that data was used:
![image](https://github.com/user-attachments/assets/eb93e4c4-6cce-499c-99a0-318e84d5b881)


## Motivation and Context
The 'get faps' query was fetching excessive data, leading to slower performance. To improve the speed and efficiency of our application, it was necessary to limit the data fetched by this query.

## Changes
1. Introduced a new `FapMinimalFragment` replacing `Fap` in multiple places, including function parameters and state variables.
2. Created a new GraphQL fragment `fapMinimal` that fetches only the essential fields from the Fap object.
3. Updated the `getFaps` query to `getFapsMinimal` to fetch less data, improving performance.
4. Modified the `useFapsData` hook to work with the new `FapMinimalFragment` and the optimized query.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated