### PR TITLE
fix: allow api keys for certain fap mutations

### DIFF
--- a/apps/backend/src/mutations/FapMutations.ts
+++ b/apps/backend/src/mutations/FapMutations.ts
@@ -163,6 +163,7 @@ export default class FapMutations {
     args: AssignReviewersToFapArgs
   ): Promise<Fap | Rejection> {
     if (
+      !agent?.isApiAccessToken &&
       !this.userAuth.isUserOfficer(agent) &&
       !(await this.userAuth.isChairOrSecretaryOfFap(agent, args.fapId))
     ) {
@@ -195,7 +196,11 @@ export default class FapMutations {
     );
     const isUserOfficer = this.userAuth.isUserOfficer(agent);
 
-    if (!isUserOfficer && !isChairOrSecretaryOfFap) {
+    if (
+      !agent?.isApiAccessToken &&
+      !isUserOfficer &&
+      !isChairOrSecretaryOfFap
+    ) {
       return rejection(
         'Could not remove member from Fap because of insufficient permissions',
         { agent, args }
@@ -430,6 +435,7 @@ export default class FapMutations {
     args: AssignFapReviewersToProposalsArgs
   ): Promise<Fap | Rejection> {
     if (
+      !agent?.isApiAccessToken &&
       !this.userAuth.isUserOfficer(agent) &&
       !(await this.userAuth.isChairOrSecretaryOfFap(agent, args.fapId))
     ) {
@@ -534,6 +540,7 @@ export default class FapMutations {
     args: RemoveFapReviewerFromProposalArgs
   ): Promise<Fap | Rejection> {
     if (
+      !agent?.isApiAccessToken &&
       !this.userAuth.isUserOfficer(agent) &&
       !(await this.userAuth.isChairOrSecretaryOfFap(agent, args.fapId))
     ) {


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1311
## Description

<!--- Describe your changes in detail -->
Allows users with API keys to carry out certain FAP mutations.

## Changes

- `apps/backend/src/mutations/FapMutations.ts` Allows API keys to `assignReviewersToFap`, `assignFapReviewersToProposals`, `removeMemberFromFap`, `removeMemberFromFapProposal`

## Tests included/Docs Updated?
Manually