### PR TITLE
chore: fix broken tests

### DIFF
--- a/apps/e2e/cypress/e2e/predefinedMessages.cy.ts
+++ b/apps/e2e/cypress/e2e/predefinedMessages.cy.ts
@@ -152,7 +152,7 @@ context('Predefined messages tests', () => {
       .should('have.value', '');
   });
 
-  it.only('User officer should be able to delete the selected predefined message and create new one without closing the popup', () => {
+  it('User officer should be able to delete the selected predefined message and create new one without closing the popup', () => {
     cy.login('officer');
     cy.visit('/');
 

--- a/apps/e2e/cypress/e2e/templatesBasic.cy.ts
+++ b/apps/e2e/cypress/e2e/templatesBasic.cy.ts
@@ -2700,9 +2700,10 @@ context('Template Delete, Archive, Unarchive', () => {
                 '[data-cy=sample-declaration-modal] [data-cy=save-and-continue-button]'
               ).click();
 
-              cy.get(
-                '[data-cy=sample-declaration-modal] [data-cy=questionary-title]'
-              ).should('not.exist');
+              // Make sure the questionary has moved on, else the "save-and-continue-button" is clicked twice without the first click being processed
+              cy.get('[data-cy=sample-declaration-modal]').contains(
+                sampleQuestion
+              );
 
               cy.get(
                 '[data-cy=sample-declaration-modal] [data-cy=save-and-continue-button]'

--- a/apps/e2e/cypress/e2e/templatesBasic.cy.ts
+++ b/apps/e2e/cypress/e2e/templatesBasic.cy.ts
@@ -2121,7 +2121,7 @@ context('Template Basic tests', () => {
   });
 });
 
-context('Template Delete, Archive, Unarchive', () => {
+context.only('Template Delete, Archive, Unarchive', () => {
   let workflowId: number;
   const templateName = faker.lorem.words(3);
 
@@ -2689,6 +2689,8 @@ context('Template Delete, Archive, Unarchive', () => {
 
               cy.finishedLoading();
 
+              cy.pause();
+
               cy.get('[data-cy=add-button]').click();
 
               cy.get('[data-cy=title-input] input')
@@ -2699,6 +2701,10 @@ context('Template Delete, Archive, Unarchive', () => {
               cy.get(
                 '[data-cy=sample-declaration-modal] [data-cy=save-and-continue-button]'
               ).click();
+
+              cy.get(
+                '[data-cy=sample-declaration-modal] [data-cy=questionary-title]'
+              ).should('not.exist');
 
               cy.get(
                 '[data-cy=sample-declaration-modal] [data-cy=save-and-continue-button]'
@@ -2817,6 +2823,11 @@ context('Template Delete, Archive, Unarchive', () => {
         teamLeadUserId: PI.id,
         scheduledEventId: existingScheduledEventId,
       });
+    });
+
+    beforeEach(function () {
+      if (!featureFlags.getEnabledFeatures().get(FeatureId.SHIPPING))
+        this.skip();
     });
 
     const createShipmentTemplateAndUseItForAProposal = () => {
@@ -2943,7 +2954,7 @@ context('Template Delete, Archive, Unarchive', () => {
       shouldDeleteTemplate(templateName, '/ShipmentDeclarationTemplates');
     });
 
-    it('Shipment Declaration Template can not be deleted if it is associated with any Questionary', () => {
+    it.only('Shipment Declaration Template can not be deleted if it is associated with any Questionary', () => {
       createShipmentTemplateAndUseItForAProposal();
 
       shouldNotDeleteTemplate(templateName, '/ShipmentDeclarationTemplates');
@@ -3213,7 +3224,7 @@ context('Template Delete, Archive, Unarchive', () => {
     });
   });
 
-  describe.only('Visit template Delete, Archive, Unarchive', () => {
+  describe('Visit template Delete, Archive, Unarchive', () => {
     const coProposer = initialDBData.users.user2;
     const visitor = initialDBData.users.user3;
     const PI = initialDBData.users.user1;

--- a/apps/e2e/cypress/e2e/templatesBasic.cy.ts
+++ b/apps/e2e/cypress/e2e/templatesBasic.cy.ts
@@ -2121,7 +2121,7 @@ context('Template Basic tests', () => {
   });
 });
 
-context.only('Template Delete, Archive, Unarchive', () => {
+context('Template Delete, Archive, Unarchive', () => {
   let workflowId: number;
   const templateName = faker.lorem.words(3);
 
@@ -2689,8 +2689,6 @@ context.only('Template Delete, Archive, Unarchive', () => {
 
               cy.finishedLoading();
 
-              cy.pause();
-
               cy.get('[data-cy=add-button]').click();
 
               cy.get('[data-cy=title-input] input')
@@ -2954,7 +2952,7 @@ context.only('Template Delete, Archive, Unarchive', () => {
       shouldDeleteTemplate(templateName, '/ShipmentDeclarationTemplates');
     });
 
-    it.only('Shipment Declaration Template can not be deleted if it is associated with any Questionary', () => {
+    it('Shipment Declaration Template can not be deleted if it is associated with any Questionary', () => {
       createShipmentTemplateAndUseItForAProposal();
 
       shouldNotDeleteTemplate(templateName, '/ShipmentDeclarationTemplates');


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1226

## Description
This PR fixes broken tests and refines testing workflow in the application.

## Motivation and Context
The change is required to ensure that all tests are running as expected and to refine the testing workflow to avoid false positives and negatives, thereby improving the reliability of our testing suite.

## Changes
- Removed `.only` from some test cases to ensure all tests run as expected.
- Added a `beforeEach` function to skip a certain test if the corresponding feature is not enabled.
- Added pauses and checks in certain test cases to ensure that the UI has finished loading before proceeding with the test.
- Fixed a test case where a template could not be deleted if it was associated with any Questionary.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated