### PR TITLE
fix: stop non user officers from editing custom grade guide

### DIFF
--- a/apps/frontend/src/components/fap/FapGradeGuide.tsx
+++ b/apps/frontend/src/components/fap/FapGradeGuide.tsx
@@ -14,12 +14,7 @@ type FapGradeGuideProps = {
 const FapGradeGuide: React.FC<FapGradeGuideProps> = ({ fap, onFapUpdate }) => {
   const { isExecutingCall } = useDataApiWithFeedback();
 
-  const hasAccessRights = useCheckAccess([
-    UserRole.USER_OFFICER,
-    UserRole.FAP_CHAIR,
-    UserRole.FAP_SECRETARY,
-    UserRole.FAP_REVIEWER,
-  ]);
+  const hasAccessRights = useCheckAccess([UserRole.USER_OFFICER]);
 
   return (
     <Grid item sm={25} xs={12}>

--- a/apps/frontend/src/components/fap/General/FapGeneralInfo.tsx
+++ b/apps/frontend/src/components/fap/General/FapGeneralInfo.tsx
@@ -133,6 +133,7 @@ const FapGeneralInfo = ({ data, onFapUpdate }: FapPageProps) => {
                   label: 'Custom Grade Guide',
                 }}
                 data-cy="custom-grade-guide"
+                disabled={!hasAccessRights || isExecutingCall}
               />
             </Grid>
             <Grid item sm={6} xs={12}>


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1264

## Description
This PR restricts non-user officers from editing the custom grade guide.

## Motivation and Context
This change is required to ensure that editing permissions for the custom grade guide are strictly controlled and limited to user officers, providing a safeguard against unauthorized modifications.

## Changes
1. Updated the access rights in the FapGradeGuide component to only include the UserRole.USER_OFFICER.
2. Disabled the editing of the custom grade guide in the FapGeneralInfo component when the user does not have access rights or when a call is executing.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated