### PR TITLE
chore: upgrade Node.js version to 20.x

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -8,7 +8,7 @@ on:
       - staging
 
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 20.x
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -5,7 +5,7 @@ on:
       - master
 
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 20.x
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     branches: [develop, master]
 
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 20.x
 
 jobs:
   run-linters:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,7 +7,7 @@ on:
     branches: [develop]
 
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 20.x
   FRONTEND_SDK_KEY: sdk-frontend-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.18.0-alpine AS build-stage
+FROM node:20.19.0-alpine AS build-stage
 
 USER node
 
@@ -16,7 +16,7 @@ COPY --chown=node:node . .
 
 RUN npm run build
 
-FROM node:18.18.0-alpine
+FROM node:20.19.0-alpine
 
 USER node
 

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18.18.0-alpine
+FROM node:20.19.0-alpine
 
 USER node
 

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -71,7 +71,7 @@
         "@types/lodash.merge": "^4.6.7",
         "@types/luxon": "^3.4.2",
         "@types/multer": "^1.4.7",
-        "@types/node": "^18.0.0",
+        "@types/node": "^20.17.24",
         "@types/pg": "^8.11.5",
         "@types/pg-large-object": "^2.0.7",
         "@types/sanitize-html": "^2.6.2",
@@ -99,8 +99,8 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.8.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2760,9 +2760,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.17.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.7.tgz",
-      "integrity": "sha512-WJj/p/cIg6zUsxv1n2leZHpvn8hr9TYuLQxAZxZcK/7+5t5ukmJGelOLGOy3L1MLhAO/sapTJGd1V7kvoIuzUg=="
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -12986,6 +12990,12 @@
       "peerDependencies": {
         "underscore": "1.x"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/unicode-trie": {
       "version": "2.0.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -95,7 +95,7 @@
     "@types/lodash.merge": "^4.6.7",
     "@types/luxon": "^3.4.2",
     "@types/multer": "^1.4.7",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.17.24",
     "@types/pg": "^8.11.5",
     "@types/pg-large-object": "^2.0.7",
     "@types/sanitize-html": "^2.6.2",
@@ -123,7 +123,7 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.8.2",
+    "node": ">=20.0.0"
   }
 }

--- a/apps/e2e/package-lock.json
+++ b/apps/e2e/package-lock.json
@@ -25,7 +25,7 @@
         "@cypress/webpack-preprocessor": "^6.0.0",
         "@types/eslint": "^8.56.9",
         "@types/luxon": "^3.4.2",
-        "@types/node": "^16.0.0",
+        "@types/node": "^20.17.24",
         "@types/pdf-parse": "^1.1.1",
         "@typescript-eslint/eslint-plugin": "^7.1.0",
         "@typescript-eslint/parser": "^7.1.0",
@@ -40,8 +40,8 @@
         "webpack": "^5.94.0"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.8.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2400,10 +2400,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.40.tgz",
-      "integrity": "sha512-7bOWglXUO6f21NG3YDI7hIpeMX3M59GG+DzZuzX2EkFKYUnRoxq3EOg4R0KNv2hxryY9M3UUqG5akwwsifrukw==",
-      "devOptional": true
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/pdf-parse": {
       "version": "1.1.1",
@@ -7396,6 +7400,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -9489,10 +9500,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.40.tgz",
-      "integrity": "sha512-7bOWglXUO6f21NG3YDI7hIpeMX3M59GG+DzZuzX2EkFKYUnRoxq3EOg4R0KNv2hxryY9M3UUqG5akwwsifrukw==",
-      "devOptional": true
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "devOptional": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/pdf-parse": {
       "version": "1.1.1",
@@ -13084,6 +13098,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "devOptional": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -21,7 +21,7 @@
     "@cypress/webpack-preprocessor": "^6.0.0",
     "@types/eslint": "^8.56.9",
     "@types/luxon": "^3.4.2",
-    "@types/node": "^16.0.0",
+    "@types/node": "^20.17.24",
     "@types/pdf-parse": "^1.1.1",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
@@ -36,8 +36,8 @@
     "webpack": "^5.94.0"
   },
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.8.2",
+    "node": ">=20.0.0"
   },
   "scripts": {
     "lint": "tsc --noEmit && eslint . --ext .js,.ts --quiet",

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 0, "build-stage", based on Node.js, to build and compile the frontend
-FROM node:18.18.0-alpine as build-stage
+FROM node:20.19.0-alpine as build-stage
 
 ARG ORCID_REDIRECT=
 ARG BUILD_VERSION=<unknown>

--- a/apps/frontend/Dockerfile.dev
+++ b/apps/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18.18.0-alpine
+FROM node:20.19.0-alpine
 
 USER node
 

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -54,7 +54,7 @@
         "@types/eslint": "^8.2.1",
         "@types/luxon": "^3.4.2",
         "@types/mime": "^2.0.3",
-        "@types/node": "^18.0.0",
+        "@types/node": "^20.17.24",
         "@types/react": "^18.3.3",
         "@types/react-test-renderer": "^18.3.0",
         "@types/yup": "^0.29.13",
@@ -74,8 +74,8 @@
         "vite": "^5.4.14"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.8.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4330,9 +4330,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.17.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.8.tgz",
-      "integrity": "sha512-Av/7MqX/iNKwT9Tr60V85NqMnsmh8ilfJoBlIVibkXfitk9Q22D9Y5mSpm+FvG5DET7EbVfB40bOiLzKgYFgPw=="
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -13253,6 +13257,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
     "node_modules/unixify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
@@ -16647,9 +16657,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.17.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.8.tgz",
-      "integrity": "sha512-Av/7MqX/iNKwT9Tr60V85NqMnsmh8ilfJoBlIVibkXfitk9Q22D9Y5mSpm+FvG5DET7EbVfB40bOiLzKgYFgPw=="
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.2",
@@ -22856,6 +22869,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg=="
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "unixify": {
       "version": "1.0.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -82,7 +82,7 @@
     "@types/eslint": "^8.2.1",
     "@types/luxon": "^3.4.2",
     "@types/mime": "^2.0.3",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.17.24",
     "@types/react": "^18.3.3",
     "@types/react-test-renderer": "^18.3.0",
     "@types/yup": "^0.29.13",
@@ -102,7 +102,7 @@
     "vite": "^5.4.14"
   },
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.8.2",
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
## Description
This PR upgrades Node.js version from 18.x to 20.x across all Dockerfiles and workflows.

## Motivation and Context
Node 18 is ending its life in April 2025. This upgrade features performance updates as well as will allow us to get active maintenance updates until April 2026.
Upgrade to 22 was considered but postponed due to issues on dependent libraries like muhammara.

## Changes
- Updated Node.js version in all Dockerfiles from 18.18.0-alpine to 20.19.0-alpine.
- Updated Node.js version in Github workflows (`build-push.yml`, `github-tag-and-release.yml`, `lint.yml`, `test-build.yml`) from 18.x to 20.x.
- Updated `@types/node` version in `package.json` of `apps/backend`, `apps/e2e`, and `apps/frontend` from 18.0.0 and 16.0.0 respectively to 20.0.0.
- Updated the required `node` and `npm` versions in `engines` section of `package.json` in `apps/backend`, `apps/e2e`, and `apps/frontend`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4470](https://jira.esss.lu.se/browse/SWAP-4470)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated