### PR TITLE
fix: migrated sample safety to experiment safety reviewers in the workflow email recipients configuration

### DIFF
--- a/apps/backend/db_patches/0170_MigrateSampleSafetyRoleInWorkflowActionEmail.sql
+++ b/apps/backend/db_patches/0170_MigrateSampleSafetyRoleInWorkflowActionEmail.sql
@@ -1,0 +1,13 @@
+DO
+$$
+BEGIN
+	IF register_patch('0170_MigrateSampleSafetyRoleInWorkflowActionEmail.sql', 'Yoganandan Pandiyan', 'Migrate the Role Sample Safety Reviewer to Experiment Safety Reviewer in the configured Workflow Email recepients', '2025-02-25') THEN
+    BEGIN
+      UPDATE proposal_workflow_connection_has_actions
+      SET config = REPLACE(config::TEXT, '"SAMPLE_SAFETY"', '"EXPERIMENT_SAFETY_REVIEWERS"')::jsonb
+      WHERE config::TEXT LIKE '%"SAMPLE_SAFETY"%';
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

During the role change from Sample Safety to Experiment Safety Review, an edge case was unhandled and due to which, there is a potential error in the Workflow system. 

In the Workflow, under the Status Action  sections, there is an ability to select the Email recipients and the Roles for this list is hardcoded. One such hardcoded value is SAMPLE_SAFETY and it was replaced with EXPERIMENT_SAFETY_REVIEWERS. This hardcoded value gets into the jsonb column `config` of `proposal_workflow_connection_has_actions`. So for the old records, this should be changed to EXPERIMENT_SAFETY_REVIEWERS ensuring Data consistency. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

Added a migration that does the update. The hack is to convert the json into a text, thereby facilitating easier string operation and putting back as a jsonb.
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
