### PR TITLE
fix: refactor getting call details for proposal downloads

### DIFF
--- a/apps/backend/src/factory/pdf/proposal.ts
+++ b/apps/backend/src/factory/pdf/proposal.ts
@@ -239,6 +239,10 @@ export const collectProposalPDFData = async (
 
   const call = await baseContext.queries.call.get(user, proposal.callId);
 
+  if (call === null) {
+    throw new Error('Call not found for the proposal');
+  }
+
   /*
    * Because naming things is hard, the PDF template ID is the templateId for
    * for the PdfTemplate and not the pdfTemplateId.
@@ -386,10 +390,7 @@ export const collectProposalPDFData = async (
           : [Number(answer.value?.instrumentId || '0')];
         const instruments =
           await baseContext.queries.instrument.getInstrumentsByIds(user, ids);
-        const call = await baseContext.queries.call.getCallOfAnswersProposal(
-          user,
-          answer.answerId
-        );
+
         answer.value = instrumentPickerAnswer(answer, instruments, call);
       } else if (answer.question.dataType === DataType.TECHNIQUE_PICKER) {
         const techniqueIds = Array.isArray(answer.value)


### PR DESCRIPTION
## Description
This PR refactors the way we retrieve call details for proposal downloads, enhancing the overall code quality and error handling. 

## Motivation and Context
Previously, the call details retrieval for proposal downloads was not optimally structured and lacked proper error handling. This could result in unexpected behaviors if a call was not found for a proposal. This refactor aims to improve the robustness of the code and provide better error handling.

## Changes
1. Added an error condition to throw an error if the call associated with a proposal is not found, ensuring the code fails fast and predictably in such a scenario.
2. Removed redundant call fetching in the 'collectProposalPDFData' function, simplifying the function's logic. The call details are fetched once at the beginning and used throughout the function.
3. The changes have been made in the 'proposal.ts' file in the 'pdf' module of the backend application.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

https://github.com/UserOfficeProject/issue-tracker/issues/1278

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated