### PR TITLE
feat: add option to export xpress proposals

### DIFF
--- a/apps/backend/src/factory/DownloadService.ts
+++ b/apps/backend/src/factory/DownloadService.ts
@@ -17,7 +17,7 @@ export enum XLSXType {
   PROPOSAL = 'proposal',
   FAP = 'fap',
   CALL_FAP = 'call_fap',
-  XPRESS_PROPOSAL = 'xpressProposal',
+  TECHNIQUE = 'technique',
 }
 
 export enum PDFType {

--- a/apps/backend/src/factory/DownloadService.ts
+++ b/apps/backend/src/factory/DownloadService.ts
@@ -17,6 +17,7 @@ export enum XLSXType {
   PROPOSAL = 'proposal',
   FAP = 'fap',
   CALL_FAP = 'call_fap',
+  XPRESS_PROPOSAL = 'xpressProposal',
 }
 
 export enum PDFType {

--- a/apps/backend/src/factory/xlsx/proposal.ts
+++ b/apps/backend/src/factory/xlsx/proposal.ts
@@ -4,9 +4,20 @@ import {
 } from '@user-office-software/duo-localisation';
 
 import baseContext from '../../buildContext';
+import { Call } from '../../models/Call';
+import { Instrument } from '../../models/Instrument';
+import { PdfTemplate } from '../../models/PdfTemplate';
 import { ProposalEndStatus } from '../../models/Proposal';
+import { getTopicActiveAnswers } from '../../models/ProposalModelFunctions';
+import { Answer } from '../../models/Questionary';
 import { TechnicalReviewStatus } from '../../models/TechnicalReview';
+import { DataType } from '../../models/Template';
 import { UserWithRole } from '../../models/User';
+import { InstrumentPickerConfig } from '../../resolvers/types/FieldConfig';
+import { collectGenericTemplatePDFData } from '../pdf/genericTemplates';
+import { ProposalPDFData } from '../pdf/proposal';
+import { collectSamplePDFData } from '../pdf/sample';
+import { Attachment, getFileAttachments } from '../util';
 
 type ProposalXLSData = Array<string | number>;
 
@@ -94,4 +105,251 @@ export const collectProposalXLSXData = async (
     proposal.commentForManagement || '<missing>',
     ProposalEndStatus[proposal.finalStatus] ?? '<missing>',
   ];
+};
+
+export const collectEnhancedProposalXLSXData = async (
+  proposalPk: number,
+  user: UserWithRole,
+  notify?: CallableFunction
+): Promise<ProposalXLSData> => {
+  const proposal = await baseContext.queries.proposal.get(user, proposalPk);
+
+  if (!proposal) {
+    throw new Error(
+      `Proposal with ID '${proposalPk}' not found, or the user has insufficient rights`
+    );
+  }
+
+  const principalInvestigator = await baseContext.queries.user.getBasic(
+    user,
+    proposal.proposerId
+  );
+
+  if (!principalInvestigator) {
+    throw new Error(
+      `Proposal with ID '${principalInvestigator}' not found, or the user has insufficient rights`
+    );
+  }
+
+  notify?.(
+    `proposal_${proposal.created.getUTCFullYear()}_${proposal.proposalId}.xlsx`
+  );
+
+  const proposer = await baseContext.queries.user.get(
+    user,
+    proposal.proposerId
+  );
+
+  if (!proposer) {
+    throw new Error(
+      `Proposer with ID '${proposal.proposerId}' not found, or the user has insufficient rights`
+    );
+  }
+
+  const instruments =
+    await baseContext.queries.instrument.getInstrumentsByProposalPk(
+      user,
+      proposal.primaryKey
+    );
+
+  const call = await baseContext.queries.call.get(user, proposal.callId);
+
+  /*
+   * Because naming things is hard, the PDF template ID is the templateId for
+   * for the PdfTemplate and not the pdfTemplateId.
+   */
+  const pdfTemplateId = call?.pdfTemplateId;
+  let pdfTemplate: PdfTemplate | null = null;
+  if (pdfTemplateId !== undefined) {
+    pdfTemplate = (
+      await baseContext.queries.pdfTemplate.getPdfTemplates(user, {
+        filter: {
+          templateIds: [pdfTemplateId],
+        },
+      })
+    )[0];
+  }
+
+  const sampleAttachments: Attachment[] = [];
+
+  const samples = await baseContext.queries.sample.getSamples(user, {
+    filter: { proposalPk },
+  });
+
+  const samplePDFData = (
+    await Promise.all(
+      samples.map((sample) => collectSamplePDFData(sample.id, user))
+    )
+  ).map(({ sample, sampleQuestionaryFields, attachments }) => {
+    sampleAttachments.push(...attachments);
+
+    return { sample, sampleQuestionaryFields };
+  });
+
+  const genericTemplateAttachments: Attachment[] = [];
+
+  const genericTemplates =
+    await baseContext.queries.genericTemplate.getGenericTemplates(user, {
+      filter: { proposalPk },
+    });
+
+  const genericTemplatePDFData = (
+    await Promise.all(
+      genericTemplates.map((genericTemplate) =>
+        collectGenericTemplatePDFData(genericTemplate.id, user)
+      )
+    )
+  ).map(
+    ({ genericTemplate, genericTemplateQuestionaryFields, attachments }) => {
+      genericTemplateAttachments.push(...attachments);
+
+      return { genericTemplate, genericTemplateQuestionaryFields };
+    }
+  );
+
+  const out: ProposalPDFData = {
+    proposal,
+    questionarySteps: [],
+    attachments: [],
+    technicalReviews: [],
+    samples: samplePDFData,
+    genericTemplates: genericTemplatePDFData,
+    pdfTemplate,
+    coProposers: [],
+    principalInvestigator,
+  };
+
+  const queries = baseContext.queries.questionary;
+
+  const questionarySteps = await queries.getQuestionarySteps(
+    user,
+    proposal.questionaryId
+  );
+
+  if (questionarySteps == null) {
+    throw new Error('Could not fetch questionary');
+  }
+
+  // Information from each topic in proposal
+  for (const step of questionarySteps) {
+    if (!step) {
+      throw 'Could not download generated PDF';
+    }
+
+    const topic = step.topic;
+    const answers = getTopicActiveAnswers(questionarySteps, topic.id).filter(
+      // skip `PROPOSAL_BASIS` types
+      (answer) => answer.question.dataType !== DataType.PROPOSAL_BASIS
+    );
+
+    // if the questionary step has nothing else but `PROPOSAL_BASIS` question
+    // skip the whole step because the first page already has every related information
+    if (answers.length === 0) {
+      continue;
+    }
+
+    const questionaryAttachments: Attachment[] = [];
+
+    for (let i = 0; i < answers.length; i++) {
+      const answer = answers[i];
+
+      questionaryAttachments.push(...getFileAttachments(answer));
+
+      if (answer.question.dataType === DataType.SAMPLE_DECLARATION) {
+        answer.value = samples
+          .filter((sample) => sample.questionId === answer.question.id)
+          .map((sample) => sample);
+      } else if (answer.question.dataType === DataType.GENERIC_TEMPLATE) {
+        answer.value = genericTemplates
+          .filter(
+            (genericTemplate) =>
+              genericTemplate.questionId === answer.question.id
+          )
+          .map((genericTemplate) => genericTemplate);
+      } else if (answer.question.dataType === DataType.INSTRUMENT_PICKER) {
+        const ids = Array.isArray(answer.value)
+          ? answer.value.map((v: { instrumentId: string }) =>
+              Number(v.instrumentId)
+            )
+          : [Number(answer.value?.instrumentId || '0')];
+        const instruments =
+          await baseContext.queries.instrument.getInstrumentsByIds(user, ids);
+        const call = await baseContext.queries.call.getCallByQuestionId(
+          user,
+          answer.question.id
+        );
+        answer.value = instrumentPickerAnswer(answer, instruments, call);
+      } else if (answer.question.dataType === DataType.TECHNIQUE_PICKER) {
+        const techniqueIds = Array.isArray(answer.value)
+          ? answer.value
+          : [answer.value];
+        const techniques =
+          await baseContext.queries.technique.getTechniquesByIds(
+            user,
+            techniqueIds
+          );
+        answer.value = techniques?.length
+          ? techniques.map((technique) => technique.name).join(', ')
+          : '';
+      }
+    }
+
+    out.questionarySteps.push({
+      ...step,
+      fields: answers,
+    });
+    out.attachments.push(...questionaryAttachments);
+    out.attachments.push(...sampleAttachments);
+    out.attachments.push(...genericTemplateAttachments);
+  }
+
+  return [
+    proposal.title,
+    proposal.proposalId,
+    `${proposer.firstname} ${proposer.lastname}`,
+    instruments.length
+      ? instruments
+          .map((instrument) => instrument.name ?? '<missing>')
+          .join(', ')
+      : '<missing>',
+    ProposalEndStatus[proposal.finalStatus] ?? '<missing>',
+  ];
+};
+
+const instrumentPickerAnswer = (
+  answer: Answer,
+  instruments: Instrument[],
+  call: Call
+): string => {
+  const instrumentPickerConfig = answer.config as InstrumentPickerConfig;
+  if (instrumentPickerConfig.requestTime) {
+    const instrumentWithTime = instruments?.map((i) => {
+      const filtered = Array.isArray(answer.value)
+        ? answer.value.find(
+            (v: {
+              instrumentId: string;
+              instrumentName: string;
+              timeRequested: number;
+            }) => Number(v.instrumentId) == i.id
+          )
+        : answer.value;
+
+      return (
+        i.name +
+        ' (' +
+        filtered.timeRequested +
+        ' ' +
+        call.allocationTimeUnit +
+        ') '
+      );
+    });
+
+    return instrumentWithTime?.join(', ');
+  } else {
+    const instrumentWithTime = instruments?.length
+      ? instruments.map((instrument) => instrument.name).join(', ')
+      : '';
+
+    return instrumentWithTime;
+  }
 };

--- a/apps/backend/src/factory/xlsx/proposal.ts
+++ b/apps/backend/src/factory/xlsx/proposal.ts
@@ -4,20 +4,9 @@ import {
 } from '@user-office-software/duo-localisation';
 
 import baseContext from '../../buildContext';
-import { Call } from '../../models/Call';
-import { Instrument } from '../../models/Instrument';
-import { PdfTemplate } from '../../models/PdfTemplate';
 import { ProposalEndStatus } from '../../models/Proposal';
-import { getTopicActiveAnswers } from '../../models/ProposalModelFunctions';
-import { Answer } from '../../models/Questionary';
 import { TechnicalReviewStatus } from '../../models/TechnicalReview';
-import { DataType } from '../../models/Template';
 import { UserWithRole } from '../../models/User';
-import { InstrumentPickerConfig } from '../../resolvers/types/FieldConfig';
-import { collectGenericTemplatePDFData } from '../pdf/genericTemplates';
-import { ProposalPDFData } from '../pdf/proposal';
-import { collectSamplePDFData } from '../pdf/sample';
-import { Attachment, getFileAttachments } from '../util';
 
 type ProposalXLSData = Array<string | number>;
 
@@ -107,7 +96,7 @@ export const collectProposalXLSXData = async (
   ];
 };
 
