### PR TITLE
test: turn on tech review tests stfc mode and clean up only

### DIFF
--- a/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
@@ -138,13 +138,16 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
         if (filter?.callId) {
           query.where('call_id', filter.callId);
         }
-        if (filter?.instrumentFilter?.instrumentId) {
+        if (filter?.instrumentFilter?.showMultiInstrumentProposals) {
+          query.whereRaw('jsonb_array_length(instruments) > 1');
+        } else if (filter?.instrumentFilter?.instrumentId) {
           // NOTE: Using jsonpath we check the jsonb (instruments) field if it contains object with id equal to filter.instrumentId
           query.whereRaw(
             'jsonb_path_exists(instruments, \'$[*].id \\? (@.type() == "number" && @ == :instrumentId:)\')',
             { instrumentId: filter?.instrumentFilter?.instrumentId }
           );
         }
+
         if (filter?.proposalStatusId) {
           query.where('proposal_status_id', filter?.proposalStatusId);
         }

--- a/apps/e2e/cypress/e2e/genericTemplates.cy.ts
+++ b/apps/e2e/cypress/e2e/genericTemplates.cy.ts
@@ -1111,7 +1111,7 @@ context('GenericTemplates tests', () => {
   });
 
   describe('Generic sub template tests', () => {
-    it.only('Sub template should be cleared if dependencies are not satisfied after clonning', () => {
+    it('Sub template should be cleared if dependencies are not satisfied after clonning', () => {
       let proposalPK: number;
       cy.createProposalWorkflow(proposalWorkflow).then((result) => {
         if (result.createProposalWorkflow) {

--- a/apps/e2e/cypress/e2e/instruments.cy.ts
+++ b/apps/e2e/cypress/e2e/instruments.cy.ts
@@ -687,13 +687,12 @@ context('Instrument tests', () => {
     let createdProposalId: string;
 
     beforeEach(function () {
-      if (!featureFlags.getEnabledFeatures().get(FeatureId.SCHEDULER)) {
-        this.skip();
+      if (featureFlags.getEnabledFeatures().get(FeatureId.SCHEDULER)) {
+        cy.updateUserRoles({
+          id: scientist2.id,
+          roles: [initialDBData.roles.instrumentScientist],
+        });
       }
-      cy.updateUserRoles({
-        id: scientist2.id,
-        roles: [initialDBData.roles.instrumentScientist],
-      });
 
       cy.createInstrument(instrument1).then((result) => {
         if (result.createInstrument) {
@@ -868,7 +867,10 @@ context('Instrument tests', () => {
       // cy.contains(proposal1.title).should('exist');
     });
 
-    it('Instrument scientists should be able to filter only their own proposals', () => {
+    it('Instrument scientists should be able to filter only their own proposals', function () {
+      if (featureFlags.getEnabledFeatures().get(FeatureId.STFC_IDLE_TIMER)) {
+        this.skip();
+      }
       cy.createProposal({ callId: initialDBData.call.id }).then((result) => {
         if (result.createProposal) {
           createdProposalPk = result.createProposal.primaryKey;


### PR DESCRIPTION
Close https://github.com/UserOfficeProject/issue-tracker/issues/1365

## Description
The PR includes enhancements to the proposal data source and test cases, improving the overall functionality and reliability of the application.

## Motivation and Context
The changes were necessary to enable technical review tests in STFC mode and to address certain issues related to proposal filtering and test case execution.

## Changes
1. In `StfcProposalDataSource.ts`, the proposal filter logic has been updated to allow filtering of proposals with multiple instruments. This expands the filtering capabilities of the application.
2. In `genericTemplates.cy.ts`, a test case related to sub-template cloning has been updated, enhancing the robustness of our test suite.
3. In `instruments.cy.ts`, the setup for instrument-related test cases has been modified to account for the enabled SCHEDULER feature. Also, a condition has been added to skip a test case if the STFC_IDLE_TIMER feature is enabled. This ensures that our test cases run correctly under different feature flag configurations.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated