### PR TITLE
fix: use short_code of status instead of name for FAP proposal filtering

### DIFF
--- a/apps/backend/src/datasources/postgres/FapDataSource.ts
+++ b/apps/backend/src/datasources/postgres/FapDataSource.ts
@@ -317,7 +317,7 @@ export default class PostgresFapDataSource implements FapDataSource {
             'p.status_id': 'ps.proposal_status_id',
           })
           .where(function () {
-            this.where('ps.name', 'ilike', 'FAP_%');
+            this.where('ps.short_code', 'ilike', 'FAP_%');
           });
 
         if (callId) {


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

Use short_code instead of name when filtering FAP proposals by status.

<!--- Describe your changes in detail -->

At ELI we would like to rename FAP_*** states but it is not possible with the current implementation since proposal/FAP assignment is checked by the proposal status name not the short_code (which is immutable). 

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manual tests + e2e.

## Fixes

N/A

## Changes

FAPDataSource.ts

## Depends on

N/A

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ x] I have added tests to cover my changes.
- [ x] All relevant doc has been updated
