### PR TITLE
feat: add co proposer claim to invite

### DIFF
--- a/apps/backend/db_patches/0168_AddCoProposerClaims.sql
+++ b/apps/backend/db_patches/0168_AddCoProposerClaims.sql
@@ -4,11 +4,11 @@ BEGIN
   IF register_patch('0168_CreateCoProposerInvite', 'Jekabs Karklins', 'Adding co-proposer claims', '2025-01-10') THEN
     BEGIN
       CREATE TABLE co_proposer_invites (
-        role_invite_id SERIAL PRIMARY KEY,
+        co_proposer_invite_id SERIAL PRIMARY KEY,
         invite_code_id INT NOT NULL REFERENCES invite_codes(invite_code_id) ON DELETE CASCADE,
-        role_id INT NOT NULL REFERENCES roles(role_id) ON DELETE CASCADE
+        proposal_pk INT NOT NULL REFERENCES proposals(proposal_pk) ON DELETE CASCADE
       );
-      CREATE INDEX co_proposer_invites_invite_code_id_idx ON co_proposer_invites(invite_code_id);
+      CREATE INDEX co_proposer_co_proposer_invite_id_idx ON co_proposer_invites(co_proposer_invite_id);
 
     END;
   END IF;

--- a/apps/backend/db_patches/0168_AddCoProposerClaims.sql
+++ b/apps/backend/db_patches/0168_AddCoProposerClaims.sql
@@ -1,0 +1,17 @@
+DO
+$$
+BEGIN
+  IF register_patch('0168_CreateCoProposerInvite', 'Jekabs Karklins', 'Adding co-proposer claims', '2025-01-10') THEN
+    BEGIN
+      CREATE TABLE co_proposer_invites (
+        role_invite_id SERIAL PRIMARY KEY,
+        invite_code_id INT NOT NULL REFERENCES invite_codes(invite_code_id) ON DELETE CASCADE,
+        role_id INT NOT NULL REFERENCES roles(role_id) ON DELETE CASCADE
+      );
+      CREATE INDEX co_proposer_invites_invite_code_id_idx ON co_proposer_invites(invite_code_id);
+
+    END;
+  END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/backend/db_patches/0168_AddCoProposerClaims.sql
+++ b/apps/backend/db_patches/0168_AddCoProposerClaims.sql
@@ -3,12 +3,12 @@ $$
 BEGIN
   IF register_patch('0168_CreateCoProposerInvite', 'Jekabs Karklins', 'Adding co-proposer claims', '2025-01-10') THEN
     BEGIN
-      CREATE TABLE co_proposer_invites (
+      CREATE TABLE IF NOT EXISTS co_proposer_invites (
         co_proposer_invite_id SERIAL PRIMARY KEY,
         invite_code_id INT NOT NULL REFERENCES invite_codes(invite_code_id) ON DELETE CASCADE,
         proposal_pk INT NOT NULL REFERENCES proposals(proposal_pk) ON DELETE CASCADE
       );
-      CREATE INDEX co_proposer_co_proposer_invite_id_idx ON co_proposer_invites(co_proposer_invite_id);
+      CREATE INDEX IF NOT EXISTS co_proposer_co_proposer_invite_id_idx ON co_proposer_invites(co_proposer_invite_id);
 
     END;
   END IF;

--- a/apps/backend/db_patches/0168_AddCoProposerClaims.sql
+++ b/apps/backend/db_patches/0168_AddCoProposerClaims.sql
@@ -4,12 +4,9 @@ BEGIN
   IF register_patch('0168_CreateCoProposerInvite', 'Jekabs Karklins', 'Adding co-proposer claims', '2025-01-10') THEN
     BEGIN
       CREATE TABLE IF NOT EXISTS co_proposer_invites (
-        co_proposer_invite_id SERIAL PRIMARY KEY,
         invite_code_id INT NOT NULL REFERENCES invite_codes(invite_code_id) ON DELETE CASCADE,
-        proposal_pk INT NOT NULL REFERENCES proposals(proposal_pk) ON DELETE CASCADE
-      );
-      CREATE INDEX IF NOT EXISTS co_proposer_co_proposer_invite_id_idx ON co_proposer_invites(co_proposer_invite_id);
-
+        proposal_pk INT NOT NULL REFERENCES proposals(proposal_pk) ON DELETE CASCADE,
+        PRIMARY KEY (invite_code_id, proposal_pk));
     END;
   END IF;
 END;

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -16,7 +16,7 @@
         "@user-office-software/duo-localisation": "^1.2.0",
         "@user-office-software/duo-logger": "^2.1.1",
         "@user-office-software/duo-message-broker": "^1.6.0",
-        "@user-office-software/duo-validation": "^5.1.9",
+        "@user-office-software/duo-validation": "^5.1.11",
         "@user-office-software/openid": "^1.4.0",
         "await-to-js": "^2.1.1",
         "bcryptjs": "^2.4.3",
@@ -3218,9 +3218,9 @@
       }
     },
     "node_modules/@user-office-software/duo-validation": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.1.9.tgz",
-      "integrity": "sha512-o915wcv1YipTz9tvR/0fHOzjA/3p2HtbBOGwWm3zN1I679CJ3/glClfCtkRk3CrB4UNfqawMO4zPC9lTNyyn7A==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-validation/-/duo-validation-5.1.11.tgz",
+      "integrity": "sha512-QY5Twc4+DovKcpNMimbVpRUdAKU6DffT7ld9fyXl3s8dhgbBfItK9Vpn48pzJYIeLci/kDM6Q7V93n1+tYdF/g==",
       "license": "ISC",
       "dependencies": {
         "luxon": "^2.5.0",
@@ -3236,6 +3236,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
       "integrity": "sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -40,7 +40,7 @@
     "@user-office-software/duo-localisation": "^1.2.0",
     "@user-office-software/duo-logger": "^2.1.1",
     "@user-office-software/duo-message-broker": "^1.6.0",
-    "@user-office-software/duo-validation": "^5.1.9",
+    "@user-office-software/duo-validation": "^5.1.11",
     "@user-office-software/openid": "^1.4.0",
     "await-to-js": "^2.1.1",
     "bcryptjs": "^2.4.3",

--- a/apps/backend/src/auth/InviteAuthorizer.ts
+++ b/apps/backend/src/auth/InviteAuthorizer.ts
@@ -14,12 +14,13 @@ export class InviteAuthorization {
     agent: UserWithRole | null,
     roleIds?: number[]
   ) => {
-    // If no roleIds are provided, the invite is authorized
+    // If no roleIds are provided, the invite is considered as authorized
     if (roleIds === undefined || roleIds.length === 0) return true;
 
-    const onlyUserRole = roleIds.length === 1 && roleIds[0] === UserRole.USER;
-    const isUserOfficer = this.userAuth.isUserOfficer(agent);
+    if (this.userAuth.isUserOfficer(agent)) return true;
 
-    return isUserOfficer || onlyUserRole;
+    const onlyUserRole = roleIds.length === 1 && roleIds[0] === UserRole.USER;
+
+    return onlyUserRole;
   };
 }

