### PR TITLE
chore: update backend package-lock.json

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -14,7 +14,7 @@
         "@graphql-tools/utils": "^10.1.0",
         "@isaacs/ttlcache": "^1.4.1",
         "@user-office-software/duo-localisation": "^1.2.0",
-        "@user-office-software/duo-logger": "^2.1.1",
+        "@user-office-software/duo-logger": "^2.3.1",
         "@user-office-software/duo-message-broker": "^1.6.0",
         "@user-office-software/duo-validation": "^5.1.11",
         "@user-office-software/openid": "^1.4.0",
@@ -3211,16 +3211,17 @@
       "integrity": "sha512-9axYsEtg5rr7FDibUTIaGxd1+sRpvreytLuhEQBZdzA+MXL5TxZcDGAqSQarrTklHP4mcJTWvDzyMV/yCKmYOw=="
     },
     "node_modules/@user-office-software/duo-logger": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-logger/-/duo-logger-2.1.1.tgz",
-      "integrity": "sha512-ud/uaYLkOANmtpUO4qLEMYHwIJlcwLGtsjBz5cfw/90/9aDSgOEkbUofjkLcqi+DgngI2n/XxyUCF0m47SGUdw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-logger/-/duo-logger-2.3.1.tgz",
+      "integrity": "sha512-/FbbnQcm8UHbKU0W2YvpB6eCvQHCPGeB6nPSKjcMNAzyWf/mfDP/5a5D4LWwntqHfHaaWmmBgfokWu77dBv+8g==",
+      "license": "ISC",
       "dependencies": {
         "fast-safe-stringify": "^2.1.1",
-        "gelf-pro": "^1.3.8"
+        "gelf-pro": "^1.3.11"
       },
       "engines": {
-        "node": ">=16.14.0",
-        "npm": ">=8.5.0"
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@user-office-software/duo-message-broker": {
@@ -6427,9 +6428,10 @@
       }
     },
     "node_modules/gelf-pro": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.3.10.tgz",
-      "integrity": "sha512-s6EnNLn+YTtwQAwe3dt0ZdBsmrfJTa21XQ8PnKfkIzSKjWUjq14yqm+bMFFANfYoPAuV/zkMaPdXYjC/PvRbcg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gelf-pro/-/gelf-pro-1.4.0.tgz",
+      "integrity": "sha512-VXQ1DHQjQr8/Xil83hHgozqeCcVrggGAA6A8hgjojQSatiF6PErR+nnYv/DCBxFBolO6licomD7Abaj0Iec7Qg==",
+      "license": "MIT",
       "dependencies": {
         "lodash": "~4.17.21"
       }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->

Update's the backend's package-lock.json by running npm install.

I believe this should fix a bunch of failing github action builds which seem to be using an outdated version of the backend's npm modules cache with an old version of our logging library. This cache is only updated when package-lock.json is updated, which the logger update PR didn't do https://github.com/UserOfficeProject/user-office-core/pull/933

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
