### PR TITLE
fix: prevent crashes when viewing a template's proposals

### DIFF
--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -534,11 +534,11 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
         if (filter?.templateIds) {
           query
             .leftJoin(
-              'questionary',
-              'questionary.questionary_id',
+              'questionaries',
+              'questionaries.questionary_id',
               'proposals.questionary_id'
             )
-            .whereIn('questionary.template_id', filter.templateIds);
+            .whereIn('questionaries.template_id', filter.templateIds);
         }
 
         if (filter?.proposalStatusId) {

--- a/apps/frontend/src/components/proposal/ProposalAttachmentDownload.tsx
+++ b/apps/frontend/src/components/proposal/ProposalAttachmentDownload.tsx
@@ -10,7 +10,10 @@ import { useSnackbar } from 'notistack';
 import React, { useState } from 'react';
 
 import { DataType, Question } from 'generated/sdk';
-import { useProposalsData } from 'hooks/proposal/useProposalsData';
+import {
+  ProposalsDataQuantity,
+  useProposalsData,
+} from 'hooks/proposal/useProposalsData';
 
 type ProposalAttachmentDownloadProps = {
   close: () => void;
@@ -26,7 +29,10 @@ const ProposalAttachmentDownload = ({
   referenceNumbers,
   downloadProposalAttachment,
 }: ProposalAttachmentDownloadProps) => {
-  const { proposalsData, loading } = useProposalsData({ referenceNumbers });
+  const { proposalsData, loading } = useProposalsData(
+    { referenceNumbers },
+    ProposalsDataQuantity.FULL
+  );
   const { enqueueSnackbar } = useSnackbar();
   const [selectedAttachmentsQuestions, setSelectedAttachmentsQuestions] =
     useState<string[]>([]);

--- a/apps/frontend/src/components/template/AnswerCountDetails.tsx
+++ b/apps/frontend/src/components/template/AnswerCountDetails.tsx
@@ -4,7 +4,10 @@ import React, { useMemo } from 'react';
 
 import CopyToClipboard from 'components/common/CopyToClipboard';
 import { ProposalFragment, TemplateCategoryId } from 'generated/sdk';
-import { useProposalsData } from 'hooks/proposal/useProposalsData';
+import {
+  ProposalsDataQuantity,
+  useProposalsData,
+} from 'hooks/proposal/useProposalsData';
 import { useSamplesWithQuestionaryStatus } from 'hooks/sample/useSamplesWithQuestionaryStatus';
 import { useShipments } from 'hooks/shipment/useShipments';
 import { QuestionWithUsage } from 'hooks/template/useQuestions';
@@ -37,7 +40,10 @@ function ProposalList({ question }: { question: QuestionWithUsage }) {
     () => question.answers.map((answer) => answer.questionaryId),
     [question]
   );
-  const { proposalsData } = useProposalsData({ questionaryIds });
+  const { proposalsData } = useProposalsData(
+    { questionaryIds },
+    ProposalsDataQuantity.MINIMAL
+  );
 
   const proposalsDataWithId = proposalsData.map((proposal) =>
     Object.assign(proposal, { id: proposal.primaryKey })

--- a/apps/frontend/src/components/template/ProposalTemplatesTable.tsx
+++ b/apps/frontend/src/components/template/ProposalTemplatesTable.tsx
@@ -2,11 +2,16 @@ import MaterialTable, { Column } from '@material-table/core';
 import { DialogActions, DialogContent } from '@mui/material';
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 
 import StyledDialog from 'components/common/StyledDialog';
-import { Proposal, ProposalTemplate, TemplateGroupId } from 'generated/sdk';
+import {
+  Proposal,
+  ProposalsFilter,
+  ProposalTemplate,
+  TemplateGroupId,
+} from 'generated/sdk';
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
 import { useCallsData } from 'hooks/call/useCallsData';
 import {
@@ -52,10 +57,12 @@ function CallsList(props: { filterTemplateId: number }) {
 }
 
 function ProposalsList(props: { filterTemplateId: number }) {
+  const filter = useMemo<ProposalsFilter>(
+    () => ({ templateIds: [props.filterTemplateId] }),
+    [props.filterTemplateId]
+  );
   const { proposalsData } = useProposalsData(
-    {
-      templateIds: [props.filterTemplateId],
-    },
+    filter,
     ProposalsDataQuantity.MINIMAL
   );
 

--- a/apps/frontend/src/components/template/ProposalTemplatesTable.tsx
+++ b/apps/frontend/src/components/template/ProposalTemplatesTable.tsx
@@ -9,7 +9,10 @@ import StyledDialog from 'components/common/StyledDialog';
 import { Proposal, ProposalTemplate, TemplateGroupId } from 'generated/sdk';
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
 import { useCallsData } from 'hooks/call/useCallsData';
-import { useProposalsData } from 'hooks/proposal/useProposalsData';
+import {
+  ProposalsDataQuantity,
+  useProposalsData,
+} from 'hooks/proposal/useProposalsData';
 import { tableIcons } from 'utils/materialIcons';
 
 import TemplatesTable, { TemplateRowDataType } from './TemplatesTable';
@@ -49,9 +52,12 @@ function CallsList(props: { filterTemplateId: number }) {
 }
 
 function ProposalsList(props: { filterTemplateId: number }) {
-  const { proposalsData } = useProposalsData({
-    templateIds: [props.filterTemplateId],
-  });
+  const { proposalsData } = useProposalsData(
+    {
+      templateIds: [props.filterTemplateId],
+    },
+    ProposalsDataQuantity.MINIMAL
+  );
 
   const proposalListColumns = [
     {

--- a/apps/frontend/src/components/template/ProposalTemplatesTable.tsx
+++ b/apps/frontend/src/components/template/ProposalTemplatesTable.tsx
@@ -201,7 +201,7 @@ function ProposalTemplatesTable(props: ProposalTemplatesTableProps) {
           setShowTemplateProposals(true);
         }}
         style={{ cursor: 'pointer' }}
-        data-cy="proposals-count"
+        data-cy={`proposals-count-${rowData.templateId}`}
       >
         {rowData.questionaryCount || 0}
       </Link>

--- a/apps/frontend/src/graphql/proposal/getProposalsMinimal.graphql
+++ b/apps/frontend/src/graphql/proposal/getProposalsMinimal.graphql
@@ -1,0 +1,13 @@
+query getProposalsMinimal($filter: ProposalsFilter) {
+  proposals(filter: $filter) {
+    proposals {
+      primaryKey
+      proposalId
+      title
+      submitted
+      status {
+        name
+      }
+    }
+  }
+}

--- a/apps/frontend/src/hooks/proposal/useProposalsData.ts
+++ b/apps/frontend/src/hooks/proposal/useProposalsData.ts
@@ -4,7 +4,15 @@ import { UserContext } from 'context/UserContextProvider';
 import { Proposal, ProposalsFilter } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 
-export function useProposalsData(filter: ProposalsFilter) {
+export enum ProposalsDataQuantity {
+  MINIMAL,
+  FULL,
+}
+
+export function useProposalsData(
+  filter: ProposalsFilter,
+  dataQuantity: ProposalsDataQuantity
+) {
   const api = useDataApi();
   const [proposalsData, setProposalsData] = useState<Proposal[]>([]);
   const [loading, setLoading] = useState(true);
@@ -26,29 +34,37 @@ export function useProposalsData(filter: ProposalsFilter) {
 
     setLoading(true);
 
-    api()
-      .getProposals({
-        filter: {
-          callId,
-          instrumentFilter,
-          proposalStatusId,
-          questionaryIds,
-          questionFilter,
-          templateIds,
-          text,
-          referenceNumbers,
-        },
-      })
-      .then((data) => {
-        if (unmounted) {
-          return;
-        }
+    let getProposals;
+    switch (dataQuantity) {
+      case ProposalsDataQuantity.FULL:
+        getProposals = api().getProposals;
+        break;
+      case ProposalsDataQuantity.MINIMAL:
+        getProposals = api().getProposalsMinimal;
+        break;
+    }
 
-        if (data.proposals) {
-          setProposalsData(data.proposals.proposals as Proposal[]);
-        }
-        setLoading(false);
-      });
+    getProposals({
+      filter: {
+        callId,
+        instrumentFilter,
+        proposalStatusId,
+        questionaryIds,
+        questionFilter,
+        templateIds,
+        text,
+        referenceNumbers,
+      },
+    }).then((data) => {
+      if (unmounted) {
+        return;
+      }
+
+      if (data.proposals) {
+        setProposalsData(data.proposals.proposals as Proposal[]);
+      }
+      setLoading(false);
+    });
 
     return () => {
       unmounted = true;
@@ -64,6 +80,7 @@ export function useProposalsData(filter: ProposalsFilter) {
     api,
     currentRole,
     referenceNumbers,
+    dataQuantity,
   ]);
 
   return { loading, proposalsData, setProposalsData };

--- a/apps/frontend/src/hooks/proposal/useProposalsData.ts
+++ b/apps/frontend/src/hooks/proposal/useProposalsData.ts
@@ -16,6 +16,7 @@ export function useProposalsData(filter: ProposalsFilter) {
     proposalStatusId,
     questionaryIds,
     questionFilter,
+    templateIds,
     text,
     referenceNumbers,
   } = filter;
@@ -33,6 +34,7 @@ export function useProposalsData(filter: ProposalsFilter) {
           proposalStatusId,
           questionaryIds,
           questionFilter,
+          templateIds,
           text,
           referenceNumbers,
         },
@@ -57,6 +59,7 @@ export function useProposalsData(filter: ProposalsFilter) {
     proposalStatusId,
     questionaryIds,
     questionFilter,
+    templateIds,
     text,
     api,
     currentRole,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Connects the template filter option to the API call in the frontend, fixes the implementation of that filter in the backend, and optimises the query it uses.

<!--- Describe your changes in detail -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I extended the e2e test for the proposals by template popup to check that the filtering is being applied properly

## Fixes

Closes https://github.com/UserOfficeProject/issue-tracker/issues/1252
<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