--- a/apps/backend/src/auth/InviteAuthorizer.ts
+++ b/apps/backend/src/auth/InviteAuthorizer.ts
@@ -14,6 +14,7 @@ export class InviteAuthorization {
     agent: UserWithRole | null,
     roleIds?: number[]
   ) => {
+    // If no roleIds are provided, the invite is authorized
     if (roleIds === undefined || roleIds.length === 0) return true;
 
     const onlyUserRole = roleIds.length === 1 && roleIds[0] === UserRole.USER;

--- a/apps/backend/src/auth/InviteAuthorizer.ts
+++ b/apps/backend/src/auth/InviteAuthorizer.ts
@@ -1,0 +1,24 @@
+import { inject, injectable } from 'tsyringe';
+
+import { Tokens } from '../config/Tokens';
+import { UserRole, UserWithRole } from '../models/User';
+import { UserAuthorization } from './UserAuthorization';
+
+@injectable()
+export class InviteAuthorization {
+  constructor(
+    @inject(Tokens.UserAuthorization) private userAuth: UserAuthorization
+  ) {}
+
+  public isRoleInviteAuthorized = async (
+    agent: UserWithRole | null,
+    roleIds?: number[]
+  ) => {
+    if (roleIds === undefined || roleIds.length === 0) return true;
+
+    const onlyUserRole = roleIds.length === 1 && roleIds[0] === UserRole.USER;
+    const isUserOfficer = this.userAuth.isUserOfficer(agent);
+
+    return isUserOfficer || onlyUserRole;
+  };
+}

--- a/apps/backend/src/config/Tokens.ts
+++ b/apps/backend/src/config/Tokens.ts
@@ -14,6 +14,7 @@ export const Tokens = {
   GenericTemplateDataSource: Symbol('GenericTemplateDataSource'),
   InstrumentDataSource: Symbol('InstrumentDataSource'),
   InviteCodeDataSource: Symbol('InviteCodeDataSource'),
+  InviteAuthorization: Symbol('InviteAuthorization'),
   TechniqueDataSource: Symbol('TechniqueDataSource'),
   ListenToMessageQueue: Symbol('ListenToMessageQueue'),
   MailService: Symbol('MailService'),

--- a/apps/backend/src/config/Tokens.ts
+++ b/apps/backend/src/config/Tokens.ts
@@ -5,6 +5,7 @@ export const Tokens = {
   CallDataSource: Symbol('CallDataSource'),
   ConfigureEnvironment: Symbol('ConfigureEnvironment'),
   ConfigureLogger: Symbol('ConfigureLogger'),
+  CoProposerInviteDataSource: Symbol('CoProposerInviteDataSource'),
   EmailEventHandler: Symbol('EmailEventHandler'),
   EventBus: Symbol('EventBus'),
   EventLogsDataSource: Symbol('EventLogsDataSource'),

--- a/apps/backend/src/config/dependencyConfigDefault.ts
+++ b/apps/backend/src/config/dependencyConfigDefault.ts
@@ -5,6 +5,7 @@ import {
 } from '@user-office-software/duo-logger';
 
 import 'reflect-metadata';
+import { InviteAuthorization } from '../auth/InviteAuthorizer';
 import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
@@ -73,6 +74,7 @@ mapClass(Tokens.GenericTemplateDataSource, PostgresGenericTemplateDataSource);
 mapClass(Tokens.InstrumentDataSource, PostgresInstrumentDataSource);
 mapClass(Tokens.InviteCodeDataSource, PostgresInviteCodesDataSource);
 mapClass(Tokens.RoleInviteDataSource, PostgresRoleInviteDataSource);
+mapClass(Tokens.InviteAuthorization, InviteAuthorization);
 mapClass(Tokens.InternalReviewDataSource, PostgresInternalReviewDataSource);
 mapClass(Tokens.PdfTemplateDataSource, PostgresPdfTemplateDataSource);
 mapClass(Tokens.ProposalDataSource, PostgresProposalDataSource);

--- a/apps/backend/src/config/dependencyConfigDefault.ts
+++ b/apps/backend/src/config/dependencyConfigDefault.ts
@@ -9,6 +9,7 @@ import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
 import PostgresCallDataSource from '../datasources/postgres/CallDataSource';
+import PostgresCoProposerInviteDataSource from '../datasources/postgres/CoProposerInviteDataSource';
 import PostgresEventLogsDataSource from '../datasources/postgres/EventLogsDataSource';
 import PostgresFapDataSource from '../datasources/postgres/FapDataSource';
 import PostgresFeedbackDataSource from '../datasources/postgres/FeedbackDataSource';
@@ -63,6 +64,7 @@ async function skipEmailHandler(event: ApplicationEvent) {
 }
 
 mapClass(Tokens.AdminDataSource, PostgresAdminDataSourceWithAutoUpgrade);
+mapClass(Tokens.CoProposerInviteDataSource, PostgresCoProposerInviteDataSource);
 mapClass(Tokens.CallDataSource, PostgresCallDataSource);
 mapClass(Tokens.EventLogsDataSource, PostgresEventLogsDataSource);
 mapClass(Tokens.FeedbackDataSource, PostgresFeedbackDataSource);

--- a/apps/backend/src/config/dependencyConfigE2E.ts
+++ b/apps/backend/src/config/dependencyConfigE2E.ts
@@ -1,6 +1,7 @@
 import { ConsoleLogger, setLogger } from '@user-office-software/duo-logger';
 
 import 'reflect-metadata';
+import { InviteAuthorization } from '../auth/InviteAuthorizer';
 import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import PostgresAdminDataSource from '../datasources/postgres/AdminDataSource';
@@ -64,6 +65,7 @@ mapClass(Tokens.FileDataSource, PostgresFileDataSource);
 mapClass(Tokens.GenericTemplateDataSource, PostgresGenericTemplateDataSource);
 mapClass(Tokens.InstrumentDataSource, PostgresInstrumentDataSource);
 mapClass(Tokens.InviteCodeDataSource, PostgresInviteCodesDataSource);
+mapClass(Tokens.InviteAuthorization, InviteAuthorization);
 mapClass(Tokens.RoleInviteDataSource, PostgresRoleInviteDataSource);
 mapClass(Tokens.InternalReviewDataSource, PostgresInternalReviewDataSource);
 mapClass(Tokens.PdfTemplateDataSource, PostgresPdfTemplateDataSource);

--- a/apps/backend/src/config/dependencyConfigE2E.ts
+++ b/apps/backend/src/config/dependencyConfigE2E.ts
@@ -5,6 +5,7 @@ import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import PostgresAdminDataSource from '../datasources/postgres/AdminDataSource';
 import PostgresCallDataSource from '../datasources/postgres/CallDataSource';
+import PostgresCoProposerInviteDataSource from '../datasources/postgres/CoProposerInviteDataSource';
 import PostgresEventLogsDataSource from '../datasources/postgres/EventLogsDataSource';
 import PostgresFapDataSource from '../datasources/postgres/FapDataSource';
 import PostgresFeedbackDataSource from '../datasources/postgres/FeedbackDataSource';
@@ -55,6 +56,7 @@ import { Tokens } from './Tokens';
 import { mapClass, mapValue } from './utils';
 
 mapClass(Tokens.AdminDataSource, PostgresAdminDataSource);
+mapClass(Tokens.CoProposerInviteDataSource, PostgresCoProposerInviteDataSource);
 mapClass(Tokens.CallDataSource, PostgresCallDataSource);
 mapClass(Tokens.EventLogsDataSource, PostgresEventLogsDataSource);
 mapClass(Tokens.FeedbackDataSource, PostgresFeedbackDataSource);

--- a/apps/backend/src/config/dependencyConfigELI.ts
+++ b/apps/backend/src/config/dependencyConfigELI.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 
+import { InviteAuthorization } from '../auth/InviteAuthorizer';
 import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
@@ -67,6 +68,7 @@ mapClass(Tokens.GenericTemplateDataSource, PostgresGenericTemplateDataSource);
 mapClass(Tokens.InstrumentDataSource, PostgresInstrumentDataSource);
 mapClass(Tokens.InviteCodeDataSource, PostgresInviteCodesDataSource);
 mapClass(Tokens.RoleInviteDataSource, PostgresRoleInviteDataSource);
+mapClass(Tokens.InviteAuthorization, InviteAuthorization);
 mapClass(Tokens.PdfTemplateDataSource, PostgresPdfTemplateDataSource);
 mapClass(Tokens.ProposalDataSource, PostgresProposalDataSource);
 mapClass(Tokens.ProposalEsiDataSource, PostgresProposalEsiDataSource);

--- a/apps/backend/src/config/dependencyConfigELI.ts
+++ b/apps/backend/src/config/dependencyConfigELI.ts
@@ -4,6 +4,7 @@ import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
 import PostgresCallDataSource from '../datasources/postgres/CallDataSource';
+import PostgresCoProposerInviteDataSource from '../datasources/postgres/CoProposerInviteDataSource';
 import PostgresEventLogsDataSource from '../datasources/postgres/EventLogsDataSource';
 import PostgresFapDataSource from '../datasources/postgres/FapDataSource';
 import PostgresFeedbackDataSource from '../datasources/postgres/FeedbackDataSource';
@@ -57,6 +58,7 @@ import { mapClass, mapValue } from './utils';
 const isProduction = process.env.NODE_ENV === 'production';
 
 mapClass(Tokens.AdminDataSource, PostgresAdminDataSourceWithAutoUpgrade);
+mapClass(Tokens.CoProposerInviteDataSource, PostgresCoProposerInviteDataSource);
 mapClass(Tokens.CallDataSource, PostgresCallDataSource);
 mapClass(Tokens.EventLogsDataSource, PostgresEventLogsDataSource);
 mapClass(Tokens.FeedbackDataSource, PostgresFeedbackDataSource);

--- a/apps/backend/src/config/dependencyConfigESS.ts
+++ b/apps/backend/src/config/dependencyConfigESS.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import 'reflect-metadata';
 
+import { InviteAuthorization } from '../auth/InviteAuthorizer';
 import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
@@ -67,6 +68,7 @@ mapClass(Tokens.GenericTemplateDataSource, PostgresGenericTemplateDataSource);
 mapClass(Tokens.InstrumentDataSource, PostgresInstrumentDataSource);
 mapClass(Tokens.InviteCodeDataSource, PostgresInviteCodesDataSource);
 mapClass(Tokens.RoleInviteDataSource, PostgresRoleInviteDataSource);
+mapClass(Tokens.InviteAuthorization, InviteAuthorization);
 mapClass(Tokens.PdfTemplateDataSource, PostgresPdfTemplateDataSource);
 mapClass(Tokens.ProposalDataSource, PostgresProposalDataSource);
 mapClass(Tokens.ProposalEsiDataSource, PostgresProposalEsiDataSource);

--- a/apps/backend/src/config/dependencyConfigESS.ts
+++ b/apps/backend/src/config/dependencyConfigESS.ts
@@ -5,6 +5,7 @@ import { OAuthAuthorization } from '../auth/OAuthAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
 import PostgresCallDataSource from '../datasources/postgres/CallDataSource';
+import PostgresCoProposerInviteDataSource from '../datasources/postgres/CoProposerInviteDataSource';
 import PostgresEventLogsDataSource from '../datasources/postgres/EventLogsDataSource';
 import PostgresFapDataSource from '../datasources/postgres/FapDataSource';
 import PostgresFeedbackDataSource from '../datasources/postgres/FeedbackDataSource';
@@ -57,6 +58,7 @@ import { Tokens } from './Tokens';
 import { mapClass, mapValue } from './utils';
 
 mapClass(Tokens.AdminDataSource, PostgresAdminDataSourceWithAutoUpgrade);
+mapClass(Tokens.CoProposerInviteDataSource, PostgresCoProposerInviteDataSource);
 mapClass(Tokens.CallDataSource, PostgresCallDataSource);
 mapClass(Tokens.EventLogsDataSource, PostgresEventLogsDataSource);
 mapClass(Tokens.FeedbackDataSource, PostgresFeedbackDataSource);

--- a/apps/backend/src/config/dependencyConfigSTFC.ts
+++ b/apps/backend/src/config/dependencyConfigSTFC.ts
@@ -5,6 +5,7 @@ import { StfcProposalAuthorization } from '../auth/StfcProposalAuthorization';
 import { StfcUserAuthorization } from '../auth/StfcUserAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
 import PostgresCallDataSource from '../datasources/postgres/CallDataSource';
+import PostgresCoProposerInviteDataSource from '../datasources/postgres/CoProposerInviteDataSource';
 import PostgresEventLogsDataSource from '../datasources/postgres/EventLogsDataSource';
 import PostgresFeedbackDataSource from '../datasources/postgres/FeedbackDataSource';
 import PostgresFileDataSource from '../datasources/postgres/FileDataSource';
@@ -55,6 +56,7 @@ import { Tokens } from './Tokens';
 import { mapClass, mapValue } from './utils';
 
 mapClass(Tokens.AdminDataSource, PostgresAdminDataSourceWithAutoUpgrade);
+mapClass(Tokens.CoProposerInviteDataSource, PostgresCoProposerInviteDataSource);
 mapClass(Tokens.CallDataSource, PostgresCallDataSource);
 mapClass(Tokens.EventLogsDataSource, PostgresEventLogsDataSource);
 mapClass(Tokens.FeedbackDataSource, PostgresFeedbackDataSource);

--- a/apps/backend/src/config/dependencyConfigSTFC.ts
+++ b/apps/backend/src/config/dependencyConfigSTFC.ts
@@ -1,6 +1,7 @@
 import { setLogger, ConsoleLogger } from '@user-office-software/duo-logger';
 import 'reflect-metadata';
 
+import { InviteAuthorization } from '../auth/InviteAuthorizer';
 import { StfcProposalAuthorization } from '../auth/StfcProposalAuthorization';
 import { StfcUserAuthorization } from '../auth/StfcUserAuthorization';
 import { PostgresAdminDataSourceWithAutoUpgrade } from '../datasources/postgres/AdminDataSource';
@@ -65,6 +66,7 @@ mapClass(Tokens.GenericTemplateDataSource, PostgresGenericTemplateDataSource);
 mapClass(Tokens.InstrumentDataSource, StfcInstrumentDataSource);
 mapClass(Tokens.InviteCodeDataSource, PostgresInviteCodesDataSource);
 mapClass(Tokens.RoleInviteDataSource, PostgresRoleInviteDataSource);
+mapClass(Tokens.InviteAuthorization, InviteAuthorization);
 mapClass(Tokens.PdfTemplateDataSource, PostgresPdfTemplateDataSource);
 mapClass(Tokens.ProposalDataSource, StfcProposalDataSource);
 mapClass(Tokens.ProposalEsiDataSource, PostgresProposalEsiDataSource);

--- a/apps/backend/src/config/dependencyConfigTest.ts
+++ b/apps/backend/src/config/dependencyConfigTest.ts
@@ -6,6 +6,7 @@ import 'reflect-metadata';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import { AdminDataSourceMock } from '../datasources/mockups/AdminDataSource';
 import { CallDataSourceMock } from '../datasources/mockups/CallDataSource';
+import { CoProposerInviteDataSourceMock } from '../datasources/mockups/CoProposerInviteDataSource';
 import { EventLogsDataSourceMock } from '../datasources/mockups/EventLogsDataSource';
 import { FapDataSourceMock } from '../datasources/mockups/FapDataSource';
 import { FeedbackDataSourceMock } from '../datasources/mockups/FeedbackDataSource';
@@ -49,6 +50,7 @@ import { Tokens } from './Tokens';
 import { mapClass, mapValue } from './utils';
 
 mapClass(Tokens.AdminDataSource, AdminDataSourceMock);
+mapClass(Tokens.CoProposerInviteDataSource, CoProposerInviteDataSourceMock);
 mapClass(Tokens.CallDataSource, CallDataSourceMock);
 mapClass(Tokens.EventLogsDataSource, EventLogsDataSourceMock);
 mapClass(Tokens.FeedbackDataSource, FeedbackDataSourceMock);

--- a/apps/backend/src/config/dependencyConfigTest.ts
+++ b/apps/backend/src/config/dependencyConfigTest.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { setLogger, ConsoleLogger } from '@user-office-software/duo-logger';
+import { ConsoleLogger, setLogger } from '@user-office-software/duo-logger';
 
-import { UserAuthorizationMock } from '../auth/mockups/UserAuthorization';
 import 'reflect-metadata';
+import { InviteAuthorization } from '../auth/InviteAuthorizer';
+import { UserAuthorizationMock } from '../auth/mockups/UserAuthorization';
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
 import { AdminDataSourceMock } from '../datasources/mockups/AdminDataSource';
 import { CallDataSourceMock } from '../datasources/mockups/CallDataSource';
@@ -59,6 +60,7 @@ mapClass(Tokens.GenericTemplateDataSource, GenericTemplateDataSourceMock);
 mapClass(Tokens.InstrumentDataSource, InstrumentDataSourceMock);
 mapClass(Tokens.InviteCodeDataSource, InviteCodesDataSourceMock);
 mapClass(Tokens.RoleInviteDataSource, RoleInviteDataSourceMock);
+mapClass(Tokens.InviteAuthorization, InviteAuthorization);
 mapClass(Tokens.InternalReviewDataSource, InternalReviewDataSourceMock);
 mapClass(Tokens.PdfTemplateDataSource, PdfTemplateDataSourceMock);
 mapClass(Tokens.ProposalDataSource, ProposalDataSourceMock);

--- a/apps/backend/src/datasources/CoProposerInviteDataSource.ts
+++ b/apps/backend/src/datasources/CoProposerInviteDataSource.ts
@@ -2,5 +2,5 @@ import { CoProposerInvite } from '../models/CoProposerInvite';
 
 export interface CoProposerInviteDataSource {
   create(inviteCodeId: number, proposalPk: number): Promise<CoProposerInvite>;
-  findByInviteCodeId(inviteCodeId: number): Promise<CoProposerInvite[]>;
+  findByInviteCodeId(inviteCodeId: number): Promise<CoProposerInvite | null>;
 }

--- a/apps/backend/src/datasources/CoProposerInviteDataSource.ts
+++ b/apps/backend/src/datasources/CoProposerInviteDataSource.ts
@@ -1,0 +1,6 @@
+import { CoProposerInvite } from '../models/CoProposerInvite';
+
+export interface CoProposerInviteDataSource {
+  create(inviteCodeId: number, proposalPk: number): Promise<CoProposerInvite>;
+  findByInviteCodeId(inviteCodeId: number): Promise<CoProposerInvite[]>;
+}

--- a/apps/backend/src/datasources/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/ProposalDataSource.ts
@@ -56,7 +56,8 @@ export interface ProposalDataSource {
   updateProposalTechnicalReviewer(
     args: UpdateTechnicalReviewAssigneeInput
   ): Promise<TechnicalReview[]>;
-  setProposalUsers(proposalPk: number, users: number[]): Promise<void>;
+  setProposalUsers(proposalPk: number, usersIds: number[]): Promise<void>;
+  addProposalUser(proposalPk: number, userId: number): Promise<void>;
   submitProposal(
     primaryKey: number,
     referenceNumber?: string

--- a/apps/backend/src/datasources/mockups/CoProposerInviteDataSource.ts
+++ b/apps/backend/src/datasources/mockups/CoProposerInviteDataSource.ts
@@ -8,15 +8,18 @@ export class CoProposerInviteDataSourceMock
 
   init() {
     this.invites = [
-      new CoProposerInvite(1, 1, 1),
-      new CoProposerInvite(2, 2, 2),
-      new CoProposerInvite(3, 3, 3),
+      new CoProposerInvite(1, 1),
+      new CoProposerInvite(2, 2),
+      new CoProposerInvite(3, 3),
     ];
   }
 
-  async findByInviteCodeId(inviteCodeId: number): Promise<CoProposerInvite[]> {
-    return this.invites.filter(
-      (invite) => invite.inviteCodeId === inviteCodeId
+  async findByInviteCodeId(
+    inviteCodeId: number
+  ): Promise<CoProposerInvite | null> {
+    return (
+      this.invites.find((invite) => invite.inviteCodeId === inviteCodeId) ||
+      null
     );
   }
 
@@ -24,11 +27,7 @@ export class CoProposerInviteDataSourceMock
     inviteCodeId: number,
     proposalPk: number
   ): Promise<CoProposerInvite> {
-    const newInvite = new CoProposerInvite(
-      this.invites.length + 1,
-      inviteCodeId,
-      proposalPk
-    );
+    const newInvite = new CoProposerInvite(inviteCodeId, proposalPk);
 
     this.invites.push(newInvite);
 

--- a/apps/backend/src/datasources/mockups/CoProposerInviteDataSource.ts
+++ b/apps/backend/src/datasources/mockups/CoProposerInviteDataSource.ts
@@ -1,0 +1,37 @@
+import { CoProposerInvite } from '../../models/CoProposerInvite';
+import { CoProposerInviteDataSource } from '../CoProposerInviteDataSource';
+
+export class CoProposerInviteDataSourceMock
+  implements CoProposerInviteDataSource
+{
+  private invites: CoProposerInvite[] = [];
+
+  init() {
+    this.invites = [
+      new CoProposerInvite(1, 1, 1),
+      new CoProposerInvite(2, 2, 2),
+      new CoProposerInvite(3, 3, 3),
+    ];
+  }
+
+  async findByInviteCodeId(inviteCodeId: number): Promise<CoProposerInvite[]> {
+    return this.invites.filter(
+      (invite) => invite.inviteCodeId === inviteCodeId
+    );
+  }
+
+  async create(
+    inviteCodeId: number,
+    proposalPk: number
+  ): Promise<CoProposerInvite> {
+    const newInvite = new CoProposerInvite(
+      this.invites.length + 1,
+      inviteCodeId,
+      proposalPk
+    );
+
+    this.invites.push(newInvite);
+
+    return newInvite;
+  }
+}

--- a/apps/backend/src/datasources/mockups/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/mockups/ProposalDataSource.ts
@@ -272,7 +272,14 @@ export class ProposalDataSourceMock implements ProposalDataSource {
     return proposal;
   }
 
-  async setProposalUsers(proposalPk: number, users: number[]): Promise<void> {
+  async setProposalUsers(
+    proposalPk: number,
+    usersIds: number[]
+  ): Promise<void> {
+    throw new Error('Not implemented');
+  }
+
+  async addProposalUser(proposalPk: number, userId: number): Promise<void> {
     throw new Error('Not implemented');
   }
 

--- a/apps/backend/src/datasources/postgres/CoProposerInviteDataSource.ts
+++ b/apps/backend/src/datasources/postgres/CoProposerInviteDataSource.ts
@@ -1,0 +1,40 @@
+import { CoProposerInvite } from '../../models/CoProposerInvite';
+import { CoProposerInviteDataSource } from '../CoProposerInviteDataSource';
+import database from './database';
+
+export default class PostgresCoProposerInviteDataSource
+  implements CoProposerInviteDataSource
+{
+  async findByInviteCodeId(inviteCodeId: number): Promise<CoProposerInvite[]> {
+    return database('co_proposer_invites')
+      .where({ invite_code_id: inviteCodeId })
+      .select('*')
+      .then((rows) => {
+        return rows.map(
+          (row) =>
+            new CoProposerInvite(
+              row.co_proposer_invite_id,
+              row.invite_code_id,
+              row.proposal_pk
+            )
+        );
+      });
+  }
+  async create(
+    inviteCodeId: number,
+    proposalPk: number
+  ): Promise<CoProposerInvite> {
+    return database('co_proposer_invites')
+      .insert({ invite_code_id: inviteCodeId, proposal_pk: proposalPk })
+      .returning('*')
+      .then((rows) => {
+        const row = rows[0];
+
+        return new CoProposerInvite(
+          row.co_proposer_invite_id,
+          row.invite_code_id,
+          row.proposal_pk
+        );
+      });
+  }
+}

--- a/apps/backend/src/datasources/postgres/CoProposerInviteDataSource.ts
+++ b/apps/backend/src/datasources/postgres/CoProposerInviteDataSource.ts
@@ -5,19 +5,19 @@ import database from './database';
 export default class PostgresCoProposerInviteDataSource
   implements CoProposerInviteDataSource
 {
-  async findByInviteCodeId(inviteCodeId: number): Promise<CoProposerInvite[]> {
+  async findByInviteCodeId(
+    inviteCodeId: number
+  ): Promise<CoProposerInvite | null> {
     return database('co_proposer_invites')
       .where({ invite_code_id: inviteCodeId })
       .select('*')
-      .then((rows) => {
-        return rows.map(
-          (row) =>
-            new CoProposerInvite(
-              row.co_proposer_invite_id,
-              row.invite_code_id,
-              row.proposal_pk
-            )
-        );
+      .first()
+      .then((row) => {
+        if (!row) {
+          return null;
+        }
+
+        return new CoProposerInvite(row.invite_code_id, row.proposal_pk);
       });
   }
   async create(
@@ -30,11 +30,7 @@ export default class PostgresCoProposerInviteDataSource
       .then((rows) => {
         const row = rows[0];
 
-        return new CoProposerInvite(
-          row.co_proposer_invite_id,
-          row.invite_code_id,
-          row.proposal_pk
-        );
+        return new CoProposerInvite(row.invite_code_id, row.proposal_pk);
       });
   }
 }

--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -232,6 +232,12 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
       });
   }
 
+  async addProposalUser(proposalPk: number, userId: number): Promise<void> {
+    return database
+      .insert({ proposal_pk: proposalPk, user_id: userId })
+      .into('proposal_user');
+  }
+
   async setProposalUsers(proposalPk: number, userIds: number[]): Promise<void> {
     return database.transaction(async (trx) => {
       return database

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -1455,14 +1455,9 @@ export const createRoleInviteObject = (invite: RoleInviteRecord) =>
   new RoleInvite(invite.role_invite_id, invite.invite_code_id, invite.role_id);
 
 export interface CoProposerInviteRecord {
-  readonly co_proposer_invite_id: number;
   readonly invite_code_id: number;
   readonly proposal_pk: number;
 }
 
 export const createCoProposerInviteRecord = (invite: CoProposerInviteRecord) =>
-  new CoProposerInvite(
-    invite.co_proposer_invite_id,
-    invite.invite_code_id,
-    invite.proposal_pk
-  );
+  new CoProposerInvite(invite.invite_code_id, invite.proposal_pk);

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -8,6 +8,7 @@ import {
   DependenciesLogicOperator,
   EvaluatorOperator,
 } from '../../models/ConditionEvaluator';
+import { CoProposerInvite } from '../../models/CoProposerInvite';
 import { Country } from '../../models/Country';
 import { Fap, FapAssignment, FapProposal, FapReviewer } from '../../models/Fap';
 import { FapMeetingDecision } from '../../models/FapMeetingDecision';
@@ -1451,3 +1452,16 @@ export interface RoleInviteRecord {
 
 export const createRoleInviteObject = (invite: RoleInviteRecord) =>
   new RoleInvite(invite.role_invite_id, invite.invite_code_id, invite.role_id);
+
+export interface CoProposerInviteRecord {
+  readonly co_proposer_invite_id: number;
+  readonly invite_code_id: number;
+  readonly proposal_pk: number;
+}
+
+export const createCoProposerInviteRecord = (invite: CoProposerInviteRecord) =>
+  new CoProposerInvite(
+    invite.co_proposer_invite_id,
+    invite.invite_code_id,
+    invite.proposal_pk
+  );

--- a/apps/backend/src/decorators/ValidateArgs.ts
+++ b/apps/backend/src/decorators/ValidateArgs.ts
@@ -52,7 +52,7 @@ const ValidateArgs = (
 
       if (errors) {
         return rejection('Input validation errors', {
-          errors: errors.errors ?? errors.message,
+          errors: errors.errors || errors.message,
           inputArgs,
         });
       }

--- a/apps/backend/src/decorators/ValidateArgs.ts
+++ b/apps/backend/src/decorators/ValidateArgs.ts
@@ -52,7 +52,7 @@ const ValidateArgs = (
 
       if (errors) {
         return rejection('Input validation errors', {
-          errors: errors.errors,
+          errors: errors.errors ?? errors.message,
           inputArgs,
         });
       }

--- a/apps/backend/src/models/CoProposerInvite.ts
+++ b/apps/backend/src/models/CoProposerInvite.ts
@@ -1,6 +1,5 @@
 export class CoProposerInvite {
   constructor(
-    public coProposerInviteId: number,
     public inviteCodeId: number,
     public proposalPk: number
   ) {}

--- a/apps/backend/src/models/CoProposerInvite.ts
+++ b/apps/backend/src/models/CoProposerInvite.ts
@@ -1,0 +1,7 @@
+export class CoProposerInvite {
+  constructor(
+    public coProposerInviteId: number,
+    public inviteCodeId: number,
+    public proposalPk: number
+  ) {}
+}

--- a/apps/backend/src/mutations/InviteMutations.spec.ts
+++ b/apps/backend/src/mutations/InviteMutations.spec.ts
@@ -122,7 +122,7 @@ describe('Test Invite Mutations', () => {
       note: 'Test note',
       claims: {
         roleIds: [1],
-        coProposerProposalId: proposalPk,
+        coProposerProposalPk: proposalPk,
       },
     })) as InviteCode;
 

--- a/apps/backend/src/mutations/InviteMutations.spec.ts
+++ b/apps/backend/src/mutations/InviteMutations.spec.ts
@@ -138,9 +138,10 @@ describe('Test Invite Mutations', () => {
       )
       .findByInviteCodeId(invite.id);
 
-    expect(coProposerInvite).toMatchObject([
-      { inviteCodeId: invite.id, proposalPk },
-    ]);
+    expect(coProposerInvite).toMatchObject({
+      inviteCodeId: invite.id,
+      proposalPk,
+    });
   });
 
   test('A user officer can create an invite with coProposer claims', async () => {
@@ -164,9 +165,10 @@ describe('Test Invite Mutations', () => {
       )
       .findByInviteCodeId(invite.id);
 
-    expect(coProposerInvite).toMatchObject([
-      { inviteCodeId: invite.id, proposalPk },
-    ]);
+    expect(coProposerInvite).toMatchObject({
+      inviteCodeId: invite.id,
+      proposalPk,
+    });
   });
 
   test('A user on proposal can create an invite with coProposer claims', async () => {
@@ -191,9 +193,10 @@ describe('Test Invite Mutations', () => {
       )
       .findByInviteCodeId(invite.id);
 
-    expect(coProposerInvite).toMatchObject([
-      { inviteCodeId: invite.id, proposalPk },
-    ]);
+    expect(coProposerInvite).toMatchObject({
+      inviteCodeId: invite.id,
+      proposalPk,
+    });
   });
 
   test('A user not on proposal can no create an invite with coProposer claims', async () => {
@@ -255,6 +258,6 @@ describe('Test Invite Mutations', () => {
       )
       .findByInviteCodeId(1);
 
-    expect(coProposerInvite).toMatchObject([{ inviteCodeId: 1, proposalPk }]);
+    expect(coProposerInvite).toMatchObject({ inviteCodeId: 1, proposalPk });
   });
 });

--- a/apps/backend/src/mutations/InviteMutations.spec.ts
+++ b/apps/backend/src/mutations/InviteMutations.spec.ts
@@ -6,10 +6,13 @@ import { CoProposerInviteDataSourceMock } from '../datasources/mockups/CoPropose
 import { InviteCodesDataSourceMock } from '../datasources/mockups/InviteCodesDataSource';
 import { RoleInviteDataSourceMock } from '../datasources/mockups/RoleInviteDataSource';
 import {
+  dummyUserNotOnProposalWithRole,
   dummyUserOfficerWithRole,
   dummyUserWithRole,
 } from '../datasources/mockups/UserDataSource';
 import { InviteCode } from '../models/InviteCode';
+import { Rejection } from '../models/Rejection';
+import { UserRole } from '../models/User';
 import InviteMutations from './InviteMutations';
 
 const inviteMutations = container.resolve(InviteMutations);
@@ -37,7 +40,7 @@ describe('Test Invite Mutations', () => {
         email: email,
         note: 'Test note',
         claims: {
-          roleIds: [1],
+          roleIds: [UserRole.USER],
         },
       })
     ).resolves.toHaveProperty('email', email);
@@ -49,10 +52,13 @@ describe('Test Invite Mutations', () => {
         email: 'user@example.com',
         note: 'Test note',
         claims: {
-          roleIds: [1],
+          roleIds: [UserRole.FAP_REVIEWER],
         },
       })
-    ).resolves.toHaveProperty('reason', 'INSUFFICIENT_PERMISSIONS');
+    ).resolves.toHaveProperty(
+      'reason',
+      'User is not authorized to create invites to this user type'
+    );
   });
 
   test('A user can accept valid invite code', () => {
@@ -135,5 +141,120 @@ describe('Test Invite Mutations', () => {
     expect(coProposerInvite).toMatchObject([
       { inviteCodeId: invite.id, proposalPk },
     ]);
+  });
+
+  test('A user officer can create an invite with coProposer claims', async () => {
+    const email = 'coproposer_claims@example.com';
+    const proposalPk = 1;
+
+    const response = await inviteMutations.create(dummyUserOfficerWithRole, {
+      email,
+      note: 'Test note',
+      claims: {
+        coProposerProposalPk: proposalPk,
+      },
+    });
+
+    expect(response).not.toBeInstanceOf(Rejection);
+
+    const invite = response as InviteCode;
+    const coProposerInvite = await container
+      .resolve<CoProposerInviteDataSourceMock>(
+        Tokens.CoProposerInviteDataSource
+      )
+      .findByInviteCodeId(invite.id);
+
+    expect(coProposerInvite).toMatchObject([
+      { inviteCodeId: invite.id, proposalPk },
+    ]);
+  });
+
+  test('A user on proposal can create an invite with coProposer claims', async () => {
+    const email = 'john@gmail.com';
+    const proposalPk = 1;
+
+    const response = await inviteMutations.create(dummyUserWithRole, {
+      email,
+      note: 'Test note',
+      claims: {
+        coProposerProposalPk: proposalPk,
+      },
+    });
+
+    expect(response).not.toBeInstanceOf(Rejection);
+
+    const invite = response as InviteCode;
+
+    const coProposerInvite = await container
+      .resolve<CoProposerInviteDataSourceMock>(
+        Tokens.CoProposerInviteDataSource
+      )
+      .findByInviteCodeId(invite.id);
+
+    expect(coProposerInvite).toMatchObject([
+      { inviteCodeId: invite.id, proposalPk },
+    ]);
+  });
+
+  test('A user not on proposal can no create an invite with coProposer claims', async () => {
+    const email = 'john@gmail.com';
+    const proposalPk = 1;
+
+    const response = await inviteMutations.create(
+      dummyUserNotOnProposalWithRole,
+      {
+        email,
+        note: 'Test note',
+        claims: {
+          coProposerProposalPk: proposalPk,
+        },
+      }
+    );
+
+    expect(response).toBeInstanceOf(Rejection);
+  });
+
+  test('A user officer can update invite with role claims', async () => {
+    const roleIds = [1, 2, 3];
+
+    await inviteMutations.update(dummyUserOfficerWithRole, {
+      id: 1,
+      claims: { roleIds },
+    });
+
+    const roleInvite = await container
+      .resolve<RoleInviteDataSourceMock>(Tokens.RoleInviteDataSource)
+      .findByInviteCodeId(1);
+
+    expect(roleInvite).toBeDefined();
+    expect(roleInvite.map((roleInvite) => roleInvite.roleId)).toEqual(roleIds);
+  });
+
+  test('A user can not update invite with role claims if role is User.USER_OFFICER', async () => {
+    const roleIds = [UserRole.USER_OFFICER];
+
+    return expect(
+      inviteMutations.update(dummyUserWithRole, {
+        id: 1,
+        claims: { roleIds },
+      })
+    ).resolves.toBeInstanceOf(Rejection);
+  });
+
+  test('A user officer can update invite with coProposer claims', async () => {
+    const proposalPk = 1;
+
+    await inviteMutations.update(dummyUserOfficerWithRole, {
+      id: 1,
+      claims: { coProposerProposalPk: proposalPk },
+    });
+
+    const coProposerInvite = await container
+      .resolve<CoProposerInviteDataSourceMock>(
+        Tokens.CoProposerInviteDataSource
+      )
+      .findByInviteCodeId(1);
+
+    expect(coProposerInvite).toMatchObject([{ inviteCodeId: 1, proposalPk }]);
   });
 });

--- a/apps/backend/src/mutations/InviteMutations.spec.ts
+++ b/apps/backend/src/mutations/InviteMutations.spec.ts
@@ -40,7 +40,7 @@ describe('Test Invite Mutations', () => {
         email: email,
         note: 'Test note',
         claims: {
-          roleIds: [UserRole.USER],
+          roleIds: [UserRole.FAP_REVIEWER],
         },
       })
     ).resolves.toHaveProperty('email', email);

--- a/apps/backend/src/mutations/InviteMutations.ts
+++ b/apps/backend/src/mutations/InviteMutations.ts
@@ -80,8 +80,12 @@ export default class InviteMutations {
       args.email
     );
 
-    await this.setRoleInvites(newInvite.id, roleIds);
-    await this.setCoProposerInvites(newInvite.id, coProposerProposalPk);
+    if (roleIds) {
+      await this.setRoleInvites(newInvite.id, roleIds);
+    }
+    if (coProposerProposalPk) {
+      await this.setCoProposerInvites(newInvite.id, coProposerProposalPk);
+    }
 
     return newInvite;
   }
@@ -140,19 +144,20 @@ export default class InviteMutations {
     }
 
     const updatedInvite = await this.inviteDataSource.update(args);
-    await this.setRoleInvites(updatedInvite.id, args.claims?.roleIds);
-    await this.setCoProposerInvites(
-      updatedInvite.id,
-      args.claims?.coProposerProposalPk
-    );
+    if (args.claims?.roleIds) {
+      await this.setRoleInvites(updatedInvite.id, args.claims?.roleIds);
+    }
+    if (args.claims?.coProposerProposalPk) {
+      await this.setCoProposerInvites(
+        updatedInvite.id,
+        args.claims.coProposerProposalPk
+      );
+    }
 
     return updatedInvite;
   }
 
-  private async setRoleInvites(
-    inviteCodeId: number,
-    roleIds: number[] | undefined
-  ) {
+  private async setRoleInvites(inviteCodeId: number, roleIds: number[]) {
     await this.roleInviteDataSource.deleteByInviteCodeId(inviteCodeId);
 
     if (!roleIds) return;
@@ -166,7 +171,7 @@ export default class InviteMutations {
     }
   }
 
-  private async setCoProposerInvites(invCodeId: number, proposalPk?: number) {
+  private async setCoProposerInvites(invCodeId: number, proposalPk: number) {
     if (!proposalPk) return;
 
     return this.coProposerInviteDataSource.create(invCodeId, proposalPk);

--- a/apps/backend/src/mutations/InviteMutations.ts
+++ b/apps/backend/src/mutations/InviteMutations.ts
@@ -15,6 +15,7 @@ import { Role, Roles } from '../models/Role';
 import { UserWithRole } from '../models/User';
 import { CreateInviteInput } from '../resolvers/mutations/CreateInviteMutation';
 import { UpdateInviteInput } from '../resolvers/mutations/UpdateInviteMutation';
+
 @injectable()
 export default class InviteMutations {
   constructor(
@@ -34,6 +35,8 @@ export default class InviteMutations {
     private proposalAuth: ProposalAuthorization
   ) {}
 
+  @Authorized()
+  // @ValidateArgs(createInviteValidationSchema)
   async create(
     agent: UserWithRole | null,
     args: CreateInviteInput
@@ -55,10 +58,10 @@ export default class InviteMutations {
     );
 
     // Update database
-    const { roleIds, coProposerProposalId } = args.claims;
+    const { roleIds, coProposerProposalPk } = args.claims;
 
     await this.setRoleInvites(newInvite.id, roleIds);
-    await this.setCoProposerInvites(newInvite.id, coProposerProposalId);
+    await this.setCoProposerInvites(newInvite.id, coProposerProposalPk);
 
     return newInvite;
   }
@@ -90,6 +93,7 @@ export default class InviteMutations {
   }
 
   @Authorized([Roles.USER_OFFICER])
+  // @ValidateArgs(updateInviteValidationSchema)
   async update(user: UserWithRole | null, input: UpdateInviteInput) {
     // Authorize request
     if (
@@ -103,7 +107,7 @@ export default class InviteMutations {
     await this.setRoleInvites(updatedInvite.id, input.claims?.roleIds);
     await this.setCoProposerInvites(
       updatedInvite.id,
-      input.claims?.coProposerProposalId
+      input.claims?.coProposerProposalPk
     );
 
     return updatedInvite;

--- a/apps/backend/src/mutations/InviteMutations.ts
+++ b/apps/backend/src/mutations/InviteMutations.ts
@@ -1,3 +1,7 @@
+import {
+  createInviteValidationSchema,
+  updateInviteValidationSchema,
+} from '@user-office-software/duo-validation';
 import { inject, injectable } from 'tsyringe';
 
 import { InviteAuthorization } from '../auth/InviteAuthorizer';
@@ -9,7 +13,7 @@ import { InviteCodeDataSource } from '../datasources/InviteCodeDataSource';
 import { ProposalDataSource } from '../datasources/ProposalDataSource';
 import { RoleInviteDataSource } from '../datasources/RoleInviteDataSource';
 import { UserDataSource } from '../datasources/UserDataSource';
-import { Authorized } from '../decorators';
+import { Authorized, ValidateArgs } from '../decorators';
 import { InviteCode } from '../models/InviteCode';
 import { rejection, Rejection } from '../models/Rejection';
 import { Role, Roles } from '../models/Role';
@@ -39,7 +43,7 @@ export default class InviteMutations {
   ) {}
 
   @Authorized()
-  // @ValidateArgs(createInviteValidationSchema)
+  @ValidateArgs(createInviteValidationSchema)
   async create(
     agent: UserWithRole | null,
     args: CreateInviteInput
@@ -68,7 +72,6 @@ export default class InviteMutations {
       );
     }
 
-    // Create Code
     const newCode = Math.random().toString(36).substring(2, 12).toUpperCase();
     const newInvite = await this.inviteDataSource.create(
       agent!.id,
@@ -76,7 +79,6 @@ export default class InviteMutations {
       args.email
     );
 
-    // Update database
     await this.setRoleInvites(newInvite.id, roleIds);
     await this.setCoProposerInvites(newInvite.id, coProposerProposalPk);
 
@@ -110,7 +112,7 @@ export default class InviteMutations {
   }
 
   @Authorized([Roles.USER_OFFICER])
-  // @ValidateArgs(updateInviteValidationSchema)
+  @ValidateArgs(updateInviteValidationSchema)
   async update(agent: UserWithRole | null, args: UpdateInviteInput) {
     const { roleIds, coProposerProposalPk } = args.claims ?? {};
 

--- a/apps/backend/src/mutations/InviteMutations.ts
+++ b/apps/backend/src/mutations/InviteMutations.ts
@@ -157,8 +157,12 @@ export default class InviteMutations {
 
     if (!roleIds) return;
 
-    for await (const roleId of roleIds) {
-      await this.roleInviteDataSource.create(inviteCodeId, roleId);
+    if (roleIds.length > 0) {
+      await Promise.all(
+        roleIds.map((roleId) =>
+          this.roleInviteDataSource.create(inviteCodeId, roleId)
+        )
+      );
     }
   }
 

--- a/apps/backend/src/mutations/InviteMutations.ts
+++ b/apps/backend/src/mutations/InviteMutations.ts
@@ -63,6 +63,7 @@ export default class InviteMutations {
 
     const isCoProposerClaimAuthorized =
       coProposerProposalPk === undefined ||
+      this.userAuth.isUserOfficer(agent) ||
       (await this.proposalAuth.isMemberOfProposal(agent, coProposerProposalPk));
 
     if (isCoProposerClaimAuthorized === false) {

--- a/apps/backend/src/mutations/InviteMutations.ts
+++ b/apps/backend/src/mutations/InviteMutations.ts
@@ -193,27 +193,26 @@ export default class InviteMutations {
     claimerUserId: number,
     inviteCodeId: number
   ) {
-    const coProposerInvites =
+    const coProposerInvite =
       await this.coProposerInviteDataSource.findByInviteCodeId(inviteCodeId);
 
-    if (coProposerInvites.length === 0) {
+    if (coProposerInvite === null) {
       return;
     }
 
-    for await (const coProposerInvite of coProposerInvites) {
-      const proposalHasUser = await this.proposalHasUser(
-        coProposerInvite.proposalPk,
-        claimerUserId
-      );
-      if (proposalHasUser) {
-        continue;
-      }
-
-      await this.proposalDataSource.addProposalUser(
-        coProposerInvite.proposalPk,
-        claimerUserId
-      );
+    const proposalHasUser = await this.proposalHasUser(
+      coProposerInvite.proposalPk,
+      claimerUserId
+    );
+    // already a co-proposer
+    if (proposalHasUser) {
+      return;
     }
+
+    await this.proposalDataSource.addProposalUser(
+      coProposerInvite.proposalPk,
+      claimerUserId
+    );
   }
 
   private async proposalHasUser(proposalPk: number, userId: number) {

--- a/apps/backend/src/resolvers/mutations/CreateInviteMutation.ts
+++ b/apps/backend/src/resolvers/mutations/CreateInviteMutation.ts
@@ -13,10 +13,11 @@ import { InviteCode } from '../types/Invite';
 
 @InputType()
 export class ClaimsInput {
-  @Field(() => [Int!])
+  @Field(() => [Int!], { nullable: true })
   roleIds?: number[];
 
-  // TODO: Add more fields here such as co-proposer proposal id
+  @Field(() => Int, { nullable: true })
+  coProposerProposalId?: number;
 }
 
 @InputType()
@@ -24,8 +25,8 @@ export class CreateInviteInput {
   @Field(() => String)
   email: string;
 
-  @Field(() => String)
-  note: string;
+  @Field(() => String, { nullable: true })
+  note?: string;
 
   @Field(() => ClaimsInput)
   claims: ClaimsInput;

--- a/apps/backend/src/resolvers/mutations/CreateInviteMutation.ts
+++ b/apps/backend/src/resolvers/mutations/CreateInviteMutation.ts
@@ -17,7 +17,7 @@ export class ClaimsInput {
   roleIds?: number[];
 
   @Field(() => Int, { nullable: true })
-  coProposerProposalId?: number;
+  coProposerProposalPk?: number;
 }
 
 @InputType()


### PR DESCRIPTION
## Description
This pull request adds co-proposer claim to the invite
Although 20+  files have been touched, the main changes are in the following files
- apps/backend/db_patches/0168_AddCoProposerClaims.sql
- apps/backend/src/auth/InviteAuthorizer.ts
- apps/backend/src/datasources/postgres/CoProposerInviteDataSource.ts
- apps/backend/src/mutations/InviteMutations.ts

## Motivation and Context
Now it is possible to not only add a role, but also a co-proposer claim. This allows to create invites which when claimed assigns user a role.

## Changes
1. Added a new table `co_proposer_invites` in the PostgreSQL database to store co-proposer invite data.
2. Created the `InviteAuthorizer.ts` to include a new `InviteAuthorization` class to handle co-proposer invite authorization.
3. Updated package.json to use latest duo-validation for argument validation.
4. Updated the dependency configuration files to include the new `CoProposerInviteDataSource` and `InviteAuthorization` classes.

## How Has This Been Tested?

Added Unit tests

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4395](https://jira.esss.lu.se/browse/SWAP-4395)

