### PR TITLE
refactor: remove User Office heading text

### DIFF
--- a/apps/frontend/src/components/AppToolbar/AppToolbar.tsx
+++ b/apps/frontend/src/components/AppToolbar/AppToolbar.tsx
@@ -106,9 +106,7 @@ const AppToolbar = ({ open, handleDrawerOpen, header }: AppToolbarProps) => {
             noWrap
             sx={{ flexGrow: 1 }}
           >
-            {location.pathname === '/'
-              ? 'User Office / Dashboard'
-              : 'User Office / ' + header}
+            {location.pathname === '/' ? 'Dashboard' : header}
           </Typography>
         )}
         <Box sx={{ marginLeft: 'auto', margin: theme.spacing(0, 0.5) }}>


### PR DESCRIPTION
## Description
This removes the User Office heading to make pages clearer to identify, as agreed in sprint planning.

## Motivation and Context
The "User Office" text was unnecessarily repeated on every page, making the title verbose and causing visual clutter. This change simplifies the title, improving readability and user experience.

## Changes
- The "User Office" prefix has been removed from the toolbar title. Now, the title only contains 'Dashboard' when on the home page, and the respective header for other pages.


## How Has This Been Tested?

Only manual testing that the page heading shows on each page. If there is anything else to be aware of, please let me know.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

Closes https://github.com/UserOfficeProject/issue-tracker/issues/1236

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated