### PR TITLE
fix: refactor event logging to ensure resultKey and event is defined before usage

### DIFF
--- a/apps/backend/src/decorators/EventBus.ts
+++ b/apps/backend/src/decorators/EventBus.ts
@@ -22,25 +22,25 @@ const EventBusDecorator = (eventType: Event) => {
 
       const result = await originalMethod?.apply(this, args);
 
-      // NOTE: Get the name of the object or class like: 'Fap', 'USER', 'Proposal' and lowercase it.
-      const resultKey = (result.constructor.name as string).toLowerCase();
-
       // NOTE: This needs to be checked because there are mutations where we don't have loggedIn user
       if (!loggedInUser) {
         loggedInUser = result.user;
       }
 
-      const event = {
-        type: eventType,
-        [resultKey]: result,
-        key: resultKey,
-        loggedInUserId: loggedInUser ? loggedInUser.id : null,
-        isRejection: isRejection(result),
-        inputArgs: JSON.stringify(restArgs),
-      } as ApplicationEvent;
-
       // NOTE: Do not log the event in testing environment.
       if (process.env.NODE_ENV !== 'test') {
+        // NOTE: Get the name of the object or class like: 'Fap', 'USER', 'Proposal' and lowercase it.
+        const resultKey = (result.constructor.name as string).toLowerCase();
+
+        const event = {
+          type: eventType,
+          [resultKey]: result,
+          key: resultKey,
+          loggedInUserId: loggedInUser ? loggedInUser.id : null,
+          isRejection: isRejection(result),
+          inputArgs: JSON.stringify(restArgs),
+        } as ApplicationEvent;
+
         const eventBus = resolveApplicationEventBus();
         eventBus
           .publish(event)


### PR DESCRIPTION
## Description
This PR is a tweak to make sure the `resultKey` and `event` is not defined if it is a test environment , because it is not used in test.

## Changes
1. Moved the definition of `resultKey` inside the check for `NODE_ENV !== 'test'`, ensuring it is only defined when it is needed.
2. Adjusted the creation of the `event` object to be inside the check for `NODE_ENV !== 'test'`, as it now relies on the `resultKey` that is defined inside this check.

