### PR TITLE
chore: remove only

### DIFF
--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -3736,7 +3736,7 @@ context('Automatic Fap assignment to Proposal', () => {
   });
 });
 
-context.only('Fap meeting exports test', () => {
+context('Fap meeting exports test', () => {
   let createdInstrumentId: number;
   let proposalPK: number;
 


### PR DESCRIPTION
## Description
This pull request removes the "only" function from the 'Fap meeting exports test' context in the Cypress end-to-end test suite.

## Motivation and Context
The "only" function in Cypress is used during development to run a specific set of tests exclusively, ignoring all other tests. Leaving this function in the codebase can unintentionally skip important tests, leading to undetected bugs. This change ensures that the entire test suite is run, maintaining the integrity of our testing process.

## Changes
- Removed the "only" function from the 'Fap meeting exports test' context in the file `apps/e2e/cypress/e2e/FAPs.cy.ts`. This ensures that the test suite runs all tests as intended.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated