### PR TITLE
fix: fap reviews comment character limit

### DIFF
--- a/apps/frontend/src/components/questionary/questionaryComponents/FapReviewBasis/createFapReviewBasisValidationSchema.ts
+++ b/apps/frontend/src/components/questionary/questionaryComponents/FapReviewBasis/createFapReviewBasisValidationSchema.ts
@@ -5,7 +5,7 @@ import { QuestionaryComponentDefinition } from 'components/questionary/Questiona
 
 export const createFapReviewBasisValidationSchema: QuestionaryComponentDefinition['createYupValidationSchema'] =
   () => {
-    const FAP_REVIEW_COMMENT_CHAR_LIMIT = 100;
+    const FAP_REVIEW_COMMENT_CHAR_LIMIT = 6000;
 
     let commentSchema = Yup.string().transform(function (value: string) {
       return sanitizeHtmlAndCleanText(value);


### PR DESCRIPTION
This was changed with the introduction of review templates. Since it is not in a React component, I can't use the setting context and since the frontend has no env file/variables I can't find a way of parameterising this for different facilities. 

We need this change now, so I am putting this in, and we can discuss how we parameterise validation schemas later if that is ok? 