### PR TITLE
feat: integrate Prometheus monitoring and alerting solution for backend

### DIFF
--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -15,6 +15,7 @@ import files from './src/middlewares/files';
 import apolloServer from './src/middlewares/graphql';
 import healthCheck from './src/middlewares/healthCheck';
 import jwtErrorHandler from './src/middlewares/jwtErrorHandler';
+import metrics from './src/middlewares/metrics/metrics';
 import readinessCheck from './src/middlewares/readinessCheck';
 
 async function bootstrap() {
@@ -23,6 +24,7 @@ async function bootstrap() {
   app.use(express.json({ limit: '5mb' }));
   app.use(express.urlencoded({ extended: false }));
   app
+    .use(metrics(app))
     .use(authorization())
     .use(jwtErrorHandler)
     .use(files())

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -44,6 +44,7 @@
         "openid-client": "^5.6.4",
         "pg": "^8.11.5",
         "pg-large-object": "^2.0.0",
+        "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.1",
         "sanitize-html": "^2.12.1",
         "simple-oauth2": "^4.3.0",
@@ -2208,6 +2209,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
@@ -3816,6 +3825,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -10933,6 +10947,18 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -12310,6 +12336,14 @@
       "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/teleport-javascript": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -68,6 +68,7 @@
     "openid-client": "^5.6.4",
     "pg": "^8.11.5",
     "pg-large-object": "^2.0.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.1",
     "sanitize-html": "^2.12.1",
     "simple-oauth2": "^4.3.0",

--- a/apps/backend/src/middlewares/graphql.ts
+++ b/apps/backend/src/middlewares/graphql.ts
@@ -31,6 +31,7 @@ import { registerEnums } from '../resolvers/registerEnums';
 import { buildFederatedSchema } from '../utils/buildFederatedSchema';
 import { isProduction } from '../utils/helperFunctions';
 import initGraphQLClient from './graphqlClient';
+import { apolloServerMetricsPlugin } from './metrics/apolloServerMetricsPlugin';
 
 export const context: ContextFunction<
   [ExpressContextFunctionArgument],
@@ -146,6 +147,7 @@ const apolloServer = async (app: Express) => {
   };
 
   const plugins = [
+    apolloServerMetricsPlugin(),
     ApolloServerPluginInlineTraceDisabled(),
     // Explicitly disable playground in prod
     isProduction

--- a/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
+++ b/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
@@ -34,7 +34,6 @@ const graphqlErrorCounter = new Counter({
   labelNames: ['operation', 'operation_type', 'error_code'],
 });
 
-// response size
 const graphqlResponseSize = new Histogram({
   name: 'graphql_response_size_bytes',
   help: 'Size of the GraphQL response in bytes',

--- a/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
+++ b/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
@@ -1,0 +1,123 @@
+import {
+  ApolloServerPlugin,
+  BaseContext,
+  GraphQLRequestContext,
+  GraphQLRequestContextWillSendResponse,
+} from '@apollo/server';
+import { GraphQLError, GraphQLFormattedError } from 'graphql';
+import { Counter, Histogram } from 'prom-client';
+
+type OperationType = 'query' | 'mutation' | 'subscription' | 'unknown';
+
+interface MetricLabels {
+  operation: string;
+  operation_type: OperationType;
+  status: 'success' | 'error';
+}
+
+const graphqlRequestDuration = new Histogram({
+  name: 'graphql_request_duration_seconds',
+  help: 'Duration of GraphQL requests in seconds',
+  labelNames: ['operation', 'operation_type', 'status'],
+  buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+const graphqlRequestCounter = new Counter({
+  name: 'graphql_requests_total',
+  help: 'Total number of GraphQL requests',
+  labelNames: ['operation', 'operation_type', 'status'],
+});
+
+const graphqlErrorCounter = new Counter({
+  name: 'graphql_errors_total',
+  help: 'Total number of GraphQL errors',
+  labelNames: ['operation', 'operation_type', 'error_code'],
+});
+
+// Basic plugin to collect prometheus metrics for GraphQL requests
+// It is possible to extend this plugin to include more metrics
+export const apolloServerMetricsPlugin = (): ApolloServerPlugin => ({
+  async requestDidStart(requestContext: GraphQLRequestContext<BaseContext>) {
+    const { request } = requestContext;
+
+    const operationName = request.operationName || 'anonymous';
+    const operationType = getOperationType(request.query);
+
+    const labels: MetricLabels = {
+      operation: operationName,
+      operation_type: operationType,
+      status: 'success',
+    };
+
+    const end = graphqlRequestDuration.startTimer(labels);
+    graphqlRequestCounter.inc(labels);
+
+    return {
+      async willSendResponse(
+        responseContext: GraphQLRequestContextWillSendResponse<BaseContext>
+      ) {
+        // Check for errors in the response body
+        if (responseContext.response.body.kind === 'single') {
+          const errors = responseContext.response.body.singleResult.errors;
+
+          if (errors) {
+            labels.status = 'error';
+
+            errors.forEach((error) => {
+              graphqlErrorCounter.inc({
+                operation: labels.operation,
+                operation_type: labels.operation_type,
+                error_code: getErrorCode(error),
+              });
+            });
+          }
+        }
+
+        end(labels);
+      },
+
+      async executionDidStart() {
+        return {
+          async executionDidEnd(err) {
+            if (err) {
+              labels.status = 'error';
+              graphqlErrorCounter.inc({
+                ...labels,
+                error_code: getErrorCode(err),
+              });
+            }
+          },
+        };
+      },
+    };
+  },
+});
+
+function getOperationType(query: string | undefined): OperationType {
+  if (!query) return 'unknown';
+
+  const trimmedQuery = query.trim().toLowerCase();
+  if (trimmedQuery.startsWith('query')) return 'query';
+  if (trimmedQuery.startsWith('mutation')) return 'mutation';
+  if (trimmedQuery.startsWith('subscription')) return 'subscription';
+
+  return 'unknown';
+}
+
+function getErrorCode(
+  error: GraphQLError | GraphQLFormattedError | Error
+): string {
+  if (isGraphQLError(error)) {
+    return error.extensions?.code as string;
+  } else if (error instanceof Error) {
+    return error.name;
+  }
+
+  return 'UNKNOWN_ERROR_CODE';
+}
+
+function isGraphQLError(
+  error: GraphQLError | GraphQLFormattedError | Error
+): error is GraphQLError | GraphQLFormattedError {
+  return 'extensions' in error;
+}

--- a/apps/backend/src/middlewares/metrics/metrics.ts
+++ b/apps/backend/src/middlewares/metrics/metrics.ts
@@ -1,0 +1,56 @@
+import express, { Request, Response } from 'express';
+import { collectDefaultMetrics, register } from 'prom-client';
+import { Counter, Histogram } from 'prom-client';
+
+// Collect default node.js metrics
+collectDefaultMetrics();
+
+const router = express.Router();
+
+// Expose metrics for Prometheus (ATTENTION: don't expose this endpoint to the public)
+router.get('/metrics', async (req: Request, res: Response) => {
+  res.set('Content-Type', register.contentType);
+  res.end(await register.metrics());
+});
+
+// Define the metrics
+const httpRequestCounter = new Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status_code'],
+});
+
+const httpRequestDurationMicroseconds = new Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'Duration of HTTP requests in seconds',
+  labelNames: ['method', 'route', 'status_code'],
+  buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+// Middleware to collect metrics
+export default function (app: express.Application) {
+  // Middleware to measure the duration of each request
+  app.use((req, res, next) => {
+    const end = httpRequestDurationMicroseconds.startTimer();
+
+    res.on('finish', () => {
+      // Measure the duration of the request
+      end({
+        method: req.method,
+        route: req.route ? req.route.path : req.path,
+        status_code: res.statusCode,
+      });
+
+      // Count the number of requests
+      httpRequestCounter.inc({
+        method: req.method,
+        route: req.route ? req.route.path : req.path,
+        status_code: res.statusCode,
+      });
+    });
+
+    next();
+  });
+
+  return router;
+}

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,27 @@
+# Grafana & Prometheus Stack
+
+This directory contains a default configuration for a Grafana & Prometheus stack. The stack is configured to monitor the User Office application.
+This directory is just a **demo** configuration to show how to monitor the User Office. It is not meant to be used in production.
+
+## How to use
+
+```bash
+# in the root directory of the repository
+# start the User Office application
+npm run dev
+
+# in the metrics directory
+# start the Grafana & Prometheus stack
+docker compose -f docker-compose.metrics.yml up
+```
+
+Use the application as you normally would. The metrics will be collected and displayed in Grafana.
+
+## Grafana
+
+1. Open the Grafana dashboard at [http://localhost:3333](http://localhost:3333) and login with the default credentials (admin/admin).
+2. Dashboards -> GraphQL metrics
+
+## Prometheus
+
+Prometheus is available at [http://localhost:9090](http://localhost:9090).

--- a/metrics/docker-compose.metrics.yml
+++ b/metrics/docker-compose.metrics.yml
@@ -1,0 +1,28 @@
+services:
+  grafana:
+    image: grafana/grafana:latest
+    ports:       
+      - '3333:3333'
+    depends_on:
+      - prometheus
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    environment:
+      - GF_SERVER_HTTP_PORT=3333
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-piechart-panel
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+    network_mode: host
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - '9090:9090'
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    network_mode: host
+    
+ 

--- a/metrics/grafana/dashboards/example-graphql-http-dashboard.json
+++ b/metrics/grafana/dashboards/example-graphql-http-dashboard.json
@@ -1,0 +1,770 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "left",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "topk(5, histogram_quantile(0.95, sum by(operation, le) (rate(graphql_request_duration_seconds_bucket[$__rate_interval]))))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Top Slowest Operations (95th percentile)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "expr": "sum(rate(graphql_requests_total{status=\"success\"}[$__rate_interval])) by (operation_type)",
+          "legendFormat": "Success - {{operation_type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(graphql_requests_total{status=\"error\"}[$__rate_interval])) by (operation_type)",
+          "legendFormat": "Error - {{operation_type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Operation Success vs Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "thresholds": {
+          "steps": [
+            {
+              "color": "blue",
+              "value": 0
+            },
+            {
+              "color": "green",
+              "value": 10
+            },
+            {
+              "color": "yellow",
+              "value": 50
+            }
+          ]
+        },
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(graphql_requests_total) by (operation)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Request Volume by Operation",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "sum"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(http_requests_total{}[$__rate_interval])",
+          "legendFormat": "{{method}} {{route}} {{status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "expr": "sum(graphql_errors_total) by (operation, error_code)",
+          "legendFormat": "{{operation}} ({{error_code}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Distribution by Operation",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(http_request_duration_seconds_sum{status_code=\"200\"}[$__rate_interval]) / rate(http_request_duration_seconds_count{status_code=\"200\"}[$__rate_interval])",
+          "legendFormat": "{{method}} {{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Duration",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 5,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "expr": "rate(graphql_request_duration_seconds_sum[$__rate_interval]) / rate(graphql_request_duration_seconds_count[$__rate_interval])",
+          "legendFormat": "{{operation}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Operation Latency Trends",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 1,
+      "options": {
+        "calculate": true,
+        "calculation": "rate",
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(graphql_request_duration_seconds_bucket[$__rate_interval])) by (le, operation_type)",
+          "format": "heatmap",
+          "legendFormat": "{{operation_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GraphQL Request Duration Distribution",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 9,
+      "options": {
+        "calculate": true,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{status_code=\"200\"}[$__rate_interval]))",
+          "legendFormat": "{{le}}s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Duration Histogram",
+      "type": "heatmap"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "GraphQL & HTTP Metrics",
+  "uid": "de1xzkdwh5fr4d",
+  "version": 1,
+  "weekStart": ""
+}

--- a/metrics/grafana/dashboards/example-graphql-http-dashboard.json
+++ b/metrics/grafana/dashboards/example-graphql-http-dashboard.json
@@ -29,9 +29,44 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "continuous-GrYlRd"
+            "mode": "palette-classic"
           },
-          "fieldMinMax": false,
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 32,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -57,36 +92,28 @@
       },
       "id": 3,
       "options": {
-        "displayMode": "lcd",
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
-        "maxVizHeight": 300,
-        "minVizHeight": 16,
-        "minVizWidth": 8,
-        "namePlacement": "left",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "pluginVersion": "11.3.0",
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
+          "exemplar": false,
           "expr": "topk(5, histogram_quantile(0.95, sum by(operation, le) (rate(graphql_request_duration_seconds_bucket[$__rate_interval]))))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
+          "instant": false,
           "legendFormat": "{{operation}}",
           "range": true,
           "refId": "A",
@@ -94,7 +121,7 @@
         }
       ],
       "title": "Top Slowest Operations (95th percentile)",
-      "type": "bargauge"
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -265,13 +292,13 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(graphql_requests_total) by (operation)",
+          "expr": "topk(20,increase(graphql_requests_total{}[$__range]))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "instant": false,
+          "instant": true,
           "legendFormat": "{{operation}}",
-          "range": true,
+          "range": false,
           "refId": "A",
           "useBackend": false
         }
@@ -500,7 +527,9 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
+          "exemplar": false,
           "expr": "rate(http_request_duration_seconds_sum{status_code=\"200\"}[$__rate_interval]) / rate(http_request_duration_seconds_count{status_code=\"200\"}[$__rate_interval])",
+          "instant": false,
           "legendFormat": "{{method}} {{route}}",
           "range": true,
           "refId": "A"
@@ -749,9 +778,103 @@
       ],
       "title": "HTTP Request Duration Histogram",
       "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(graphql_response_size_bytes_sum[$__rate_interval]) / rate(graphql_response_size_bytes_count[$__rate_interval])",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GraphQL Response Size - Average",
+      "type": "timeseries"
     }
   ],
   "preload": false,
+  "refresh": "5s",
   "schemaVersion": 40,
   "tags": [],
   "templating": {

--- a/metrics/grafana/dashboards/example-graphql-http-dashboard.json
+++ b/metrics/grafana/dashboards/example-graphql-http-dashboard.json
@@ -109,7 +109,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(5, histogram_quantile(0.95, sum by(operation, le) (rate(graphql_request_duration_seconds_bucket[$__rate_interval]))))",
+          "expr": "topk(20, histogram_quantile(0.95, sum by(operation, le) (rate(graphql_request_duration_seconds_bucket[$__rate_interval])) != 0))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -205,13 +205,17 @@
       "pluginVersion": "11.3.0",
       "targets": [
         {
+          "editorMode": "code",
           "expr": "sum(rate(graphql_requests_total{status=\"success\"}[$__rate_interval])) by (operation_type)",
           "legendFormat": "Success - {{operation_type}}",
+          "range": true,
           "refId": "A"
         },
         {
+          "editorMode": "code",
           "expr": "sum(rate(graphql_requests_total{status=\"error\"}[$__rate_interval])) by (operation_type)",
           "legendFormat": "Error - {{operation_type}}",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -292,7 +296,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(20,increase(graphql_requests_total{}[$__range]))",
+          "expr": "topk(20, increase(graphql_requests_total{}[$__range]))",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -528,7 +532,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(http_request_duration_seconds_sum{status_code=\"200\"}[$__rate_interval]) / rate(http_request_duration_seconds_count{status_code=\"200\"}[$__rate_interval])",
+          "expr": "sort(rate(http_request_duration_seconds_sum{status_code=\"200\"}[$__rate_interval]) / rate(http_request_duration_seconds_count{status_code=\"200\"}[$__rate_interval]) > 0)",
           "instant": false,
           "legendFormat": "{{method}} {{route}}",
           "range": true,
@@ -617,8 +621,10 @@
       "pluginVersion": "11.3.0",
       "targets": [
         {
+          "editorMode": "code",
           "expr": "rate(graphql_request_duration_seconds_sum[$__rate_interval]) / rate(graphql_request_duration_seconds_count[$__rate_interval])",
           "legendFormat": "{{operation}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -691,7 +697,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(graphql_request_duration_seconds_bucket[$__rate_interval])) by (le, operation_type)",
+          "expr": "sum(rate(graphql_request_duration_seconds_bucket[$__rate_interval])) by (le, operation_type) > 0",
           "format": "heatmap",
           "legendFormat": "{{operation_type}}",
           "range": true,
@@ -835,8 +841,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "decbytes"
+          }
         },
         "overrides": []
       },

--- a/metrics/grafana/provisioning/dashboards/dashboard.yaml
+++ b/metrics/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: "Default"
+    orgId: 1
+    folder: ""
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/metrics/grafana/provisioning/datasources/prometheus.yaml
+++ b/metrics/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://127.0.0.1:9090
+    isDefault: true
+    version: 1
+    editable: true

--- a/metrics/prometheus/prometheus.yml
+++ b/metrics/prometheus/prometheus.yml
@@ -1,0 +1,37 @@
+# my global config
+global:
+  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: "prometheus"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "user-office-core"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["localhost:4000"]


### PR DESCRIPTION
This PR integrates Prometheus metrics, monitoring, and alerting capabilities into the backend application.

Changes:
- New **/metrics** endpoint to expose collected data.
- New apolloServerMetricsPlugin to record GraphQL-related metrics data.
- New middleware to collect HTTP request information.
- Tracking of default Node.js application metrics.
- New package installed: [prom-client](https://github.com/siimon/prom-client).
- Added Prometheus & Grafana stack in the metrics directory (for demo purposes).