### PR TITLE
fix: handle empty files

### DIFF
--- a/apps/backend/src/mutations/FileMutations.ts
+++ b/apps/backend/src/mutations/FileMutations.ts
@@ -19,7 +19,7 @@ export default class FileMutations {
     path: string
   ): Promise<FileMetadata | Rejection> {
     if (sizeImBytes === 0) {
-      return rejection('Could not save file because its 0 bytes', {
+      return rejection('Could not save file because it's 0 bytes', {
         fileName,
         path,
       });

--- a/apps/backend/src/mutations/FileMutations.ts
+++ b/apps/backend/src/mutations/FileMutations.ts
@@ -19,7 +19,7 @@ export default class FileMutations {
     path: string
   ): Promise<FileMetadata | Rejection> {
     if (sizeImBytes === 0) {
-      return rejection('Could not save file because it's 0 bytes', {
+      return rejection('Could not save file because it is 0 bytes', {
         fileName,
         path,
       });

--- a/apps/backend/src/mutations/FileMutations.ts
+++ b/apps/backend/src/mutations/FileMutations.ts
@@ -18,6 +18,13 @@ export default class FileMutations {
     sizeImBytes: number,
     path: string
   ): Promise<FileMetadata | Rejection> {
+    if (sizeImBytes === 0) {
+      return rejection('Could not save file because its 0 bytes', {
+        fileName,
+        path,
+      });
+    }
+
     return this.dataSource
       .put(fileName, mimeType, sizeImBytes, path)
       .then((metadata) => metadata)

--- a/apps/frontend/src/components/common/FileUploadComponent.tsx
+++ b/apps/frontend/src/components/common/FileUploadComponent.tsx
@@ -210,6 +210,9 @@ export function NewFileEntry(props: {
 }) {
   const theme = useTheme();
   const { uploadFile, progress, state, setState, abort } = useFileUpload();
+  const [rejectionMessage, setRejectionMessage] = useState(
+    'Incorrect file type'
+  );
 
   const hasValidContentHeader = (file: File): boolean => {
     if (!props.filetype) {
@@ -243,6 +246,13 @@ export function NewFileEntry(props: {
     const selectedFile = e.target.files ? e.target.files[0] : null;
     if (!selectedFile) return;
 
+    if (selectedFile.size === 0) {
+      setState(UPLOAD_STATE.REJECTED);
+      setRejectionMessage('File size is 0 bytes');
+
+      return;
+    }
+
     if (hasExtension(selectedFile) && hasValidContentHeader(selectedFile)) {
       uploadFile(selectedFile, props.onUploadComplete);
     } else {
@@ -265,8 +275,8 @@ export function NewFileEntry(props: {
             </Avatar>
           </ListItemAvatar>
           <ListItemText
-            primary="Incorrect file type"
-            secondary="Ensure that the file is of the correct type and has an extension."
+            primary={rejectionMessage}
+            secondary="Ensure that the file is of the correct type, size and has an extension."
           />
           <ListItemSecondaryAction>
             <CancelIcon onClick={() => abort()} />

--- a/apps/frontend/src/components/common/FileUploadComponent.tsx
+++ b/apps/frontend/src/components/common/FileUploadComponent.tsx
@@ -276,7 +276,7 @@ export function NewFileEntry(props: {
           </ListItemAvatar>
           <ListItemText
             primary={rejectionMessage}
-            secondary="Ensure that the file is of the correct type, size and has an extension."
+            secondary="Please make sure your file is of correct type, has an extension and not zero bytes."
           />
           <ListItemSecondaryAction>
             <CancelIcon onClick={() => abort()} />


### PR DESCRIPTION
## Description
This PR introduces a new feature that prevents the uploading and saving of empty files (0 bytes) to the system.

## Motivation and Context
The change is required to enhance the error handling mechanism of our file upload process. Previously, the system allowed empty files to be uploaded and saved, which could lead to data inconsistency and potential errors down the line.

## Changes
1. Added a condition to check the file size in the backend (FileMutations.ts). If the file size is 0 bytes, the system will reject the file and return an error message.
2. Updated the frontend (FileUploadComponent.tsx) to handle the new rejection case. If a user tries to upload an empty file, they will see a rejection message stating "File size is 0 bytes".
3. Updated the error message displayed to the user to include issues with file size, in addition to the existing messages about file type and extension.

## How Has This Been Tested?
Manual testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1326

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated