### PR TITLE
chore: optimised sample safety auth by using user auth for discovering sample safety user

### DIFF
--- a/apps/backend/src/auth/SampleAuthorization.ts
+++ b/apps/backend/src/auth/SampleAuthorization.ts
@@ -2,10 +2,10 @@ import { container, inject, injectable } from 'tsyringe';
 
 import { Tokens } from '../config/Tokens';
 import { SampleDataSource } from '../datasources/SampleDataSource';
-import { Roles } from '../models/Role';
 import { UserWithRole } from '../models/User';
 import { Sample } from './../resolvers/types/Sample';
 import { ProposalAuthorization } from './ProposalAuthorization';
+import { UserAuthorization } from './UserAuthorization';
 
 @injectable()
 export class SampleAuthorization {
@@ -13,7 +13,8 @@ export class SampleAuthorization {
 
   constructor(
     @inject(Tokens.SampleDataSource)
-    private sampleDataSource: SampleDataSource
+    private sampleDataSource: SampleDataSource,
+    @inject(Tokens.UserAuthorization) private userAuth: UserAuthorization
   ) {}
 
   private async resolveSample(
@@ -28,14 +29,6 @@ export class SampleAuthorization {
     }
 
     return sample;
-  }
-
-  isSampleSafetyReviewer(agent: UserWithRole | null) {
-    if (agent == null) {
-      return false;
-    }
-
-    return agent?.currentRole?.shortCode === Roles.SAMPLE_SAFETY_REVIEWER;
   }
 
   async hasReadRights(
@@ -92,7 +85,7 @@ export class SampleAuthorization {
     return (
       canEditProposal ||
       (isMemberOfProposal && isPostProposalSubmission) ||
-      this.isSampleSafetyReviewer(agent)
+      this.userAuth.isSampleSafetyReviewer(agent)
     );
   }
 }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

User Authorization is responsible for verifying the roles of various user. However in Sample Authorization, it has its own verification method, which is a duplicated of what User Authorization has. The duplicated method has been removed from the Sample Authorization, ensuring User Authorization is the only source of identifying roles. 

## Motivation and Context

Avoiding duplication

## How Has This Been Tested

Manually

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
