### PR TITLE
feat: send instrument selection events to RabbitMQ

### DIFF
--- a/apps/backend/src/eventHandlers/messageBroker.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.ts
@@ -277,6 +277,16 @@ export async function createPostToRabbitMQHandler() {
         );
         break;
       }
+      case Event.PROPOSAL_INSTRUMENTS_SELECTED: {
+        const jsonMessage = JSON.stringify(event.instrumentshasproposals);
+
+        await rabbitMQ.sendMessageToExchange(
+          EXCHANGE_NAME,
+          event.type,
+          jsonMessage
+        );
+        break;
+      }
       case Event.USER_UPDATED:
       case Event.USER_DELETED: {
         const jsonMessage = JSON.stringify(event.user);


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->

Sends the [already generated instrument selection events](https://github.com/UserOfficeProject/user-office-core/blob/2cee6d98122a15f1c3aa908790556296886ea709/apps/backend/src/mutations/InstrumentMutations.ts#L145) to rabbitmq so that we can respond to Xpress instrument changes in our downstream software.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

While the process for entering reviews on xpress proposals should be to assign the instrument and then change the proposals status, it's possible that a reviewer will do them out of order, or select the wrong instrument by mistake and need to change it. To ensure our downstream data is accurate we need to be informed of changes to both instrument and status.

## How Has This Been Tested

- submitting xpress proposals locally and inspecting the rabbitmq queue with the admin interface
- modifying the downstream software that will consume the events from rabbitmq

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

Closes https://github.com/UserOfficeProject/issue-tracker/issues/1286

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
