### PR TITLE
refactor: changes user already added error message

### DIFF
--- a/apps/frontend/src/components/user/PeopleTable.tsx
+++ b/apps/frontend/src/components/user/PeopleTable.tsx
@@ -429,7 +429,7 @@ const PeopleTable = ({
           }
 
           if (selectedUsers?.includes(userDetails.id)) {
-            setFieldError('email', 'User is already on the proposal');
+            setFieldError('email', 'User has already been added');
 
             return;
           }


### PR DESCRIPTION
closes https://github.com/UserOfficeProject/issue-tracker/issues/1240

## Description

Changes the message that's displayed when you search for the email of a user that's already been added to a proposal/visit/FAP from "User is already on the proposal" to the more generic "User has already been added".

![image](https://github.com/user-attachments/assets/982b98a9-3cdb-4b95-b5c6-6f8594bba635)


## Motivation and Context

PeopleTable is used in several contexts so the error message so be more generic.

## How Has This Been Tested

Tested manually

## Changes

`apps/frontend/src/components/user/PeopleTable.tsx line 432` - Error message has been changed
