### PR TITLE
feat: add isRequired option for generic template questions

### DIFF
--- a/apps/frontend/src/components/questionary/questionaryComponents/GenericTemplate/GenericTemplateDefinition.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/GenericTemplate/GenericTemplateDefinition.tsx
@@ -29,6 +29,10 @@ export const genericTemplateDefinition: QuestionaryComponentDefinition = {
     const config = answer.config as SubTemplateConfig;
     let schema = Yup.array().of<Yup.AnyObjectSchema>(Yup.object());
 
+    if (config.required) {
+      schema = schema.min(1, 'This is a required field');
+    }
+
     if (config.minEntries) {
       schema = schema.min(
         config.minEntries,

--- a/apps/frontend/src/components/questionary/questionaryComponents/GenericTemplate/QuestionGenericTemplateForm.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/GenericTemplate/QuestionGenericTemplateForm.tsx
@@ -148,6 +148,16 @@ export const QuestionGenericTemplateForm = (props: QuestionFormProps) => {
           </TitledContainer>
           <TitledContainer label="Constraints">
             <Field
+              name="config.required"
+              id="Is-Required-Input"
+              component={CheckboxWithLabel}
+              type="checkbox"
+              Label={{
+                label: 'Is required',
+              }}
+              data-cy="required"
+            />
+            <Field
               name="config.minEntries"
               id="Min-Input"
               label="Min entries"

--- a/apps/frontend/src/components/questionary/questionaryComponents/GenericTemplate/QuestionTemplateRelationGenericTemplateForm.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/GenericTemplate/QuestionTemplateRelationGenericTemplateForm.tsx
@@ -109,6 +109,15 @@ export const QuestionTemplateRelationGenericTemplateForm = (
 
           <TitledContainer label="Constraints">
             <Field
+              name="config.required"
+              component={CheckboxWithLabel}
+              type="checkbox"
+              Label={{
+                label: 'Is required',
+              }}
+              data-cy="required"
+            />
+            <Field
               name="config.minEntries"
               label="Min entries"
               id="Min-input"


### PR DESCRIPTION
## Description
This PR introduces an "isRequired" option for generic template questions in the application. 

## Motivation and Context
Previously, there was no way to mandate the input for generic template questions. This was causing issues as some responses were left blank by users, leading to incomplete data. This feature aims to solve this problem by allowing the option to make these questions required.

## Changes
- Added a new "isRequired" option in the `genericTemplateDefinition` in `GenericTemplateDefinition.tsx`. This checks if the configuration requires an answer and adjusts the schema accordingly.
- Added a new checkbox in `QuestionGenericTemplateForm.tsx` and `QuestionTemplateRelationGenericTemplateForm.tsx` to allow users to mark a question as required.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

https://github.com/UserOfficeProject/issue-tracker/issues/1180

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated