### PR TITLE
feat: add download dialog to fap document store

### DIFF
--- a/apps/frontend/src/components/common/FileLink.tsx
+++ b/apps/frontend/src/components/common/FileLink.tsx
@@ -1,7 +1,8 @@
 import Link from '@mui/material/Link';
 import { SxProps, Theme } from '@mui/system';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 
+import { DownloadMonitorDialog } from 'context/DownloadContextProvider';
 import { UserContext } from 'context/UserContextProvider';
 
 export function FileLink(props: {
@@ -11,9 +12,12 @@ export function FileLink(props: {
   sx?: SxProps<Theme>;
 }) {
   const { token } = useContext(UserContext);
+  const [isLoading, setIsLoading] = useState(false);
 
-  const AddAuthToLink = (link: string, fileName: string) => {
-    fetch(link, {
+  const AddAuthToLink = async (link: string, fileName: string) => {
+    setIsLoading(true);
+
+    return fetch(link, {
       method: 'GET',
       headers: {
         authorization: `Bearer ${token}`,
@@ -29,16 +33,24 @@ export function FileLink(props: {
         link.click();
         link.remove();
         URL.revokeObjectURL(blobUrl);
+        setIsLoading(false);
       });
   };
 
   return (
-    <Link
-      download
-      onClick={() => AddAuthToLink(props.link, props.filename)}
-      sx={{ cursor: 'pointer', ...props.sx }}
-    >
-      {props.children}
-    </Link>
+    <>
+      <Link
+        download
+        onClick={() => AddAuthToLink(props.link, props.filename)}
+        sx={{ cursor: 'pointer', ...props.sx }}
+      >
+        {props.children}
+      </Link>
+      {isLoading && (
+        <DownloadMonitorDialog
+          items={[{ id: props.filename, name: props.filename, total: 1 }]}
+        />
+      )}
+    </>
   );
 }

--- a/apps/frontend/src/context/DownloadContextProvider.tsx
+++ b/apps/frontend/src/context/DownloadContextProvider.tsx
@@ -21,12 +21,12 @@ import { downloadBlob } from 'utils/downloadBlob';
 
 import { UserContext } from './UserContextProvider';
 
-const DownloadMonitorDialog = ({
+export const DownloadMonitorDialog = ({
   items,
   cancel,
 }: {
   items: InProgressItem[];
-  cancel: (id: string) => void;
+  cancel?: (id: string) => void;
 }) => {
   const theme = useTheme();
   const [open, setOpen] = useState(true);
@@ -92,9 +92,11 @@ const DownloadMonitorDialog = ({
                       )
                     }
                   />
-                  <Button variant="text" onClick={() => cancel(item.id)}>
-                    Cancel
-                  </Button>
+                  {cancel && (
+                    <Button variant="text" onClick={() => cancel(item.id)}>
+                      Cancel
+                    </Button>
+                  )}
                 </ListItem>
               );
             })}


### PR DESCRIPTION
Closes: UserOfficeProject/issue-tracker#1260

## Description
This PR introduces a download dialog to the FAP document store.

## Motivation and Context
The change was necessary to provide users with feedback when they initiate a file download, preventing confusion and enhancing the user experience.

## Changes
- Added a new state variable 'isLoading' to track the download status in `FileLink.tsx`.
- Created a download dialog component in `DownloadContextProvider.tsx` and made it visible when a file is being downloaded.
- Integrated the dialog with the file download function in `FileLink.tsx`. Now, whenever a user clicks a file link, the download dialog pops up until the download is complete.
  
Please note that the 'cancel' function in the download dialog is optional and will only appear if provided.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated