### PR TITLE
feat: add instrument filter to proposal and assignments table

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -9227,11 +9227,11 @@
       "license": "ISC"
     },
     "node_modules/muhammara/node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.3.7",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -9451,7 +9451,7 @@
       }
     },
     "node_modules/muhammara/node_modules/ms": {
-      "version": "2.1.2",
+      "version": "2.1.3",
       "inBundle": true,
       "license": "MIT"
     },

--- a/apps/backend/src/datasources/FapDataSource.ts
+++ b/apps/backend/src/datasources/FapDataSource.ts
@@ -71,7 +71,11 @@ export interface FapDataSource {
     userId: number,
     proposalPk: number
   ): Promise<boolean>;
-  getFapProposals(fapId: number, callId: number | null): Promise<FapProposal[]>;
+  getFapProposals(
+    fapId: number,
+    callId: number | null,
+    instrumentId: number | null
+  ): Promise<FapProposal[]>;
   getFapUsersByProposalPkAndCallId(
     proposalPk: number,
     callId: number

--- a/apps/backend/src/datasources/mockups/FapDataSource.ts
+++ b/apps/backend/src/datasources/mockups/FapDataSource.ts
@@ -324,7 +324,11 @@ export class FapDataSourceMock implements FapDataSource {
     return { totalCount: dummyFapsCopy.length, faps: dummyFapsCopy };
   }
 
-  async getFapProposals(fapId: number, callId: number | null) {
+  async getFapProposals(
+    fapId: number,
+    callId: number | null,
+    instrumentId: number | null
+  ) {
     return dummyFapProposals.filter((proposal) => proposal.fapId === fapId);
   }
 

--- a/apps/backend/src/datasources/postgres/FapDataSource.ts
+++ b/apps/backend/src/datasources/postgres/FapDataSource.ts
@@ -303,7 +303,8 @@ export default class PostgresFapDataSource implements FapDataSource {
 
   async getFapProposals(
     fapId: number,
-    callId: number | null
+    callId: number | null,
+    instrumentId: number | null
   ): Promise<FapProposal[]> {
     const fapProposals: FapProposalRecord[] = await database
       .select(['fp.*'])
@@ -322,6 +323,9 @@ export default class PostgresFapDataSource implements FapDataSource {
 
         if (callId) {
           query.andWhere('fp.call_id', callId);
+        }
+        if (instrumentId) {
+          query.andWhere('fp.instrument_id', instrumentId);
         }
       })
       .where('fp.fap_id', fapId)

--- a/apps/backend/src/queries/FapQueries.ts
+++ b/apps/backend/src/queries/FapQueries.ts
@@ -64,14 +64,18 @@ export default class FapQueries {
   ])
   async getFapProposals(
     agent: UserWithRole | null,
-    { fapId, callId }: { fapId: number; callId: number | null }
+    {
+      fapId,
+      callId,
+      instrumentId,
+    }: { fapId: number; callId: number | null; instrumentId: number | null }
   ) {
     if (
       agent?.isApiAccessToken ||
       this.userAuth.isUserOfficer(agent) ||
       (await this.userAuth.isMemberOfFap(agent, fapId))
     ) {
-      return this.dataSource.getFapProposals(fapId, callId);
+      return this.dataSource.getFapProposals(fapId, callId, instrumentId);
     } else {
       return null;
     }

--- a/apps/backend/src/resolvers/queries/FapQuery.ts
+++ b/apps/backend/src/resolvers/queries/FapQuery.ts
@@ -35,9 +35,15 @@ export class FapQuery {
   async fapProposals(
     @Arg('fapId', () => Int) fapId: number,
     @Arg('callId', () => Int, { nullable: true }) callId: number | null,
+    @Arg('instrumentId', () => Int, { nullable: true })
+    instrumentId: number | null,
     @Ctx() context: ResolverContext
   ): Promise<FapProposal[] | null> {
-    return context.queries.fap.getFapProposals(context.user, { fapId, callId });
+    return context.queries.fap.getFapProposals(context.user, {
+      fapId,
+      callId,
+      instrumentId,
+    });
   }
 
   @Query(() => FapProposal, { nullable: true })

--- a/apps/backend/src/resolvers/types/FapProposal.ts
+++ b/apps/backend/src/resolvers/types/FapProposal.ts
@@ -10,6 +10,7 @@ import {
 
 import { ResolverContext } from '../../context';
 import { FapAssignment } from './FapAssignments';
+import { Instrument } from './Instrument';
 import { Proposal } from './Proposal';
 
 @ObjectType()
@@ -60,5 +61,15 @@ export class FapProposalResolver {
       fapProposal.proposalPk,
       fapProposal.instrumentId
     );
+  }
+
+  @FieldResolver(() => Instrument, { nullable: true })
+  async instrument(
+    @Root() fapProposal: FapProposal,
+    @Ctx() context: ResolverContext
+  ) {
+    return fapProposal.instrumentId
+      ? context.queries.instrument.get(context.user, fapProposal.instrumentId)
+      : null;
   }
 }

--- a/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
@@ -163,6 +163,10 @@ const FapProposalColumns: Column<FapProposalType>[] = [
         getGradesFromReviews(getReviewsFromAssignments(b.assignments ?? []))
       ),
   },
+  {
+    title: 'Instrument',
+    field: 'instrument.name',
+  },
 ];
 
 const FapProposalsAndAssignmentsTable = ({

--- a/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
@@ -67,6 +67,7 @@ type FapProposalsAndAssignmentsTableProps = {
   selectedCallId: number | null;
   /** Confirmation function that comes from withConfirm HOC */
   confirm: WithConfirmType;
+  selectedInstrumentId: number | null;
 };
 
 const getReviewsFromAssignments = (assignments: FapProposalAssignmentType[]) =>
@@ -174,12 +175,13 @@ const FapProposalsAndAssignmentsTable = ({
   onAssignmentsUpdate,
   selectedCallId,
   confirm,
+  selectedInstrumentId,
 }: FapProposalsAndAssignmentsTableProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const reviewModal = searchParams.get('reviewModal');
 
   const { loadingFapProposals, FapProposalsData, setFapProposalsData } =
-    useFapProposalsData(data.id, selectedCallId);
+    useFapProposalsData(data.id, selectedCallId, selectedInstrumentId);
   const { api } = useDataApiWithFeedback();
   const [proposalPks, setProposalPks] = useState<number[]>([]);
   const downloadPDFProposal = useDownloadPDFProposal();

--- a/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsView.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsView.tsx
@@ -3,8 +3,10 @@ import React from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import CallFilter from 'components/common/proposalFilters/CallFilter';
+import InstrumentFilter from 'components/common/proposalFilters/InstrumentFilter';
 import { Fap } from 'generated/sdk';
 import { useCallsData } from 'hooks/call/useCallsData';
+import { useFapInstruments } from 'hooks/instrument/useFapInstruments';
 
 import FapProposalsAndAssignmentsTable from './FapProposalsAndAssignmentsTable';
 
@@ -20,9 +22,18 @@ const FapProposalsAndAssignments = ({
 }: FapProposalsAndAssignmentsProps) => {
   const { loadingCalls, calls } = useCallsData({ fapIds: [fapData.id] });
   // NOTE: Default null means load all calls if nothing is selected
+  const { loadingInstruments, instruments } = useFapInstruments(
+    fapData.id,
+    null
+  );
 
   const [searchParams] = useSearchParams();
   const call = searchParams.get('call');
+  const instrument = searchParams.get('instrument');
+  console.log('Selected Instrument ID:', instrument ? +instrument : null);
+
+  console.log('Instrument Number:', instrument);
+  console.log('Instruments List:', instruments);
 
   return (
     <>
@@ -34,12 +45,19 @@ const FapProposalsAndAssignments = ({
             shouldShowAll={true}
             callId={call ? +call : null}
           />
+          <InstrumentFilter
+            instruments={instruments}
+            isLoading={loadingInstruments}
+            shouldShowAll={true}
+            instrumentId={instrument ? +instrument : null}
+          />
         </Grid>
       </Grid>
       <FapProposalsAndAssignmentsTable
         data={fapData}
         onAssignmentsUpdate={onFapUpdate}
         selectedCallId={call ? +call : null}
+        selectedInstrumentId={instrument ? +instrument : null}
       />
     </>
   );

--- a/apps/frontend/src/graphql/fap/getFapInstruments.graphql
+++ b/apps/frontend/src/graphql/fap/getFapInstruments.graphql
@@ -1,0 +1,7 @@
+query getFapInstruments($fapId: Int!, $callId: Int) {
+  fapProposals(fapId: $fapId, callId: $callId) {
+    instrument {
+      ...instrumentMinimal
+    }
+  }
+}

--- a/apps/frontend/src/graphql/fap/getFapProposals.graphql
+++ b/apps/frontend/src/graphql/fap/getFapProposals.graphql
@@ -21,6 +21,11 @@ query getFapProposals($fapId: Int!, $callId: Int) {
         institutionId
       }
     }
+    instrument {
+      id
+      name
+      shortCode
+    }
     assignments {
       proposalPk
       fapMemberUserId

--- a/apps/frontend/src/graphql/fap/getFapProposals.graphql
+++ b/apps/frontend/src/graphql/fap/getFapProposals.graphql
@@ -1,5 +1,5 @@
-query getFapProposals($fapId: Int!, $callId: Int) {
-  fapProposals(fapId: $fapId, callId: $callId) {
+query getFapProposals($fapId: Int!, $callId: Int, $instrumentId: Int) {
+  fapProposals(fapId: $fapId, callId: $callId, instrumentId: $instrumentId) {
     proposalPk
     dateAssigned
     fapId

--- a/apps/frontend/src/hooks/fap/useFapProposalsData.ts
+++ b/apps/frontend/src/hooks/fap/useFapProposalsData.ts
@@ -14,7 +14,8 @@ export type FapProposalAssignmentType = Unpacked<
 
 export function useFapProposalsData(
   fapId: number,
-  callId: number | null
+  callId: number | null,
+  instrumentId: number | null
 ): {
   loadingFapProposals: boolean;
   FapProposalsData: FapProposalType[];
@@ -29,7 +30,7 @@ export function useFapProposalsData(
     let cancelled = false;
     setLoadingFapProposals(true);
     api()
-      .getFapProposals({ fapId, callId })
+      .getFapProposals({ fapId, callId, instrumentId })
       .then((data) => {
         if (cancelled) {
           return;
@@ -44,7 +45,7 @@ export function useFapProposalsData(
     return () => {
       cancelled = true;
     };
-  }, [fapId, api, callId]);
+  }, [fapId, api, callId, instrumentId]);
 
   return {
     loadingFapProposals,

--- a/apps/frontend/src/hooks/instrument/useFapInstruments.ts
+++ b/apps/frontend/src/hooks/instrument/useFapInstruments.ts
@@ -1,0 +1,69 @@
+import {
+  useEffect,
+  useState,
+  SetStateAction,
+  Dispatch,
+  useContext,
+} from 'react';
+
+import { UserContext } from 'context/UserContextProvider';
+import { InstrumentMinimalFragment } from 'generated/sdk';
+import { useDataApi } from 'hooks/common/useDataApi';
+
+export function useFapInstruments(
+  fapId: number,
+  callId: number | null
+): {
+  loadingInstruments: boolean;
+  instruments: InstrumentMinimalFragment[];
+  setInstruments: Dispatch<SetStateAction<InstrumentMinimalFragment[]>>;
+} {
+  const [instruments, setInstruments] = useState<InstrumentMinimalFragment[]>(
+    []
+  );
+  const [loadingInstruments, setLoadingInstruments] = useState(true);
+  const { currentRole } = useContext(UserContext);
+
+  const api = useDataApi();
+
+  useEffect(() => {
+    let unmounted = false;
+
+    setLoadingInstruments(true);
+
+    api()
+      .getFapInstruments({ fapId, callId })
+      .then((data) => {
+        if (unmounted) {
+          return;
+        }
+
+        if (data.fapProposals) {
+          setInstruments(
+            data.fapProposals
+              .map((fapProposal) => fapProposal.instrument)
+              .filter(
+                (instrument): instrument is InstrumentMinimalFragment =>
+                  instrument !== null
+              )
+              .filter(
+                (instrument, index, self) =>
+                  self.findIndex((inst) => inst.id === instrument.id) === index
+              )
+          );
+        }
+        setLoadingInstruments(false);
+      });
+
+    return () => {
+      // used to avoid unmounted component state update error
+      unmounted = true;
+    };
+  }, [api, currentRole, callId, fapId]);
+
+  return {
+    loadingInstruments,
+    instruments,
+    setInstruments,
+  };
+}


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->
Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1313
- Added a column to show the instruments associated with proposals in the `Proposals and Assignments` table.
- Added the ability to filter proposals by instruments.

## Motivation and Context

Part of FAP Reviews improvements based on left-over issues from the 2024_2 round and requests through the support inbox.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

- Updated `getFapProposals` query to add `instrumentId` and updated its implementation throughout.
- Updated `FapProposalsAndAssignmentsTable` and `FapProposalsAndAssignmentsView` to display the instruments column and apply the `Instrument Filter`
- Added the `getFapInstrument` query to retrieve instrument data  effeciently and added the `useFapInstruments` hook accordingly.

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
