### PR TITLE
chore: swap 4228 uo fe use search params type implementation

### DIFF
--- a/apps/frontend/src/components/call/CallsTable.tsx
+++ b/apps/frontend/src/components/call/CallsTable.tsx
@@ -6,9 +6,8 @@ import { DialogContent } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import i18n from 'i18n';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
 
 import ScienceIcon from 'components/common/icons/ScienceIcon';
 import StyledDialog from 'components/common/StyledDialog';
@@ -23,6 +22,7 @@ import {
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
 import { CallsDataQuantity, useCallsData } from 'hooks/call/useCallsData';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { useDownloadXLSXCallFap } from 'hooks/fap/useDownloadXLSXCallFap';
 import { tableIcons } from 'utils/materialIcons';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
@@ -63,13 +63,20 @@ const CallsTable = ({ confirm }: WithConfirmProps) => {
   >(null);
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
 
-  const [searchParam, setSearchParam] = useSearchParams({
-    callStatus: CallStatus.ACTIVE,
-  });
+  const initialParams = useMemo(
+    () => ({
+      callStatus: CallStatus.ACTIVE,
+    }),
+    []
+  );
+
+  const [typedParams, setTypedParams] = useTypeSafeSearchParams<{
+    callStatus: CallStatusFilters;
+  }>(initialParams);
 
   const exportFapData = useDownloadXLSXCallFap();
 
-  const callStatus = searchParam.get('callStatus');
+  const callStatus = typedParams.callStatus;
 
   const {
     loadingCalls,
@@ -86,12 +93,10 @@ const CallsTable = ({ confirm }: WithConfirmProps) => {
   );
 
   const handleStatusFilterChange = (callStatus: CallStatus) => {
-    setSearchParam((searchParam) => {
-      searchParam.set('callStatus', callStatus);
-
-      return searchParam;
-    });
-
+    setTypedParams((prev) => ({
+      ...prev,
+      callStatus: callStatus as CallStatusFilters,
+    }));
     setCallsFilter(() => ({
       ...getFilterStatus(callStatus as CallStatusFilters),
     }));

--- a/apps/frontend/src/components/common/SimpleTabs.tsx
+++ b/apps/frontend/src/components/common/SimpleTabs.tsx
@@ -3,8 +3,9 @@ import { useTheme } from '@mui/material/styles';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useMemo } from 'react';
+
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -58,11 +59,25 @@ const SimpleTabs = ({
 }: SimpleTabsProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery('(max-width: 500px)');
-  const [searchParams, setSearchParams] = useSearchParams();
 
-  const tab = searchParams.get('tab') ?? '0';
-  const modalTab = searchParams.get('modalTab') ?? '0';
-  const verticalTab = searchParams.get('verticalTab') ?? '0';
+  const initialParams = useMemo(
+    () => ({
+      verticalTab: null,
+      modalTab: null,
+      tab: null,
+    }),
+    []
+  );
+
+  const [typedParams, setTypedParams] = useTypeSafeSearchParams<{
+    verticalTab: number | null;
+    modalTab: number | null;
+    tab: number | null;
+  }>(initialParams);
+  typedParams;
+  const tab = typedParams.tab ?? 0;
+  const modalTab = typedParams.modalTab ?? 0;
+  const verticalTab = typedParams.verticalTab ?? 0;
 
   const noItems = children.length === 0;
 
@@ -99,29 +114,20 @@ const SimpleTabs = ({
     const tabValue = newValue > 0 ? newValue : undefined;
 
     if (isVerticalOrientation) {
-      setSearchParams((searchParam) => {
-        const searchParamCloned = new URLSearchParams(searchParam);
-        searchParamCloned.delete('verticalTab');
-        if (tabValue) searchParamCloned.append('verticalTab', String(tabValue));
-
-        return searchParamCloned;
-      });
+      setTypedParams((prev) => ({
+        ...prev,
+        verticalTab: tabValue ?? null,
+      }));
     } else if (isInsideModal) {
-      setSearchParams((searchParam) => {
-        const searchParamCloned = new URLSearchParams(searchParam);
-        searchParamCloned.delete('modalTab');
-        if (tabValue) searchParamCloned.append('modalTab', String(tabValue));
-
-        return searchParamCloned;
-      });
+      setTypedParams((prev) => ({
+        ...prev,
+        modalTab: tabValue ?? null,
+      }));
     } else {
-      setSearchParams((searchParam) => {
-        const searchParamCloned = new URLSearchParams(searchParam);
-        searchParamCloned.delete('tab');
-        if (tabValue) searchParamCloned.append('tab', String(tabValue));
-
-        return searchParamCloned;
-      });
+      setTypedParams((prev) => ({
+        ...prev,
+        tab: tabValue ?? null,
+      }));
     }
   };
 

--- a/apps/frontend/src/components/common/proposalFilters/CallFilter.tsx
+++ b/apps/frontend/src/components/common/proposalFilters/CallFilter.tsx
@@ -3,10 +3,10 @@ import Box from '@mui/material/Box';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import TextField from '@mui/material/TextField';
-import React, { Dispatch } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { Dispatch, useMemo } from 'react';
 
 import { Call } from 'generated/sdk';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 type CallFilterProps = {
   calls?: Pick<Call, 'shortCode' | 'id'>[];
@@ -23,7 +23,16 @@ const CallFilter = ({
   onChange,
   shouldShowAll,
 }: CallFilterProps) => {
-  const [, setSearchParams] = useSearchParams();
+  const initialParams = useMemo(
+    () => ({
+      call: null,
+    }),
+    []
+  );
+
+  const [, setTypedParams] = useTypeSafeSearchParams<{
+    call: number | null;
+  }>(initialParams);
 
   if (calls === undefined) {
     return null;
@@ -66,12 +75,10 @@ const CallFilter = ({
              */
             disableClearable
             onChange={(_, call) => {
-              setSearchParams((searchParams) => {
-                searchParams.delete('call');
-                if (call?.id) searchParams.set('call', String(call.id));
-
-                return searchParams;
-              });
+              setTypedParams((prev) => ({
+                ...prev,
+                call: call.id,
+              }));
               onChange?.(call?.id as number);
             }}
             getOptionLabel={(option) => option.shortCode}

--- a/apps/frontend/src/components/common/proposalFilters/InstrumentFilter.tsx
+++ b/apps/frontend/src/components/common/proposalFilters/InstrumentFilter.tsx
@@ -5,14 +5,14 @@ import InputLabel from '@mui/material/InputLabel';
 import ListSubheader from '@mui/material/ListSubheader';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
-import React, { Dispatch } from 'react';
+import React, { Dispatch, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
 
 import {
   InstrumentFilterInput,
   InstrumentMinimalFragment,
 } from 'generated/sdk';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 export enum InstrumentFilterEnum {
   ALL = 'all',
@@ -38,7 +38,17 @@ const InstrumentFilter = ({
   shouldShowMultiple,
   showMultiInstrumentProposals,
 }: InstrumentFilterProps) => {
-  const [, setSearchParams] = useSearchParams();
+  const initialParams = useMemo(
+    () => ({
+      instrument: InstrumentFilterEnum.ALL,
+    }),
+    []
+  );
+
+  const [, setTypedParams] = useTypeSafeSearchParams<{
+    instrument: InstrumentFilterEnum;
+  }>(initialParams);
+
   const { t } = useTranslation();
 
   if (instruments === undefined) {
@@ -68,17 +78,11 @@ const InstrumentFilter = ({
                 showAllProposals: false,
               };
 
-              setSearchParams((searchParams) => {
-                searchParams.delete('instrument');
-                if (
-                  e.target.value &&
-                  e.target.value != InstrumentFilterEnum.ALL
-                ) {
-                  searchParams.set('instrument', e.target.value.toString());
-                }
+              setTypedParams((prev) => ({
+                ...prev,
+                instrument: e.target.value as InstrumentFilterEnum,
+              }));
 
-                return searchParams;
-              });
               if (
                 e.target.value === InstrumentFilterEnum.ALL ||
                 e.target.value === InstrumentFilterEnum.MULTI

--- a/apps/frontend/src/components/common/proposalFilters/ProposalStatusFilter.tsx
+++ b/apps/frontend/src/components/common/proposalFilters/ProposalStatusFilter.tsx
@@ -4,10 +4,10 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import PropTypes from 'prop-types';
-import React, { Dispatch } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { Dispatch, useMemo } from 'react';
 
 import { ProposalStatus } from 'generated/sdk';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 type ProposalStatusFilterProps = {
   proposalStatuses?: ProposalStatus[];
@@ -39,7 +39,17 @@ const ProposalStatusFilter = ({
   shouldShowAll,
   hiddenStatuses,
 }: ProposalStatusFilterProps) => {
-  const [, setSearchParams] = useSearchParams();
+  const initialParams = useMemo(
+    () => ({
+      proposalStatus: null,
+    }),
+    []
+  );
+
+  const [, setTypedParams] = useTypeSafeSearchParams<{
+    proposalStatus: string | null;
+  }>(initialParams);
+
   if (proposalStatuses === undefined) {
     return null;
   }
@@ -61,17 +71,13 @@ const ProposalStatusFilter = ({
             id="proposal-status-select"
             aria-labelledby="proposal-status-select-label"
             onChange={(proposalStatus) => {
-              setSearchParams((searchParams) => {
-                searchParams.delete('proposalStatus');
-                if (proposalStatus.target.value && !!shouldShowAll) {
-                  searchParams.set(
-                    'proposalStatus',
-                    proposalStatus.target.value.toString()
-                  );
-                }
+              if (proposalStatus.target.value && !!shouldShowAll) {
+                setTypedParams((prev) => ({
+                  ...prev,
+                  proposalStatus: proposalStatus.target.value.toString(),
+                }));
+              }
 
-                return searchParams;
-              });
               onChange?.(proposalStatus.target.value as number);
             }}
             value={proposalStatusId || 0}

--- a/apps/frontend/src/components/common/proposalFilters/TechniqueFilter.tsx
+++ b/apps/frontend/src/components/common/proposalFilters/TechniqueFilter.tsx
@@ -5,11 +5,11 @@ import InputLabel from '@mui/material/InputLabel';
 import ListSubheader from '@mui/material/ListSubheader';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
-import React, { Dispatch } from 'react';
+import React, { Dispatch, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
 
 import { TechniqueMinimalFragment, TechniqueFilterInput } from 'generated/sdk';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 export enum TechniqueFilterEnum {
   ALL = 'all',
@@ -35,7 +35,17 @@ const TechniqueFilter = ({
   shouldShowMultiple,
   showMultiTechniqueProposals,
 }: TechniqueFilterProps) => {
-  const [, setSearchParams] = useSearchParams();
+  const initialParams = useMemo(
+    () => ({
+      technique: TechniqueFilterEnum.ALL,
+    }),
+    []
+  );
+
+  const [, setTypedParams] = useTypeSafeSearchParams<{
+    technique: TechniqueFilterEnum;
+  }>(initialParams);
+
   const { t } = useTranslation();
 
   if (techniques === undefined) {
@@ -60,18 +70,10 @@ const TechniqueFilter = ({
                 showMultiTechniqueProposals: false,
                 showAllProposals: false,
               };
-              setSearchParams((searchParams) => {
-                searchParams.delete('technique');
-
-                if (
-                  e.target.value &&
-                  e.target.value != TechniqueFilterEnum.ALL
-                ) {
-                  searchParams.set('technique', e.target.value.toString());
-                }
-
-                return searchParams;
-              });
+              setTypedParams((prev) => ({
+                ...prev,
+                technique: e.target.value as TechniqueFilterEnum,
+              }));
               if (
                 e.target.value === TechniqueFilterEnum.ALL ||
                 e.target.value === TechniqueFilterEnum.MULTI

--- a/apps/frontend/src/components/experiment/ExperimentFilterBar.tsx
+++ b/apps/frontend/src/components/experiment/ExperimentFilterBar.tsx
@@ -1,40 +1,46 @@
 import Grid from '@mui/material/Grid';
 import { DateTime } from 'luxon';
-import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useMemo } from 'react';
 
 import CallFilter from 'components/common/proposalFilters/CallFilter';
 import InstrumentFilter from 'components/common/proposalFilters/InstrumentFilter';
 import { useCallsData } from 'hooks/call/useCallsData';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 
 import DateFilter from './DateFilter';
 
 function ExperimentFilterBar() {
-  const [searchParams, setSearchParam] = useSearchParams();
-  const call = searchParams.get('call');
-  const instrument = searchParams.get('instrument');
-  const experimentFromDate = searchParams.get('from');
-  const experimentToDate = searchParams.get('to');
+  const initialParams = useMemo(
+    () => ({
+      call: null,
+      instrument: null,
+      from: null,
+      to: null,
+    }),
+    []
+  );
+
+  const [typedParams, setTypedParams] = useTypeSafeSearchParams<{
+    call: string | null;
+    instrument: string | null;
+    from: string | null;
+    to: string | null;
+  }>(initialParams);
+  const call = typedParams.call;
+  const instrument = typedParams.instrument;
+  const experimentFromDate = typedParams.from;
+  const experimentToDate = typedParams.to;
 
   const { instruments, loadingInstruments } = useInstrumentsMinimalData();
   const { calls, loadingCalls } = useCallsData();
 
   const handleOnChange = (format: string, from?: Date, to?: Date) => {
-    setSearchParam((searchParam) => {
-      searchParam.delete('from');
-      searchParam.delete('to');
-
-      if (from) {
-        searchParam.set('from', DateTime.fromJSDate(from).toFormat(format));
-      }
-
-      if (to) {
-        searchParam.set('to', DateTime.fromJSDate(to).toFormat(format));
-      }
-
-      return searchParam;
-    });
+    setTypedParams((prev) => ({
+      ...prev,
+      from: from ? DateTime.fromJSDate(from).toFormat(format) : null,
+      to: to ? DateTime.fromJSDate(to).toFormat(format) : null,
+    }));
   };
 
   return (

--- a/apps/frontend/src/components/experiment/ExperimentTable.tsx
+++ b/apps/frontend/src/components/experiment/ExperimentTable.tsx
@@ -1,14 +1,14 @@
 import { Typography } from '@mui/material';
 import { TFunction } from 'i18next';
 import { DateTime } from 'luxon';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
 
 import SuperMaterialTable from 'components/common/SuperMaterialTable';
 import ProposalEsiDetailsButton from 'components/questionary/questionaryComponents/ProposalEsiBasis/ProposalEsiDetailsButton';
 import { GetScheduledEventsCoreQuery, SettingsId } from 'generated/sdk';
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { useScheduledEvents } from 'hooks/scheduledEvent/useScheduledEvents';
 import { tableIcons } from 'utils/materialIcons';
 import { getFullUserName } from 'utils/user';
@@ -19,11 +19,30 @@ import ExperimentVisitsTable from './ExperimentVisitsTable';
 type RowType = GetScheduledEventsCoreQuery['scheduledEventsCore'][0];
 
 function ExperimentTable() {
-  const [searchParams] = useSearchParams();
-  const call = searchParams.get('call');
-  const instrument = searchParams.get('instrument');
-  const experimentFromDate = searchParams.get('from');
-  const experimentToDate = searchParams.get('to');
+  const initialParams = useMemo(
+    () => ({
+      call: null,
+      instrument: null,
+      from: null,
+      to: null,
+    }),
+    []
+  );
+
+  const [typedParams] = useTypeSafeSearchParams<{
+    call: string | null;
+    instrument: string | null;
+    from: string | null;
+    to: string | null;
+  }>(initialParams);
+
+  const {
+    call,
+    instrument,
+    from: experimentFromDate,
+    to: experimentToDate,
+  } = typedParams;
+
   const { scheduledEvents, setScheduledEvents, loadingEvents, setArgs } =
     useScheduledEvents({});
 

--- a/apps/frontend/src/components/fap/FapsTable.tsx
+++ b/apps/frontend/src/components/fap/FapsTable.tsx
@@ -2,9 +2,9 @@ import { Column } from '@material-table/core';
 import Edit from '@mui/icons-material/Edit';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-import React, { useContext, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 
 import CopyToClipboard from 'components/common/CopyToClipboard';
 import SuperMaterialTable from 'components/common/SuperMaterialTable';
@@ -13,6 +13,7 @@ import AddFap from 'components/fap/General/AddFap';
 import { UserContext } from 'context/UserContextProvider';
 import { Fap, FapMinimalFragment, UserRole } from 'generated/sdk';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { useFapsData } from 'hooks/fap/useFapsData';
 import { tableIcons } from 'utils/materialIcons';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
@@ -62,18 +63,28 @@ const FapsTable = () => {
   });
   const [editFapID, setEditFapID] = useState(0);
 
-  const [searchParam, setSearchParam] = useSearchParams();
-  const fapStatus = searchParam.get('fapStatus');
+  const initialParams = useMemo(
+    () => ({
+      fapStatus: FapStatus.ACTIVE,
+    }),
+    []
+  );
+
+  const [typedParams, setTypedParams] = useTypeSafeSearchParams<{
+    fapStatus: FapStatus;
+  }>(initialParams);
+
+  const { fapStatus } = typedParams;
 
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
   const { t } = useTranslation();
 
   const handleStatusFilterChange = (fapStatus: FapStatus) => {
-    setSearchParam((searchParam) => {
-      searchParam.set('fapStatus', fapStatus);
+    setTypedParams((prev) => ({
+      ...prev,
+      fapStatus,
+    }));
 
-      return searchParam;
-    });
     if (fapStatus === FapStatus.ALL) {
       setIsActiveFilter(undefined);
     } else {

--- a/apps/frontend/src/components/fap/MeetingComponents/FapInstrumentProposalsTable.tsx
+++ b/apps/frontend/src/components/fap/MeetingComponents/FapInstrumentProposalsTable.tsx
@@ -10,9 +10,14 @@ import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import { useTheme } from '@mui/material/styles';
 import Tooltip from '@mui/material/Tooltip';
-import React, { useContext, DragEvent, useState, useEffect } from 'react';
+import React, {
+  useContext,
+  DragEvent,
+  useState,
+  useEffect,
+  useMemo,
+} from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
 
 import { UserContext } from 'context/UserContextProvider';
 import {
@@ -26,6 +31,7 @@ import {
   ProposalPkWithRankOrder,
 } from 'generated/sdk';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { useFapProposalsByInstrument } from 'hooks/fap/useFapProposalsByInstrument';
 import { tableIcons } from 'utils/materialIcons';
 import {
@@ -101,9 +107,18 @@ const FapInstrumentProposalsTable = ({
   fapId,
   selectedCall,
 }: FapInstrumentProposalsTableProps) => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const initialParams = useMemo(
+    () => ({
+      fapMeetingModal: null,
+    }),
+    []
+  );
 
-  const fapMeetingModal = searchParams.get('fapMeetingModal');
+  const [typedParams, setTypedParams] = useTypeSafeSearchParams<{
+    fapMeetingModal: string | null;
+  }>(initialParams);
+
+  const { fapMeetingModal } = typedParams;
 
   const {
     instrumentProposalsData,
@@ -408,14 +423,10 @@ const FapInstrumentProposalsTable = ({
             <IconButton
               color="inherit"
               onClick={() => {
-                setSearchParams((searchParams) => {
-                  searchParams.set(
-                    'fapMeetingModal',
-                    String(rowData.proposal.primaryKey)
-                  );
-
-                  return searchParams;
-                });
+                setTypedParams((prev) => ({
+                  ...prev,
+                  fapMeetingModal: String(rowData.proposal.primaryKey),
+                }));
                 setOpenProposal(rowData.proposal);
               }}
             >
@@ -726,11 +737,10 @@ const FapInstrumentProposalsTable = ({
           !!fapMeetingModal && +fapMeetingModal === openProposal?.primaryKey
         }
         setProposalViewModalOpen={() => {
-          setSearchParams((searchParams) => {
-            searchParams.delete('fapMeetingModal');
-
-            return searchParams;
-          });
+          setTypedParams((prev) => ({
+            ...prev,
+            fapMeetingModal: null,
+          }));
           setOpenProposal(null);
           refreshInstrumentProposalsData();
         }}

--- a/apps/frontend/src/components/fap/MeetingComponents/FapMeetingComponentsView.tsx
+++ b/apps/frontend/src/components/fap/MeetingComponents/FapMeetingComponentsView.tsx
@@ -1,10 +1,10 @@
 import Grid from '@mui/material/Grid';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useEffect, useMemo } from 'react';
 
 import CallFilter from 'components/common/proposalFilters/CallFilter';
 import { useCallsData } from 'hooks/call/useCallsData';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 import FapMeetingInstrumentsTable from './FapMeetingInstrumentsTable';
 
@@ -19,18 +19,26 @@ const FapMeetingComponentsView = ({
 }: FapMeetingComponentsViewProps) => {
   const { loadingCalls, calls } = useCallsData({ fapIds: [fapId] });
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const initialParams = useMemo(
+    () => ({
+      call: null,
+    }),
+    []
+  );
 
-  const call = searchParams.get('call');
+  const [typedParams, setTypedParams] = useTypeSafeSearchParams<{
+    call: string | null;
+  }>(initialParams);
+
+  const { call } = typedParams;
   useEffect(() => {
     if (calls.length && !call) {
-      setSearchParams((searchParams) => {
-        searchParams.set('call', calls[0].id.toString());
-
-        return searchParams;
-      });
+      setTypedParams((prev) => ({
+        ...prev,
+        call: calls[0].id.toString(),
+      }));
     }
-  }, [call, calls, setSearchParams]);
+  }, [call, calls, setTypedParams]);
 
   const selectedCall = calls.find((c) => call && c.id === +call);
 

--- a/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsView.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsView.tsx
@@ -1,10 +1,10 @@
 import Grid from '@mui/material/Grid';
-import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useMemo } from 'react';
 
 import CallFilter from 'components/common/proposalFilters/CallFilter';
 import { Fap } from 'generated/sdk';
 import { useCallsData } from 'hooks/call/useCallsData';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 import FapProposalsAndAssignmentsTable from './FapProposalsAndAssignmentsTable';
 
@@ -21,8 +21,18 @@ const FapProposalsAndAssignments = ({
   const { loadingCalls, calls } = useCallsData({ fapIds: [fapData.id] });
   // NOTE: Default null means load all calls if nothing is selected
 
-  const [searchParams] = useSearchParams();
-  const call = searchParams.get('call');
+  const initialParams = useMemo(
+    () => ({
+      call: null,
+    }),
+    []
+  );
+
+  const [typedParams] = useTypeSafeSearchParams<{
+    call: string | null;
+  }>(initialParams);
+
+  const { call } = typedParams;
 
   return (
     <>

--- a/apps/frontend/src/components/proposal/ProposalPage.tsx
+++ b/apps/frontend/src/components/proposal/ProposalPage.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useMemo } from 'react';
 
 import { ProposalsFilter } from 'generated/sdk';
 import { useCallsData } from 'hooks/call/useCallsData';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 import { useProposalStatusesData } from 'hooks/settings/useProposalStatusesData';
 import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
@@ -26,16 +26,45 @@ export interface ProposalUrlQueryParams extends URLSearchParams {
 }
 
 export default function ProposalPage() {
-  const [searchParams] = useSearchParams();
+  const initialParams = useMemo(
+    () => ({
+      call: null,
+      instrument: null,
+      proposalStatus: null,
+      reviewModal: null,
+      modalTab: null,
+      questionId: null,
+      proposalId: null,
+      compareOperator: null,
+      value: null,
+      dataType: null,
+    }),
+    []
+  );
 
-  const callId = searchParams.get('call');
-  const instrumentId = searchParams.get('instrument');
-  const proposalStatusId = searchParams.get('proposalStatus');
-  const questionId = searchParams.get('questionId');
-  const proposalId = searchParams.get('proposalId');
-  const compareOperator = searchParams.get('compareOperator');
-  const value = searchParams.get('value');
-  const dataType = searchParams.get('dataType');
+  const [typedParams] = useTypeSafeSearchParams<{
+    call: string | null;
+    instrument: string | null;
+    proposalStatus: string | null;
+    reviewModal: string | null;
+    modalTab: string | null;
+    questionId: string | null;
+    proposalId: string | null;
+    compareOperator: string | null;
+    value: string | null;
+    dataType: string | null;
+  }>(initialParams);
+
+  const {
+    call: callId,
+    instrument: instrumentId,
+    proposalStatus: proposalStatusId,
+    questionId,
+    proposalId,
+    compareOperator,
+    value,
+    dataType,
+  } = typedParams;
 
   const [proposalFilter, setProposalFilter] = React.useState<ProposalsFilter>({
     callId: callId ? +callId : undefined,

--- a/apps/frontend/src/components/proposal/TableActionsDropdownMenu.tsx
+++ b/apps/frontend/src/components/proposal/TableActionsDropdownMenu.tsx
@@ -6,8 +6,10 @@ import {
   Menu,
   MenuItem,
 } from '@mui/material';
-import React, { useEffect } from 'react';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import React, { useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 type TableActionsDropdownMenuProps = {
   event: null | HTMLElement;
@@ -119,16 +121,26 @@ const TableActionsDropdownMenu = ({
   );
   const [open, setOpen] = React.useState<boolean>(false);
   const [menuItems, setMenuItems] = React.useState(getMenuItems());
-  const [searchParams] = useSearchParams();
+  const initialParams = useMemo(
+    () => ({
+      selection: [],
+    }),
+    []
+  );
+
+  const [typedParams] = useTypeSafeSearchParams<{
+    selection: string[];
+  }>(initialParams);
+
   const { search } = useLocation();
 
   useEffect(() => {
-    if (searchParams.getAll('selection').length <= 1) {
+    if (typedParams.selection.length === 0) {
       setMenuItems(getMenuItems(false));
     } else {
       setMenuItems(getMenuItems());
     }
-  }, [search, searchParams]);
+  }, [search, typedParams.selection.length]);
 
   useEffect(() => {
     if (event) {

--- a/apps/frontend/src/components/proposalBooking/InstrSciUpcomingExperimentTimesTable.tsx
+++ b/apps/frontend/src/components/proposalBooking/InstrSciUpcomingExperimentTimesTable.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useMemo, useState } from 'react';
 
 import InstrumentFilter from 'components/common/proposalFilters/InstrumentFilter';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { useInstrumentsMinimalData } from 'hooks/instrument/useInstrumentsMinimalData';
 import { useProposalBookingsScheduledEvents } from 'hooks/proposalBooking/useProposalBookingsScheduledEvents';
 import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
@@ -9,9 +9,18 @@ import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
 import ExperimentsTable from './ExperimentTimesTable';
 
 export default function InstrSciUpcomingExperimentTimesTable() {
-  const [searchParams] = useSearchParams();
-  const instrumentId = searchParams.get('instrument');
+  const initialParams = useMemo(
+    () => ({
+      instrument: null,
+    }),
+    []
+  );
 
+  const [typedParams] = useTypeSafeSearchParams<{
+    instrument: string | null;
+  }>(initialParams);
+
+  const instrumentId = typedParams.instrument;
   const { instruments, loadingInstruments } = useInstrumentsMinimalData();
 
   const [selectedInstrumentId, setSelectedInstrumentId] = useState<

--- a/apps/frontend/src/components/review/ReviewerFilter.tsx
+++ b/apps/frontend/src/components/review/ReviewerFilter.tsx
@@ -2,11 +2,11 @@ import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
-import React, { useContext } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useContext, useMemo } from 'react';
 
 import { SettingsContext } from 'context/SettingsContextProvider';
 import { ReviewerFilter, SettingsId } from 'generated/sdk';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 
 type ReviewerFilterComponentProps = {
   reviewer: string;
@@ -30,9 +30,17 @@ const ReviewerFilterComponent = ({
   if (!reviewerFilter) {
     reviewerFilter = ReviewerFilter.ME;
   }
-  const [, setSearchParams] = useSearchParams({
-    reviewer: reviewerFilter,
-  });
+
+  const initialParams = useMemo(
+    () => ({
+      reviewer: reviewerFilter,
+    }),
+    [reviewerFilter]
+  );
+
+  const [, setTypedParams] = useTypeSafeSearchParams<{
+    reviewer: string;
+  }>(initialParams);
 
   return (
     <FormControl fullWidth>
@@ -40,11 +48,10 @@ const ReviewerFilterComponent = ({
       <Select
         id="reviewer-selection"
         onChange={(e) => {
-          setSearchParams((searchParam) => {
-            searchParam.set('reviewer', e.target.value as string);
-
-            return searchParam;
-          });
+          setTypedParams((prev) => ({
+            ...prev,
+            reviewer: e.target.value as string,
+          }));
           onChange?.(e.target.value as ReviewerFilter);
         }}
         value={reviewer}

--- a/apps/frontend/src/components/sample/SampleSafetyPage.tsx
+++ b/apps/frontend/src/components/sample/SampleSafetyPage.tsx
@@ -10,8 +10,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { Field, Form, Formik } from 'formik';
-import React, { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { ActionButtonContainer } from 'components/common/ActionButtonContainer';
 import TextField from 'components/common/FormikUITextField';
@@ -19,6 +18,7 @@ import CallFilter from 'components/common/proposalFilters/CallFilter';
 import StyledDialog from 'components/common/StyledDialog';
 import { Maybe, SampleStatus } from 'generated/sdk';
 import { useCallsData } from 'hooks/call/useCallsData';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { useDownloadPDFSample } from 'hooks/sample/useDownloadPDFSample';
 import { SampleWithProposalData } from 'models/questionary/sample/SampleWithProposalData';
 import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
@@ -177,9 +177,19 @@ const columns = [
 function SampleSafetyPage() {
   const { api, isExecutingCall } = useDataApiWithFeedback();
   const { calls, loadingCalls } = useCallsData({ isActive: true });
-  const [searchParam] = useSearchParams();
-  const call = searchParam.get('call');
 
+  const initialParams = useMemo(
+    () => ({
+      callId: null,
+    }),
+    []
+  );
+
+  const [typedParams] = useTypeSafeSearchParams<{
+    callId: string | null;
+  }>(initialParams);
+
+  const call = typedParams.callId;
   const [selectedCallId, setSelectedCallId] = useState<number>(
     call ? +call : 0
   );

--- a/apps/frontend/src/components/sample/SamplesTable.tsx
+++ b/apps/frontend/src/components/sample/SamplesTable.tsx
@@ -3,9 +3,9 @@ import MaterialTable, {
   Column,
 } from '@material-table/core';
 import { Typography } from '@mui/material';
-import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useMemo } from 'react';
 
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import { SampleWithProposalData } from 'models/questionary/sample/SampleWithProposalData';
 import { tableIcons } from 'utils/materialIcons';
 
@@ -20,8 +20,18 @@ const SamplesTable = (
     columns?: Column<SampleWithProposalData>[];
   }
 ) => {
-  const [searchParam, setSearchParam] = useSearchParams();
-  const search = searchParam.get('search');
+  const initialParams = useMemo(
+    () => ({
+      search: null,
+    }),
+    []
+  );
+
+  const [typedParams, setTypedParams] = useTypeSafeSearchParams<{
+    search: string | null;
+  }>(initialParams);
+
+  const search = typedParams.search;
 
   return (
     <div data-cy="samples-table">
@@ -34,11 +44,10 @@ const SamplesTable = (
           </Typography>
         }
         onSearchChange={(searchText) => {
-          setSearchParam((searchParam) => {
-            searchParam.set('search', searchText);
-
-            return searchParam;
-          });
+          setTypedParams((prev) => ({
+            ...prev,
+            search: searchText,
+          }));
         }}
         options={{
           ...props.options,

--- a/apps/frontend/src/components/user/ExternalAuth.tsx
+++ b/apps/frontend/src/components/user/ExternalAuth.tsx
@@ -1,8 +1,8 @@
 import BugReportIcon from '@mui/icons-material/BugReport';
 import Lock from '@mui/icons-material/Lock';
 import { Button } from '@mui/material';
-import React, { useContext, useEffect, useRef } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import AnimatedEllipsis from 'components/AnimatedEllipsis';
 import CenteredAlert from 'components/common/CenteredAlert';
@@ -10,6 +10,7 @@ import { SettingsContext } from 'context/SettingsContextProvider';
 import { UserContext } from 'context/UserContextProvider';
 import { SettingsId } from 'generated/sdk';
 import { useUnauthorizedApi } from 'hooks/common/useDataApi';
+import { useTypeSafeSearchParams } from 'hooks/common/useTypeSafeSearchParams';
 import clearSession from 'utils/clearSession';
 
 export const getCurrentUrlValues = () => {
@@ -30,11 +31,29 @@ export const getCurrentUrlValues = () => {
 };
 
 function ExternalAuth() {
-  const [searchParams] = useSearchParams();
-  const sessionid = searchParams.get('sessionid');
-  const code = searchParams.get('code');
-  const token = searchParams.get('token');
-  const errorDescription = searchParams.get('error_description');
+  const initialParams = useMemo(
+    () => ({
+      sessionid: null,
+      code: null,
+      token: null,
+      error_description: null,
+    }),
+    []
+  );
+
+  const [typedParams] = useTypeSafeSearchParams<{
+    sessionid: string | null;
+    code: string | null;
+    token: string | null;
+    error_description: string | null;
+  }>(initialParams);
+
+  const {
+    sessionid,
+    code,
+    token,
+    error_description: errorDescription,
+  } = typedParams;
 
   const unauthorizedApi = useUnauthorizedApi();
   const navigate = useNavigate();

--- a/apps/frontend/src/hooks/common/useTypeSafeSearchParams.ts
+++ b/apps/frontend/src/hooks/common/useTypeSafeSearchParams.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+type SearchParamTypePrimitive = string | number | boolean | null;
+
+export type SearchParamsType = Record<
+  string,
+  SearchParamTypePrimitive | Array<SearchParamTypePrimitive>
+>;
+
+export function useTypeSafeSearchParams<T extends SearchParamsType>(
+  initialParams: T
+): [T, (updater: (prev: T) => T) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [typedParams, setTypedParams] = useState<T>(initialParams);
+
+  // Sync from URL to state
+  useEffect(() => {
+    const newParams = { ...initialParams };
+    Object.keys(newParams).forEach((key) => {
+      const value = searchParams.get(key);
+      if (value !== null) {
+        Reflect.set(newParams, key, value);
+      }
+    });
+    setTypedParams(newParams);
+  }, [searchParams, initialParams]);
+
+  // Sync from state to URL
+  const setTypedSearchParams = useCallback(
+    (updater: (prev: T) => T) => {
+      setTypedParams((prev) => {
+        const newParams = updater(prev);
+
+        setSearchParams((searchParams) => {
+          Object.keys(newParams).forEach((key) => {
+            const value = Reflect.get(newParams, key);
+            if (
+              value === null ||
+              value === undefined ||
+              value === '' ||
+              (Array.isArray(value) && value.length === 0)
+            ) {
+              searchParams.delete(key);
+            } else {
+              searchParams.set(key, String(value));
+            }
+          });
+
+          return searchParams;
+        });
+
+        return newParams;
+      });
+    },
+    [setSearchParams]
+  );
+
+  return [typedParams, setTypedSearchParams];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,12 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.0.0, ansi-styles@^6.2.1:
+ansi-styles@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
+
+ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -149,7 +154,7 @@ commander@~12.1.0:
 
 concurrently@^9.0.1:
   version "9.1.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-9.1.0.tgz#8da6d609f4321752912dab9be8710232ac496aa0"
+  resolved "https://registry.npmjs.org/concurrently/-/concurrently-9.1.0.tgz"
   integrity sha512-VxkzwMAn4LP7WyMnJNbHN5mKV9L2IbyDjpzemKr99sXNR3GqRNMMHdm7prV1ws9wg7ETj6WUkNOigZVsptwbgg==
   dependencies:
     chalk "^4.1.2"
@@ -162,7 +167,7 @@ concurrently@^9.0.1:
 
 cross-spawn@^7.0.3:
   version "7.0.6"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
@@ -269,7 +274,7 @@ human-signals@^5.0.0:
 
 husky@^9.0.10:
   version "9.1.7"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  resolved "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz"
   integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
 
 is-fullwidth-code-point@^3.0.0:


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Add strong typings to the query params implementation. This is the improvement to the PR https://github.com/UserOfficeProject/user-office-core/pull/748

## Motivation and Context

In the current implementation of useSearchParams from react-router, it is not typed. To improve the quality of the code, a hook should be created that adds the layer of typings to the various query parameters. 

## How Has This Been Tested

Manually. e2e tests are already covered. 

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