-export const collectEnhancedProposalXLSXData = async (
+export const collectTechniqueProposalXLSXData = async (
   proposalPk: number,
   user: UserWithRole,
   notify?: CallableFunction
@@ -117,17 +106,6 @@ export const collectEnhancedProposalXLSXData = async (
   if (!proposal) {
     throw new Error(
       `Proposal with ID '${proposalPk}' not found, or the user has insufficient rights`
-    );
-  }
-
-  const principalInvestigator = await baseContext.queries.user.getBasic(
-    user,
-    proposal.proposerId
-  );
-
-  if (!principalInvestigator) {
-    throw new Error(
-      `Proposal with ID '${principalInvestigator}' not found, or the user has insufficient rights`
     );
   }
 
@@ -152,204 +130,33 @@ export const collectEnhancedProposalXLSXData = async (
       proposal.primaryKey
     );
 
-  const call = await baseContext.queries.call.get(user, proposal.callId);
-
-  /*
-   * Because naming things is hard, the PDF template ID is the templateId for
-   * for the PdfTemplate and not the pdfTemplateId.
-   */
-  const pdfTemplateId = call?.pdfTemplateId;
-  let pdfTemplate: PdfTemplate | null = null;
-  if (pdfTemplateId !== undefined) {
-    pdfTemplate = (
-      await baseContext.queries.pdfTemplate.getPdfTemplates(user, {
-        filter: {
-          templateIds: [pdfTemplateId],
-        },
-      })
-    )[0];
-  }
-
-  const sampleAttachments: Attachment[] = [];
-
-  const samples = await baseContext.queries.sample.getSamples(user, {
-    filter: { proposalPk },
-  });
-
-  const samplePDFData = (
-    await Promise.all(
-      samples.map((sample) => collectSamplePDFData(sample.id, user))
-    )
-  ).map(({ sample, sampleQuestionaryFields, attachments }) => {
-    sampleAttachments.push(...attachments);
-
-    return { sample, sampleQuestionaryFields };
-  });
-
-  const genericTemplateAttachments: Attachment[] = [];
-
-  const genericTemplates =
-    await baseContext.queries.genericTemplate.getGenericTemplates(user, {
-      filter: { proposalPk },
-    });
-
-  const genericTemplatePDFData = (
-    await Promise.all(
-      genericTemplates.map((genericTemplate) =>
-        collectGenericTemplatePDFData(genericTemplate.id, user)
-      )
-    )
-  ).map(
-    ({ genericTemplate, genericTemplateQuestionaryFields, attachments }) => {
-      genericTemplateAttachments.push(...attachments);
-
-      return { genericTemplate, genericTemplateQuestionaryFields };
-    }
-  );
-
-  const out: ProposalPDFData = {
-    proposal,
-    questionarySteps: [],
-    attachments: [],
-    technicalReviews: [],
-    samples: samplePDFData,
-    genericTemplates: genericTemplatePDFData,
-    pdfTemplate,
-    coProposers: [],
-    principalInvestigator,
-  };
-
-  const queries = baseContext.queries.questionary;
-
-  const questionarySteps = await queries.getQuestionarySteps(
-    user,
-    proposal.questionaryId
-  );
-
-  if (questionarySteps == null) {
-    throw new Error('Could not fetch questionary');
-  }
-
-  // Information from each topic in proposal
-  for (const step of questionarySteps) {
-    if (!step) {
-      throw 'Could not download generated PDF';
-    }
-
-    const topic = step.topic;
-    const answers = getTopicActiveAnswers(questionarySteps, topic.id).filter(
-      // skip `PROPOSAL_BASIS` types
-      (answer) => answer.question.dataType !== DataType.PROPOSAL_BASIS
+  const techniques =
+    await baseContext.queries.technique.getTechniquesByProposalPk(
+      user,
+      proposal.primaryKey
     );
 
-    // if the questionary step has nothing else but `PROPOSAL_BASIS` question
-    // skip the whole step because the first page already has every related information
-    if (answers.length === 0) {
-      continue;
-    }
+  const submittedDate = proposal.submittedDate
+    ? proposal.submittedDate.toLocaleString()
+    : '';
 
-    const questionaryAttachments: Attachment[] = [];
-
-    for (let i = 0; i < answers.length; i++) {
-      const answer = answers[i];
-
-      questionaryAttachments.push(...getFileAttachments(answer));
-
-      if (answer.question.dataType === DataType.SAMPLE_DECLARATION) {
-        answer.value = samples
-          .filter((sample) => sample.questionId === answer.question.id)
-          .map((sample) => sample);
-      } else if (answer.question.dataType === DataType.GENERIC_TEMPLATE) {
-        answer.value = genericTemplates
-          .filter(
-            (genericTemplate) =>
-              genericTemplate.questionId === answer.question.id
-          )
-          .map((genericTemplate) => genericTemplate);
-      } else if (answer.question.dataType === DataType.INSTRUMENT_PICKER) {
-        const ids = Array.isArray(answer.value)
-          ? answer.value.map((v: { instrumentId: string }) =>
-              Number(v.instrumentId)
-            )
-          : [Number(answer.value?.instrumentId || '0')];
-        const instruments =
-          await baseContext.queries.instrument.getInstrumentsByIds(user, ids);
-        const call = await baseContext.queries.call.getCallByQuestionId(
-          user,
-          answer.question.id
-        );
-        answer.value = instrumentPickerAnswer(answer, instruments, call);
-      } else if (answer.question.dataType === DataType.TECHNIQUE_PICKER) {
-        const techniqueIds = Array.isArray(answer.value)
-          ? answer.value
-          : [answer.value];
-        const techniques =
-          await baseContext.queries.technique.getTechniquesByIds(
-            user,
-            techniqueIds
-          );
-        answer.value = techniques?.length
-          ? techniques.map((technique) => technique.name).join(', ')
-          : '';
-      }
-    }
-
-    out.questionarySteps.push({
-      ...step,
-      fields: answers,
-    });
-    out.attachments.push(...questionaryAttachments);
-    out.attachments.push(...sampleAttachments);
-    out.attachments.push(...genericTemplateAttachments);
-  }
+  const status = await baseContext.queries.proposalSettings.getProposalStatus(
+    user,
+    proposal.statusId
+  );
 
   return [
-    proposal.title,
     proposal.proposalId,
+    proposal.title,
     `${proposer.firstname} ${proposer.lastname}`,
+    proposer.email,
+    submittedDate,
+    techniques.length
+      ? techniques.map((technique) => technique.name ?? '').join(', ')
+      : '',
     instruments.length
-      ? instruments
-          .map((instrument) => instrument.name ?? '<missing>')
-          .join(', ')
-      : '<missing>',
-    ProposalEndStatus[proposal.finalStatus] ?? '<missing>',
+      ? instruments.map((instrument) => instrument.name ?? '').join(', ')
+      : '',
+    status?.name ?? '',
   ];
-};
-
-const instrumentPickerAnswer = (
-  answer: Answer,
-  instruments: Instrument[],
-  call: Call
-): string => {
-  const instrumentPickerConfig = answer.config as InstrumentPickerConfig;
-  if (instrumentPickerConfig.requestTime) {
-    const instrumentWithTime = instruments?.map((i) => {
-      const filtered = Array.isArray(answer.value)
-        ? answer.value.find(
-            (v: {
-              instrumentId: string;
-              instrumentName: string;
-              timeRequested: number;
-            }) => Number(v.instrumentId) == i.id
-          )
-        : answer.value;
-
-      return (
-        i.name +
-        ' (' +
-        filtered.timeRequested +
-        ' ' +
-        call.allocationTimeUnit +
-        ') '
-      );
-    });
-
-    return instrumentWithTime?.join(', ');
-  } else {
-    const instrumentWithTime = instruments?.length
-      ? instruments.map((instrument) => instrument.name).join(', ')
-      : '';
-
-    return instrumentWithTime;
-  }
 };

--- a/apps/backend/src/middlewares/factory/xlsx.ts
+++ b/apps/backend/src/middlewares/factory/xlsx.ts
@@ -16,8 +16,8 @@ import {
 } from '../../factory/xlsx/callFaps';
 import { collectFapXLSXData } from '../../factory/xlsx/fap';
 import {
-  collectEnhancedProposalXLSXData,
   collectProposalXLSXData,
+  collectTechniqueProposalXLSXData,
   defaultProposalDataColumns,
 } from '../../factory/xlsx/proposal';
 
@@ -172,71 +172,71 @@ router.get(`/${XLSXType.CALL_FAP}/:call_id`, async (req, res, next) => {
   }
 });
 
-router.get(
-  `/${XLSXType.XPRESS_PROPOSAL}/:proposal_pks`,
-  async (req, res, next) => {
-    const xpressProposalDataColumns = [
-      'Title',
-      'Proposal ID',
-      'Principal Investigator',
-      'Instrument',
-      'Status',
-    ];
+router.get(`/${XLSXType.TECHNIQUE}/:proposal_pks`, async (req, res, next) => {
+  const techniqueProposalDataColumns = [
+    'Proposal ID',
+    'Title',
+    'Principal Investigator',
+    'PI Email',
+    'Date Submitted',
+    'Technique',
+    'Instrument',
+    'Status',
+  ];
 
-    try {
-      if (!req.user) {
-        throw new Error('Not authorized');
-      }
-
-      const userWithRole = {
-        ...req.user.user,
-        currentRole: req.user.currentRole,
-      };
-
-      const proposalPks: number[] = req.params.proposal_pks
-        .split(',')
-        .map((n: string) => parseInt(n))
-        .filter((id: number) => !isNaN(id));
-
-      const userAuthorization = container.resolve<UserAuthorization>(
-        Tokens.UserAuthorization
-      );
-
-      if (!userAuthorization.isUserOfficer(userWithRole)) {
-        throw new Error('User has insufficient rights');
-      }
-      const meta: XLSXMetaBase = {
-        singleFilename: '',
-        collectionFilename: `proposals_${getCurrentTimestamp()}.xlsx`,
-        columns: xpressProposalDataColumns,
-      };
-
-      const data = await Promise.all(
-        proposalPks.map((proposalPk, indx) =>
-          collectEnhancedProposalXLSXData(
-            proposalPk,
-            userWithRole,
-            indx === 0
-              ? (filename: string) => (meta.singleFilename = filename)
-              : undefined
-          )
-        )
-      );
-
-      const userRole = req.user.currentRole;
-      downloadService.callFactoryService(
-        DownloadType.XLSX,
-        XLSXType.PROPOSAL,
-        { data, meta, userRole },
-        req,
-        res,
-        next
-      );
-    } catch (e) {
-      next(e);
+  try {
+    if (!req.user) {
+      throw new Error('Not authorized');
     }
+
+    const userWithRole = {
+      ...req.user.user,
+      currentRole: req.user.currentRole,
+    };
+
+    const proposalPks: number[] = req.params.proposal_pks
+      .split(',')
+      .map((n: string) => parseInt(n))
+      .filter((id: number) => !isNaN(id));
+
+    const userAuthorization = container.resolve<UserAuthorization>(
+      Tokens.UserAuthorization
+    );
+
+    if (!userAuthorization.isUserOfficer(userWithRole)) {
+      throw new Error('User has insufficient rights');
+    }
+    const meta: XLSXMetaBase = {
+      singleFilename: '',
+      collectionFilename: `proposals_${getCurrentTimestamp()}.xlsx`,
+      columns: techniqueProposalDataColumns,
+    };
+
+    const data = await Promise.all(
+      proposalPks.map((proposalPk, indx) =>
+        collectTechniqueProposalXLSXData(
+          proposalPk,
+          userWithRole,
+          indx === 0
+            ? (filename: string) => (meta.singleFilename = filename)
+            : undefined
+        )
+      )
+    );
+
+    const userRole = req.user.currentRole;
+    downloadService.callFactoryService(
+      DownloadType.XLSX,
+      XLSXType.PROPOSAL,
+      { data, meta, userRole },
+      req,
+      res,
+      next
+    );
+  } catch (e) {
+    next(e);
   }
-);
+});
 
 export default function xlsxDownload() {
   return router;

--- a/apps/backend/src/middlewares/factory/xlsx.ts
+++ b/apps/backend/src/middlewares/factory/xlsx.ts
@@ -203,7 +203,10 @@ router.get(`/${XLSXType.TECHNIQUE}/:proposal_pks`, async (req, res, next) => {
       Tokens.UserAuthorization
     );
 
-    if (!userAuthorization.isUserOfficer(userWithRole)) {
+    if (
+      !userAuthorization.isUserOfficer(userWithRole) &&
+      !userAuthorization.isInstrumentScientist(userWithRole)
+    ) {
       throw new Error('User has insufficient rights');
     }
     const meta: XLSXMetaBase = {

--- a/apps/e2e/cypress/e2e/xpress.cy.ts
+++ b/apps/e2e/cypress/e2e/xpress.cy.ts
@@ -791,6 +791,50 @@ context('Xpress tests', () => {
 
       cy.readFile(`${downloadsFolder}/${downloadedFileName}`).should('exist');
     });
+
+    it('Officer should be able to use the view proposal option', function () {
+      cy.login('officer');
+      cy.visit('/');
+      cy.finishedLoading();
+
+      cy.contains('Xpress Proposals').click();
+
+      cy.contains(proposal1.title)
+        .parent()
+        .find('[aria-label="View proposal"]')
+        .click();
+
+      cy.finishedLoading();
+
+      cy.contains(proposal1.title);
+      cy.contains(proposal1.abstract);
+      cy.contains(createdProposalId1);
+      cy.contains(technique1.name);
+
+      cy.get('button[role="tab"]').contains('Logs').click({ force: true });
+      cy.contains('PROPOSAL_CREATED');
+      cy.contains('PROPOSAL_UPDATED');
+      cy.contains('PROPOSAL_ASSIGNED_TO_TECHNIQUES');
+    });
+
+    it('Scientist should be able to use the view proposal option', function () {
+      cy.login(scientist1);
+      cy.changeActiveRole(initialDBData.roles.instrumentScientist);
+      cy.visit('/');
+      cy.finishedLoading();
+
+      cy.contains('Xpress Proposals').click();
+
+      cy.contains(proposal1.title)
+        .parent()
+        .find('[aria-label="View proposal"]')
+        .click();
+
+      cy.contains(proposal1.title);
+      cy.contains(proposal1.abstract);
+      cy.contains(createdProposalId1);
+      cy.contains(technique1.name);
+    });
   });
 
   describe('Techniques advanced tests', () => {

--- a/apps/e2e/cypress/e2e/xpress.cy.ts
+++ b/apps/e2e/cypress/e2e/xpress.cy.ts
@@ -748,6 +748,49 @@ context('Xpress tests', () => {
       );
       cy.get('input[aria-label="Search"]').focus().clear();
     });
+
+    it('Officer should be able to export the proposals into excel', function () {
+      cy.login('officer');
+      cy.visit('/');
+      cy.finishedLoading();
+
+      cy.contains('Xpress Proposals').click();
+
+      cy.contains(proposal1.title)
+        .parent()
+        .find('input[type="checkbox"]')
+        .check();
+
+      cy.get("[aria-label='Export proposals in Excel']").first().click();
+
+      const downloadsFolder = Cypress.config('downloadsFolder');
+      const currentYear = new Date().getFullYear();
+      const downloadedFileName = `proposal_${currentYear}_${createdProposalId1}.xlsx`;
+
+      cy.readFile(`${downloadsFolder}/${downloadedFileName}`).should('exist');
+    });
+
+    it('Scientist should be able to export the proposals into excel', function () {
+      cy.login(scientist1);
+      cy.changeActiveRole(initialDBData.roles.instrumentScientist);
+      cy.visit('/');
+      cy.finishedLoading();
+
+      cy.contains('Xpress Proposals').click();
+
+      cy.contains(proposal1.title)
+        .parent()
+        .find('input[type="checkbox"]')
+        .check();
+
+      cy.get("[aria-label='Export proposals in Excel']").first().click();
+
+      const downloadsFolder = Cypress.config('downloadsFolder');
+      const currentYear = new Date().getFullYear();
+      const downloadedFileName = `proposal_${currentYear}_${createdProposalId1}.xlsx`;
+
+      cy.readFile(`${downloadsFolder}/${downloadedFileName}`).should('exist');
+    });
   });
 
   describe('Techniques advanced tests', () => {

--- a/apps/frontend/src/components/xpress/XpressProposalTable.tsx
+++ b/apps/frontend/src/components/xpress/XpressProposalTable.tsx
@@ -421,7 +421,8 @@ const XpressProposalTable = () => {
                       .getAll('selection')
                       .filter((item): item is string => !!item)
                       .map((item) => +item),
-                    'title'
+                    'title',
+                    true
                   );
                 },
                 position: 'toolbarOnSelect',

--- a/apps/frontend/src/components/xpress/XpressProposalTable.tsx
+++ b/apps/frontend/src/components/xpress/XpressProposalTable.tsx
@@ -4,6 +4,7 @@ import MaterialTableCore, {
   Query,
   QueryResult,
 } from '@material-table/core';
+import GridOnIcon from '@mui/icons-material/GridOn';
 import { FormControl, MenuItem, Select } from '@mui/material';
 import {
   getTranslation,
@@ -17,6 +18,7 @@ import { useSearchParams } from 'react-router-dom';
 import { UserContext } from 'context/UserContextProvider';
 import { ProposalsFilter, UserRole } from 'generated/sdk';
 import { CallsDataQuantity, useCallsData } from 'hooks/call/useCallsData';
+import { useDownloadXLSXProposal } from 'hooks/proposal/useDownloadXLSXProposal';
 import { ProposalViewData } from 'hooks/proposal/useProposalsCoreData';
 import { useProposalStatusesData } from 'hooks/settings/useProposalStatusesData';
 import { useTechniquesData } from 'hooks/technique/useTechniquesData';
@@ -365,6 +367,9 @@ const XpressProposalTable = () => {
     });
   };
 
+  const ExportIcon = (): JSX.Element => <GridOnIcon />;
+  const downloadXLSXProposal = useDownloadXLSXProposal();
+
   return (
     <>
       <StyledContainer maxWidth={false}>
@@ -406,6 +411,22 @@ const XpressProposalTable = () => {
               pageSize: pageSize ? +pageSize : 5,
               initialPage: page ? +page : 0,
             }}
+            actions={[
+              {
+                icon: ExportIcon,
+                tooltip: 'Export proposals in Excel',
+                onClick: (): void => {
+                  downloadXLSXProposal(
+                    searchParams
+                      .getAll('selection')
+                      .filter((item): item is string => !!item)
+                      .map((item) => +item),
+                    'title'
+                  );
+                },
+                position: 'toolbarOnSelect',
+              },
+            ]}
             onSelectionChange={(selectedItems) => {
               setSearchParams((searchParam) => {
                 searchParam.delete('selection');

--- a/apps/frontend/src/components/xpress/XpressProposalTable.tsx
+++ b/apps/frontend/src/components/xpress/XpressProposalTable.tsx
@@ -382,11 +382,12 @@ const XpressProposalTable = () => {
     const {
       callId,
       instrumentFilter,
+      techniqueFilter,
       proposalStatusId,
-      questionaryIds,
       text,
-      questionFilter,
       referenceNumbers,
+      dateFilter,
+      excludeProposalStatusIds,
     } = proposalFilter;
 
     const result: {
@@ -399,15 +400,15 @@ const XpressProposalTable = () => {
         filter: {
           callId: callId,
           instrumentFilter: instrumentFilter,
+          techniqueFilter: techniqueFilter,
           proposalStatusId: proposalStatusId,
-          questionaryIds: questionaryIds,
-          referenceNumbers: referenceNumbers,
-          questionFilter: questionFilter && {
-            ...questionFilter,
-            value:
-              JSON.stringify({ value: questionFilter?.value }) ?? undefined,
-          }, // We wrap the value in JSON formatted string, because GraphQL can not handle UnionType input
           text: text,
+          referenceNumbers: referenceNumbers,
+          dateFilter: dateFilter,
+          ...(currentRole === UserRole.INSTRUMENT_SCIENTIST ||
+          currentRole === UserRole.INTERNAL_REVIEWER
+            ? { excludeProposalStatusIds: excludeProposalStatusIds }
+            : {}),
         },
         searchText: searchParams.get('search'),
       })

--- a/apps/frontend/src/context/DownloadContextProvider.tsx
+++ b/apps/frontend/src/context/DownloadContextProvider.tsx
@@ -115,7 +115,7 @@ export enum PREPARE_DOWNLOAD_TYPE {
   XLSX_PROPOSAL,
   XLSX_FAP,
   XLSX_CALL_FAP,
-  XLSX_XPRESS_PROPOSAL,
+  XLSX_PROPOSAL_TECHNIQUE,
 }
 
 export type DownloadOptions = {
@@ -154,8 +154,8 @@ function generateLink(
       return '/download/pdf/generic-template/' + ids;
     case PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL:
       return '/download/xlsx/proposal/' + ids;
-    case PREPARE_DOWNLOAD_TYPE.XLSX_XPRESS_PROPOSAL:
-      return '/download/xlsx/xpressProposal/' + ids;
+    case PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL_TECHNIQUE:
+      return '/download/xlsx/technique/' + ids;
     case PREPARE_DOWNLOAD_TYPE.XLSX_CALL_FAP:
       return '/download/xlsx/call_fap/' + ids;
     case PREPARE_DOWNLOAD_TYPE.XLSX_FAP:

--- a/apps/frontend/src/context/DownloadContextProvider.tsx
+++ b/apps/frontend/src/context/DownloadContextProvider.tsx
@@ -115,6 +115,7 @@ export enum PREPARE_DOWNLOAD_TYPE {
   XLSX_PROPOSAL,
   XLSX_FAP,
   XLSX_CALL_FAP,
+  XLSX_XPRESS_PROPOSAL,
 }
 
 export type DownloadOptions = {
@@ -153,6 +154,8 @@ function generateLink(
       return '/download/pdf/generic-template/' + ids;
     case PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL:
       return '/download/xlsx/proposal/' + ids;
+    case PREPARE_DOWNLOAD_TYPE.XLSX_XPRESS_PROPOSAL:
+      return '/download/xlsx/xpressProposal/' + ids;
     case PREPARE_DOWNLOAD_TYPE.XLSX_CALL_FAP:
       return '/download/xlsx/call_fap/' + ids;
     case PREPARE_DOWNLOAD_TYPE.XLSX_FAP:

--- a/apps/frontend/src/graphql/proposal/getTechniqueScientistProposalsBasic.graphql
+++ b/apps/frontend/src/graphql/proposal/getTechniqueScientistProposalsBasic.graphql
@@ -1,0 +1,22 @@
+query getTechniqueScientistProposalsBasic(
+  $filter: ProposalsFilter
+  $searchText: String
+) {
+  techniqueScientistProposals(
+    filter: $filter
+    searchText: $searchText
+  ) {
+    proposals {
+      primaryKey
+      proposalId
+      title
+      submitted
+      submittedDate
+      finalStatus
+      statusName
+      callId
+      callShortCode
+    }
+    totalCount
+  }
+}

--- a/apps/frontend/src/hooks/proposal/useDownloadXLSXProposal.ts
+++ b/apps/frontend/src/hooks/proposal/useDownloadXLSXProposal.ts
@@ -8,8 +8,16 @@ import {
 export function useDownloadXLSXProposal() {
   const { prepareDownload } = useContext(DownloadContext);
   const downloadProposalXLSX = useCallback(
-    (proposalPks: number[], name: string) => {
-      prepareDownload(PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL, proposalPks, name);
+    (proposalPks: number[], name: string, isXpress?: boolean) => {
+      if (isXpress !== undefined && isXpress) {
+        prepareDownload(
+          PREPARE_DOWNLOAD_TYPE.XLSX_XPRESS_PROPOSAL,
+          proposalPks,
+          name
+        );
+      } else {
+        prepareDownload(PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL, proposalPks, name);
+      }
     },
     [prepareDownload]
   );

--- a/apps/frontend/src/hooks/proposal/useDownloadXLSXProposal.ts
+++ b/apps/frontend/src/hooks/proposal/useDownloadXLSXProposal.ts
@@ -8,10 +8,14 @@ import {
 export function useDownloadXLSXProposal() {
   const { prepareDownload } = useContext(DownloadContext);
   const downloadProposalXLSX = useCallback(
-    (proposalPks: number[], name: string, isXpress?: boolean) => {
-      if (isXpress !== undefined && isXpress) {
+    (
+      proposalPks: number[],
+      name: string,
+      techniqueDetailsRequired?: boolean
+    ) => {
+      if (techniqueDetailsRequired !== undefined && techniqueDetailsRequired) {
         prepareDownload(
-          PREPARE_DOWNLOAD_TYPE.XLSX_XPRESS_PROPOSAL,
+          PREPARE_DOWNLOAD_TYPE.XLSX_PROPOSAL_TECHNIQUE,
           proposalPks,
           name
         );


### PR DESCRIPTION
## Description
This PR introduces a feature that allows users to export Xpress proposals. 

## Motivation and Context
The need for this feature arose from the necessity to provide users with a way to export proposal data for offline usage and further analysis. This feature enhances the usability of the platform and provides additional value to our users.

## Changes
- Added an option to export Xpress proposals in the `DownloadService.ts` file.
- Implemented the collection of proposal data for XLSX export in the `proposal.ts` file.
- Created a new route in the `xlsx.ts` file to handle the export of the collected data.
- Added e2e tests in the `xpress.cy.ts` file to ensure the feature works as expected.
- Updated the frontend `XpressProposalTable.tsx` file to include the export option in the UI. 

## How Has This Been Tested
In addition to the unit tests that have been added, this feature has been manually tested to ensure its correct functionality. The e2e tests added in `xpress.cy.ts` confirm that an officer and a scientist can export proposals into Excel. The exported file was then manually inspected to ensure all data is present and correctly formatted.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Issue
https://github.com/UserOfficeProject/issue-tracker/issues/1028
https://github.com/UserOfficeProject/issue-tracker/issues/1205

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated