### PR TITLE
feat: colorize log output

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -38,7 +38,7 @@
     "@graphql-tools/utils": "^10.1.0",
     "@isaacs/ttlcache": "^1.4.1",
     "@user-office-software/duo-localisation": "^1.2.0",
-    "@user-office-software/duo-logger": "^2.1.1",
+    "@user-office-software/duo-logger": "^2.3.0",
     "@user-office-software/duo-message-broker": "^1.6.0",
     "@user-office-software/duo-validation": "^5.1.11",
     "@user-office-software/openid": "^1.4.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -38,7 +38,7 @@
     "@graphql-tools/utils": "^10.1.0",
     "@isaacs/ttlcache": "^1.4.1",
     "@user-office-software/duo-localisation": "^1.2.0",
-    "@user-office-software/duo-logger": "^2.3.0",
+    "@user-office-software/duo-logger": "^2.3.1",
     "@user-office-software/duo-message-broker": "^1.6.0",
     "@user-office-software/duo-validation": "^5.1.11",
     "@user-office-software/openid": "^1.4.0",

--- a/apps/backend/src/config/dependencyConfigTest.ts
+++ b/apps/backend/src/config/dependencyConfigTest.ts
@@ -105,7 +105,9 @@ mapClass(Tokens.MailService, SkipSendMailService);
 mapValue(Tokens.EmailEventHandler, essEmailHandler);
 
 mapValue(Tokens.ConfigureEnvironment, () => {});
-mapValue(Tokens.ConfigureLogger, () => setLogger(new ConsoleLogger()));
+mapValue(Tokens.ConfigureLogger, () =>
+  setLogger(new ConsoleLogger({ colorize: true }))
+);
 
 mapClass(Tokens.DownloadService, DefaultDownloadService);
 

--- a/apps/backend/src/config/ess/configureGrayLogLogger.ts
+++ b/apps/backend/src/config/ess/configureGrayLogLogger.ts
@@ -11,7 +11,7 @@ export function configureGraylogLogger() {
   if (server && port) {
     const env = process.env.NODE_ENV || 'unset';
     setLogger([
-      new ConsoleLogger(), // Log to console
+      new ConsoleLogger({ colorize: true }), // Log to console
       new GrayLogLogger( // Log to Graylog
         server,
         parseInt(port),
@@ -20,6 +20,6 @@ export function configureGraylogLogger() {
       ),
     ]);
   } else {
-    setLogger(new ConsoleLogger()); // Log to console
+    setLogger(new ConsoleLogger({ colorize: true })); // Log to console
   }
 }


### PR DESCRIPTION
## Description

Info messages are now bold, error messages appear in red, and warnings are shown in yellow. These changes improve the readability of log outputs in the console making it easier to spot the error outputs.
![image](https://github.com/user-attachments/assets/bdfa8652-b84b-4f4a-9fa4-57481958239e)

Relates to: https://github.com/UserOfficeProject/user-office-lib/pull/209

## Motivation and Context
The changes were made to enhance the clarity of log outputs, making it easier to distinguish between different types of log messages at a glance, ultimately aiding in debugging and monitoring.


## Changes
- Added ANSI color codes to format INFO, ERROR, and WARN log levels.
- Refactored the log method in ConsoleLogger to apply the appropriate color formatting.

