### PR TITLE
fix: update GitHub Actions workflow to use dynamic runner for e2e tests

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -248,7 +248,7 @@ jobs:
 
           npm run test:backend
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.pattern.files }}
     needs: [resolve_dep, build]
 
     strategy:
@@ -257,22 +257,31 @@ jobs:
         pattern:
           - id: ae
             files: cypress/e2e/[a-e]*.ts
+            runner: ubuntu-latest
           - id: fh
             files: cypress/e2e/[f-h]*.ts
+            runner: ubuntu-latest
           - id: io
             files: cypress/e2e/[i-o]*.ts
+            runner: ubuntu-latest
           - id: p-am
             files: cypress/e2e/p[a-m]*.ts
+            runner: ubuntu-latest
           - id: p-nz
             files: cypress/e2e/p[n-z]*.ts
+            runner: ubuntu-latest
           - id: rs
             files: cypress/e2e/[r-s]*.ts
+            runner: ubuntu-latest
           - id: t
             files: cypress/e2e/t*.ts
+            runner: self-hosted
           - id: uz
             files: cypress/e2e/[u-z]*.ts
+            runner: ubuntu-latest
           - id: AZ
             files: cypress/e2e/[A-Z]*.ts
+            runner: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -351,6 +351,7 @@ jobs:
       - name: Download required repositories
         run: |
           cd "$GITHUB_WORKSPACE/.."
+          rm -rf user-office-factory
           git clone --depth 1 --branch "${{ needs.resolve_dep.outputs.FACTORY_TAG }}" https://github.com/UserOfficeProject/user-office-factory.git
 
       - name: Run e2e tests stfc

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -73,8 +73,10 @@ jobs:
   install-and-cache:
     name: Run install and cache
     needs: resolve_dep
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, self-hosted]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -248,9 +248,6 @@ jobs:
 
           npm run test:backend
   e2e:
-    runs-on: ${{ matrix.pattern.files }}
-    needs: [resolve_dep, build]
-
     strategy:
       fail-fast: false
       matrix:
@@ -282,6 +279,9 @@ jobs:
           - id: AZ
             files: cypress/e2e/[A-Z]*.ts
             runner: ubuntu-latest
+
+    runs-on: ${{ matrix.pattern.runner }}
+    needs: [resolve_dep, build]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
This PR updates the GitHub Actions workflow to use dynamic runners for e2e tests.

## Motivation and Context
The change is necessary to improve the efficiency and speed of our e2e tests by distributing tests across multiple runners based on their file names.

## Changes
1. The `runs-on` property for e2e tests in the GitHub Actions workflow is now dynamically set based on the `pattern.runner` matrix configuration.
2. Additional runner configurations have been added to the `pattern` matrix to distribute tests across both ubuntu-latest and self-hosted runners.
3. The `actions/checkout@v4` step has been maintained to ensure the latest codebase is used for tests.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated