### PR TITLE
feat: add tool tips in Xpress management page

### DIFF
--- a/apps/frontend/src/components/xpress/ProposalScientistComment.tsx
+++ b/apps/frontend/src/components/xpress/ProposalScientistComment.tsx
@@ -1,4 +1,12 @@
-import { Button, DialogContent, Grid, Typography } from '@mui/material';
+import { Info } from '@mui/icons-material';
+import {
+  Button,
+  DialogContent,
+  Grid,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { Form, Formik } from 'formik';
 import React from 'react';
 import * as Yup from 'yup';
@@ -42,6 +50,25 @@ const ProposalScientistComment = (props: ProposalScientistCommentProps) => {
             gutterBottom
           >
             Proposal Scientist Comment
+            <Tooltip
+              title={
+                <span>
+                  <p>Tips: </p>
+                  <p>1. Comments are managed by only instrument scientists.</p>
+                  <p>
+                    2. Comments are not be accessible to users or sample safety.
+                  </p>
+                  <p>
+                    3. Comments will be available for editing in all proposal
+                    statuses.
+                  </p>
+                </span>
+              }
+            >
+              <IconButton>
+                <Info />
+              </IconButton>
+            </Tooltip>
           </Typography>
           <Formik
             initialValues={{ comment: scientistCommentData?.comment }}

--- a/apps/frontend/src/components/xpress/XpressProposalTable.tsx
+++ b/apps/frontend/src/components/xpress/XpressProposalTable.tsx
@@ -4,7 +4,7 @@ import MaterialTableCore, {
   Query,
   QueryResult,
 } from '@material-table/core';
-import { Visibility } from '@mui/icons-material';
+import { Info, Visibility } from '@mui/icons-material';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
 import GridOnIcon from '@mui/icons-material/GridOn';
 import {
@@ -289,7 +289,32 @@ const XpressProposalTable = ({ confirm }: { confirm: WithConfirmType }) => {
     t: TFunction<'translation', undefined>
   ) => [
     {
-      title: t('instrument'),
+      title: (
+        <>
+          <span>
+            {t('instrument')}
+            <Tooltip
+              title={
+                <span>
+                  <p>Tips: </p>
+                  <p>
+                    1.Change the status of a proposal to Under Review to enable
+                    experimental area selection.
+                  </p>
+                  <p>
+                    2.Once a proposal is marked as Approved / Unsuccessful, the
+                    selected experimental area cannot be changed.
+                  </p>
+                </span>
+              }
+            >
+              <IconButton>
+                <Info />
+              </IconButton>
+            </Tooltip>
+          </span>
+        </>
+      ),
       field: 'instruments.name',
       sorting: false,
       render: (rowData: ProposalViewData) => {
@@ -374,7 +399,47 @@ const XpressProposalTable = ({ confirm }: { confirm: WithConfirmType }) => {
 
   const statusColumn = () => [
     {
-      title: 'Status',
+      title: (
+        <>
+          <span>
+            Status
+            <Tooltip
+              title={
+                <span>
+                  <p>Tips: </p>
+                  <p>
+                    1.Change the status of a proposal to Under Review to enable
+                    experimental area selection.
+                  </p>
+                  <p>
+                    2.Status can be changed to Approved / Unsuccessful, once
+                    experimental area selection and review is completed.
+                  </p>
+                  <p>
+                    3.Once a proposal is marked as Approved / Unsuccessful, the
+                    selected experimental area cannot be changed.
+                  </p>
+                  <p>
+                    4.Further status changes are not allowed once a proposal is
+                    marked as Unsuccessful.
+                  </p>
+                  <p>
+                    5.Status of Approved proposals can be changed to
+                    Unsuccessful / Finished.
+                  </p>
+                  <p>
+                    6.Finished status can be marked only for Approved proposals.
+                  </p>
+                </span>
+              }
+            >
+              <IconButton>
+                <Info />
+              </IconButton>
+            </Tooltip>
+          </span>
+        </>
+      ),
       field: 'statusName',
       sorting: false,
       render: (rowData: ProposalViewData) => {

--- a/apps/frontend/src/components/xpress/XpressProposalTable.tsx
+++ b/apps/frontend/src/components/xpress/XpressProposalTable.tsx
@@ -298,12 +298,12 @@ const XpressProposalTable = ({ confirm }: { confirm: WithConfirmType }) => {
                 <span>
                   <p>Tips: </p>
                   <p>
-                    1.Change the status of a proposal to Under Review to enable
+                    1. Change the status of a proposal to Under Review to enable
                     experimental area selection.
                   </p>
                   <p>
-                    2.Once a proposal is marked as Approved / Unsuccessful, the
-                    selected experimental area cannot be changed.
+                    2. Once a proposal is marked as Approved / Unsuccessful /
+                    Finished, the selected experimental area cannot be changed.
                   </p>
                 </span>
               }
@@ -408,27 +408,28 @@ const XpressProposalTable = ({ confirm }: { confirm: WithConfirmType }) => {
                 <span>
                   <p>Tips: </p>
                   <p>
-                    1.Change the status of a proposal to Under Review to enable
+                    1. Change the status of a proposal to Under Review to enable
                     experimental area selection.
                   </p>
                   <p>
-                    2.Status can be changed to Approved / Unsuccessful, once
-                    experimental area selection and review is completed.
+                    2. Status can be changed to Unsuccessful, or Approved after
+                    an experimental area is selected.
                   </p>
                   <p>
-                    3.Once a proposal is marked as Approved / Unsuccessful, the
-                    selected experimental area cannot be changed.
+                    3. Once a proposal is marked as Approved / Unsuccessful /
+                    Finished, the selected experimental area cannot be changed.
                   </p>
                   <p>
-                    4.Further status changes are not allowed once a proposal is
+                    4. Further status changes are not allowed once a proposal is
                     marked as Unsuccessful.
                   </p>
                   <p>
-                    5.Status of Approved proposals can be changed to
+                    5. Status of Approved proposals can be changed to
                     Unsuccessful / Finished.
                   </p>
                   <p>
-                    6.Finished status can be marked only for Approved proposals.
+                    6. Finished status can be marked only for Approved
+                    proposals.
                   </p>
                 </span>
               }


### PR DESCRIPTION
## Description
This PR introduces tool tips in the Xpress management page to improve user experience.

## Motivation and Context
The change was required to provide important contextual information to users, guiding them on how to interact with various elements on the Xpress management page, hence enhancing usability and user experience.

## Changes
1. Tooltips have been added to the "Proposal Scientist Comment" section in `ProposalScientistComment.tsx`, providing users with important guidelines on how to interact with comments.
2. Tooltips have been added to the "Instrument" and "Status" columns in `XpressProposalTable.tsx`, helping users understand the rules and conditions associated with changing the status of a proposal and experimental area selection.
3. The layout and structure of some code blocks have been modified to accommodate these new features. 

These changes should make the Xpress management page more intuitive and user-friendly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Issue

https://github.com/UserOfficeProject/issue-tracker/issues/1272
https://github.com/UserOfficeProject/issue-tracker/issues/1285

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated