### PR TITLE
fix: remove wrong condition from fap reviewer grade access

### DIFF
--- a/apps/frontend/src/components/questionary/questionaries/fapReview/FapReviewQuestionaryWizardStep.ts
+++ b/apps/frontend/src/components/questionary/questionaries/fapReview/FapReviewQuestionaryWizardStep.ts
@@ -1,23 +1,13 @@
 import { ReviewStatus } from 'generated/sdk';
 import { FapReviewSubmissionState } from 'models/questionary/fapReview/FapReviewSubmissionState';
 import { QuestionarySubmissionState } from 'models/questionary/QuestionarySubmissionState';
-import { isCallEnded } from 'utils/helperFunctions';
 
 import { QuestionaryWizardStep } from '../../DefaultWizardStepFactory';
 
 export class FapReviewQuestionaryWizardStep extends QuestionaryWizardStep {
   isItemWithQuestionaryEditable(state: QuestionarySubmissionState) {
     const { fapReview } = state as FapReviewSubmissionState;
-    const isCallInternalActive = fapReview.call?.isActiveInternal ?? false;
-    const callHasEnded = isCallEnded(
-      fapReview.proposal?.call?.startCall,
-      fapReview.proposal?.call?.endCall
-    );
 
-    if (callHasEnded && !isCallInternalActive) {
-      return false;
-    } else {
-      return fapReview.status === ReviewStatus.DRAFT;
-    }
+    return fapReview.status === ReviewStatus.DRAFT;
   }
 }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

The FAP reviewer has no write access to FAP reviews after end of call.

<!--- Describe your changes in detail -->

## Motivation and Context

The bug was introduced in the FAP review template implementation. 

## How Has This Been Tested

Manual and e2e tests. 

## Fixes

Fall back to the original logic: only disable FAP reviews for FAP reviewers if the review has already been submitted. 

## Changes

Fix condition in FapReviewQuestionaryWizardStep.ts

## Depends on

N/A

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
