### PR TITLE
perf: stop overfetching of instrument data

### DIFF
--- a/apps/frontend/src/components/common/proposalFilters/InstrumentFilter.tsx
+++ b/apps/frontend/src/components/common/proposalFilters/InstrumentFilter.tsx
@@ -9,7 +9,10 @@ import React, { Dispatch } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
-import { InstrumentFilterInput, InstrumentFragment } from 'generated/sdk';
+import {
+  InstrumentFilterInput,
+  InstrumentMinimalFragment,
+} from 'generated/sdk';
 
 export enum InstrumentFilterEnum {
   ALL = 'all',
@@ -17,7 +20,7 @@ export enum InstrumentFilterEnum {
 }
 
 type InstrumentFilterProps = {
-  instruments?: InstrumentFragment[];
+  instruments?: InstrumentMinimalFragment[];
   isLoading?: boolean;
   onChange?: Dispatch<InstrumentFilterInput>;
   shouldShowAll?: boolean;

--- a/apps/frontend/src/components/experiment/ExperimentFilterBar.tsx
+++ b/apps/frontend/src/components/experiment/ExperimentFilterBar.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from 'react-router-dom';
 import CallFilter from 'components/common/proposalFilters/CallFilter';
 import InstrumentFilter from 'components/common/proposalFilters/InstrumentFilter';
 import { useCallsData } from 'hooks/call/useCallsData';
-import { useInstrumentsData } from 'hooks/instrument/useInstrumentsData';
+import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 
 import DateFilter from './DateFilter';
 
@@ -17,7 +17,7 @@ function ExperimentFilterBar() {
   const experimentFromDate = searchParams.get('from');
   const experimentToDate = searchParams.get('to');
 
-  const { instruments, loadingInstruments } = useInstrumentsData();
+  const { instruments, loadingInstruments } = useInstrumentsMinimalData();
   const { calls, loadingCalls } = useCallsData();
 
   const handleOnChange = (format: string, from?: Date, to?: Date) => {

--- a/apps/frontend/src/components/instrument/AssignProposalsToInstruments.tsx
+++ b/apps/frontend/src/components/instrument/AssignProposalsToInstruments.tsx
@@ -9,14 +9,14 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormikUIAutocomplete from 'components/common/FormikUIAutocomplete';
-import { InstrumentFragment } from 'generated/sdk';
-import { useInstrumentsData } from 'hooks/instrument/useInstrumentsData';
+import { InstrumentMinimalFragment } from 'generated/sdk';
+import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 import { getUniqueArray } from 'utils/helperFunctions';
 
 type AssignProposalsToInstrumentsProps = {
   close: () => void;
   assignProposalsToInstruments: (
-    instrument: InstrumentFragment[] | null
+    instrument: InstrumentMinimalFragment[] | null
   ) => Promise<void>;
   callIds: number[];
   instrumentIds: (number | null)[];
@@ -30,7 +30,8 @@ const AssignProposalsToInstruments = ({
 }: AssignProposalsToInstrumentsProps) => {
   const { t } = useTranslation();
 
-  const { instruments, loadingInstruments } = useInstrumentsData(callIds);
+  const { instruments, loadingInstruments } =
+    useInstrumentsMinimalData(callIds);
 
   const uniqueInstrumentIds = getUniqueArray(instrumentIds);
 

--- a/apps/frontend/src/components/proposal/ProposalFilterBar.tsx
+++ b/apps/frontend/src/components/proposal/ProposalFilterBar.tsx
@@ -8,7 +8,7 @@ import QuestionaryFilter from 'components/common/proposalFilters/QuestionaryFilt
 import {
   Call,
   DataType,
-  InstrumentFragment,
+  InstrumentMinimalFragment,
   ProposalsFilter,
   ProposalStatus,
   QuestionFilterCompareOperator,
@@ -38,7 +38,7 @@ export const questionaryFilterFromUrlQuery = (urlQuery: {
 };
 type ProposalFilterBarProps = {
   calls?: { data: Call[]; isLoading: boolean };
-  instruments?: { data: InstrumentFragment[]; isLoading: boolean };
+  instruments?: { data: InstrumentMinimalFragment[]; isLoading: boolean };
   proposalStatuses?: { data: ProposalStatus[]; isLoading: boolean };
   setProposalFilter: (filter: ProposalsFilter) => void;
   filter: ProposalsFilter;

--- a/apps/frontend/src/components/proposal/ProposalPage.tsx
+++ b/apps/frontend/src/components/proposal/ProposalPage.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 
 import { ProposalsFilter } from 'generated/sdk';
 import { useCallsData } from 'hooks/call/useCallsData';
-import { useInstrumentsData } from 'hooks/instrument/useInstrumentsData';
+import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 import { useProposalStatusesData } from 'hooks/settings/useProposalStatusesData';
 import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
 
@@ -54,7 +54,7 @@ export default function ProposalPage() {
     }),
   });
   const { calls, loadingCalls } = useCallsData();
-  const { instruments, loadingInstruments } = useInstrumentsData();
+  const { instruments, loadingInstruments } = useInstrumentsMinimalData();
   const { proposalStatuses, loadingProposalStatuses } =
     useProposalStatusesData();
 

--- a/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableInstrumentScientist.tsx
@@ -41,7 +41,7 @@ import {
 import { useInstrumentScientistCallsData } from 'hooks/call/useInstrumentScientistCallsData';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
 import { useLocalStorage } from 'hooks/common/useLocalStorage';
-import { useInstrumentsData } from 'hooks/instrument/useInstrumentsData';
+import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 import { useDownloadPDFProposal } from 'hooks/proposal/useDownloadPDFProposal';
 import { useDownloadProposalAttachment } from 'hooks/proposal/useDownloadProposalAttachment';
 import {
@@ -332,7 +332,7 @@ const ProposalTableInstrumentScientist = ({
     },
     searchText: search ?? undefined,
   });
-  const { instruments, loadingInstruments } = useInstrumentsData();
+  const { instruments, loadingInstruments } = useInstrumentsMinimalData();
   const { calls, loadingCalls } = useInstrumentScientistCallsData(user.id);
   const { proposalStatuses, loadingProposalStatuses } =
     useProposalStatusesData();

--- a/apps/frontend/src/components/proposal/ProposalTableOfficer.tsx
+++ b/apps/frontend/src/components/proposal/ProposalTableOfficer.tsx
@@ -46,7 +46,7 @@ import {
   Call,
   ProposalsFilter,
   ProposalStatus,
-  InstrumentFragment,
+  InstrumentMinimalFragment,
   FeatureId,
   FapInstrumentInput,
   FapInstrument,
@@ -529,7 +529,7 @@ const ProposalTableOfficer = ({
   };
 
   const assignProposalsToInstruments = async (
-    instruments: InstrumentFragment[] | null
+    instruments: InstrumentMinimalFragment[] | null
   ): Promise<void> => {
     if (instruments?.length) {
       await api({

--- a/apps/frontend/src/components/proposalBooking/InstrSciUpcomingExperimentTimesTable.tsx
+++ b/apps/frontend/src/components/proposalBooking/InstrSciUpcomingExperimentTimesTable.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import InstrumentFilter from 'components/common/proposalFilters/InstrumentFilter';
-import { useInstrumentsData } from 'hooks/instrument/useInstrumentsData';
+import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 import { useProposalBookingsScheduledEvents } from 'hooks/proposalBooking/useProposalBookingsScheduledEvents';
 import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
 
@@ -12,7 +12,7 @@ export default function InstrSciUpcomingExperimentTimesTable() {
   const [searchParams] = useSearchParams();
   const instrumentId = searchParams.get('instrument');
 
-  const { instruments, loadingInstruments } = useInstrumentsData();
+  const { instruments, loadingInstruments } = useInstrumentsMinimalData();
 
   const [selectedInstrumentId, setSelectedInstrumentId] = useState<
     number | null | undefined

--- a/apps/frontend/src/components/review/ProposalTableReviewer.tsx
+++ b/apps/frontend/src/components/review/ProposalTableReviewer.tsx
@@ -24,7 +24,7 @@ import {
 } from 'generated/sdk';
 import { useCallsData } from 'hooks/call/useCallsData';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
-import { useInstrumentsData } from 'hooks/instrument/useInstrumentsData';
+import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 import { useDownloadPDFProposal } from 'hooks/proposal/useDownloadPDFProposal';
 import { useUserWithReviewsData } from 'hooks/user/useUserData';
 import { capitalize, setSortDirectionOnSortField } from 'utils/helperFunctions';
@@ -84,7 +84,7 @@ const columns: (
 const ProposalTableReviewer = ({ confirm }: { confirm: WithConfirmType }) => {
   const downloadPDFProposal = useDownloadPDFProposal();
   const { calls, loadingCalls } = useCallsData();
-  const { instruments, loadingInstruments } = useInstrumentsData();
+  const { instruments, loadingInstruments } = useInstrumentsMinimalData();
   const { api } = useDataApiWithFeedback();
   const { t } = useTranslation();
   const isFapReviewer = useCheckAccess([UserRole.FAP_REVIEWER]);

--- a/apps/frontend/src/graphql/instrument/getInstrumentsMinimal.graphql
+++ b/apps/frontend/src/graphql/instrument/getInstrumentsMinimal.graphql
@@ -1,0 +1,8 @@
+query getInstrumentsMinimal($callIds: [Int!]) {
+  instruments(callIds: $callIds) {
+    instruments {
+      ...instrumentMinimal
+    }
+    totalCount
+  }
+}

--- a/apps/frontend/src/graphql/instrument/getMyInstrumentsMinimal.graphql
+++ b/apps/frontend/src/graphql/instrument/getMyInstrumentsMinimal.graphql
@@ -1,0 +1,7 @@
+query getMyInstrumentsMinimal {
+  me {
+    instruments {
+      ...instrumentMinimal
+    }
+  }
+}

--- a/apps/frontend/src/graphql/instrument/instrumentMinimal.fragment.graphql
+++ b/apps/frontend/src/graphql/instrument/instrumentMinimal.fragment.graphql
@@ -1,0 +1,5 @@
+fragment instrumentMinimal on Instrument {
+  id
+  name
+  shortCode
+}

--- a/apps/frontend/src/hooks/instrument/useInstrumentsMinimalData.ts
+++ b/apps/frontend/src/hooks/instrument/useInstrumentsMinimalData.ts
@@ -1,0 +1,78 @@
+import {
+  useEffect,
+  useState,
+  SetStateAction,
+  Dispatch,
+  useContext,
+} from 'react';
+
+import { UserContext } from 'context/UserContextProvider';
+import { InstrumentMinimalFragment, UserRole } from 'generated/sdk';
+import { useDataApi } from 'hooks/common/useDataApi';
+
+export function useInstrumentsMinimalData(callIds?: number[]): {
+  loadingInstruments: boolean;
+  instruments: InstrumentMinimalFragment[];
+  setInstruments: Dispatch<SetStateAction<InstrumentMinimalFragment[]>>;
+} {
+  const [instruments, setInstruments] = useState<InstrumentMinimalFragment[]>(
+    []
+  );
+  const [loadingInstruments, setLoadingInstruments] = useState(true);
+  const { currentRole } = useContext(UserContext);
+
+  const api = useDataApi();
+
+  useEffect(() => {
+    let unmounted = false;
+
+    setLoadingInstruments(true);
+    if (
+      currentRole &&
+      [
+        UserRole.USER_OFFICER,
+        UserRole.FAP_REVIEWER,
+        UserRole.FAP_CHAIR,
+        UserRole.FAP_SECRETARY,
+        UserRole.USER,
+      ].includes(currentRole)
+    ) {
+      api()
+        .getInstrumentsMinimal({ callIds })
+        .then((data) => {
+          if (unmounted) {
+            return;
+          }
+
+          if (data.instruments) {
+            setInstruments(data.instruments.instruments);
+          }
+          setLoadingInstruments(false);
+        });
+    } else {
+      api()
+        .getMyInstrumentsMinimal()
+        .then((data) => {
+          if (unmounted) {
+            return;
+          }
+
+          if (data.me?.instruments) {
+            setInstruments(data.me.instruments);
+          }
+          setLoadingInstruments(false);
+        });
+    }
+
+    return () => {
+      // used to avoid unmounted component state update error
+      unmounted = true;
+    };
+  }, [api, currentRole, callIds]);
+
+  return {
+    loadingInstruments,
+    instruments,
+    setInstruments,
+  };
+}


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1223

## Description
This PR optimizes the fetching of instrument data by introducing a minimal version of instrument data fetching. 

## Motivation and Context
This change is required to improve the performance of the application by minimizing the amount of data fetched when full instrument data is not necessary.

## Changes
1. Introduced a minimal version of instrument data fetching in various components where full instrument data was previously fetched.
2. Updated the types and usages of instrument data in various components to use the minimal version.
3. Replaced the calls to `useInstrumentsData()` with `useInstrumentsMinimalData()` in various components.

## Additional Context
This change will reduce the load on the server and improve the user experience by speeding up the loading times.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated