### PR TITLE
chore: update muhammara to version 5.3.0 and npm engine to 10.9.2

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -39,7 +39,7 @@
         "lodash.merge": "^4.6.2",
         "luxon": "^3.4.4",
         "magic-bytes.js": "^1.10.0",
-        "muhammara": "^4.1.0",
+        "muhammara": "^5.3.0",
         "multer": "^1.4.4",
         "openapi-typescript-codegen": "^0.29.0",
         "openid-client": "^5.6.4",
@@ -100,7 +100,7 @@
       },
       "engines": {
         "node": ">=22.0.0",
-        "npm": ">=10.8.2"
+        "npm": ">=10.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9106,21 +9106,22 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/muhammara": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/muhammara/-/muhammara-4.1.0.tgz",
-      "integrity": "sha512-6h8cPdL5b+BtlKE6Yp9AnK0YgGWGO4bBvA/blm4pM/C9Xp6jXPI9JJNVJpYnqESGmUFGGCV7b04nVK3zf56XZQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/muhammara/-/muhammara-5.3.0.tgz",
+      "integrity": "sha512-TnufLQM0J3QbbXbJiUS1FWdBrtIVw2DudZBxFimIwlm7pgkFWPY/jNr1wx+6qLExqiI5njfESh+LXuuAXeMwcQ==",
       "bundleDependencies": [
         "@mapbox/node-pre-gyp"
       ],
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.10",
+        "@mapbox/node-pre-gyp": "^1.0.11",
         "@xmldom/xmldom": "^0.8.6",
         "linebreak": "^1.1.0",
         "memory-streams": "^0.1.3"
       },
       "engines": {
-        "node": ">=15"
+        "node": ">=17"
       }
     },
     "node_modules/muhammara/node_modules/@mapbox/node-pre-gyp": {
@@ -9181,6 +9182,7 @@
     },
     "node_modules/muhammara/node_modules/are-we-there-yet": {
       "version": "2.0.0",
+      "deprecated": "This package is no longer supported.",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9232,7 +9234,7 @@
       "license": "ISC"
     },
     "node_modules/muhammara/node_modules/debug": {
-      "version": "4.3.7",
+      "version": "4.4.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9253,7 +9255,7 @@
       "license": "MIT"
     },
     "node_modules/muhammara/node_modules/detect-libc": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9294,6 +9296,7 @@
     },
     "node_modules/muhammara/node_modules/gauge": {
       "version": "3.0.2",
+      "deprecated": "This package is no longer supported.",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9313,6 +9316,7 @@
     },
     "node_modules/muhammara/node_modules/glob": {
       "version": "7.2.3",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9349,6 +9353,7 @@
     },
     "node_modules/muhammara/node_modules/inflight": {
       "version": "1.0.6",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9371,7 +9376,6 @@
     },
     "node_modules/muhammara/node_modules/lru-cache": {
       "version": "6.0.0",
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -9495,6 +9499,7 @@
     },
     "node_modules/muhammara/node_modules/npmlog": {
       "version": "5.0.1",
+      "deprecated": "This package is no longer supported.",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9543,6 +9548,7 @@
     },
     "node_modules/muhammara/node_modules/rimraf": {
       "version": "3.0.2",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9575,12 +9581,9 @@
       "license": "MIT"
     },
     "node_modules/muhammara/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.3",
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9631,7 +9634,7 @@
       }
     },
     "node_modules/muhammara/node_modules/tar": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -9374,16 +9374,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/muhammara/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/muhammara/node_modules/make-dir": {
       "version": "3.1.0",
       "inBundle": true,

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -63,7 +63,7 @@
     "lodash.merge": "^4.6.2",
     "luxon": "^3.4.4",
     "magic-bytes.js": "^1.10.0",
-    "muhammara": "^4.1.0",
+    "muhammara": "^5.3.0",
     "multer": "^1.4.4",
     "openapi-typescript-codegen": "^0.29.0",
     "openid-client": "^5.6.4",

--- a/apps/e2e/cypress.config.ts
+++ b/apps/e2e/cypress.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from 'cypress';
 
 import {
   convertXlsxToJson,
+  deleteFile,
   downloadFile,
   readPdf,
   unzip,
@@ -113,6 +114,8 @@ module.exports = defineConfig({
       on('task', { unzip });
 
       on('task', { convertXlsxToJson });
+
+      on('task', { deleteFile });
     },
   },
 });

--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -4122,9 +4122,11 @@ context('Fap meeting exports test', () => {
     cy.visit('/FapPage/2?tab=4&call=1');
 
     cy.get('button[aria-label="Export in Excel"]').click();
+    cy.get('[data-cy=preparing-download-dialog').should('not.exist');
 
     const downloadsFolder = Cypress.config('downloadsFolder');
     const fileName = `Fap-${fap1.code}-${updatedCall.shortCode}.xlsx`;
+    const fileUri = `${downloadsFolder}/${fileName}`;
 
     cy.readFile(`${downloadsFolder}/${fileName}`)
       .should('exist')
@@ -4137,6 +4139,8 @@ context('Fap meeting exports test', () => {
           }
         );
       });
+
+    cy.task('deleteFile', fileUri);
   });
 
   it('Officer should be able to download all FAP meetings in excel', function () {
@@ -4154,8 +4158,11 @@ context('Fap meeting exports test', () => {
       .find('[aria-label="Export Fap Data"]')
       .click();
 
+    cy.get('[data-cy=preparing-download-dialog').should('not.exist');
+
     const downloadsFolder = Cypress.config('downloadsFolder');
     const fileName = `${updatedCall.shortCode}_FAP_Results.xlsx`;
+    const fileUri = `${downloadsFolder}/${fileName}`;
 
     cy.readFile(`${downloadsFolder}/${fileName}`)
       .should('exist')
@@ -4168,6 +4175,8 @@ context('Fap meeting exports test', () => {
           }
         );
       });
+
+    cy.task('deleteFile', fileUri);
   });
 
   it('Officer should be able to download a summary of the FAP meeting stfc', function () {
@@ -4180,9 +4189,11 @@ context('Fap meeting exports test', () => {
     cy.visit('/FapPage/2?tab=4&call=1');
 
     cy.get('button[aria-label="Export in Excel"]').click();
+    cy.get('[data-cy=preparing-download-dialog').should('not.exist');
 
     const downloadsFolder = Cypress.config('downloadsFolder');
     const fileName = `Fap-${fap1.code}-${updatedCall.shortCode}.xlsx`;
+    const fileUri = `${downloadsFolder}/${fileName}`;
 
     cy.readFile(`${downloadsFolder}/${fileName}`)
       .should('exist')
@@ -4195,6 +4206,8 @@ context('Fap meeting exports test', () => {
           }
         );
       });
+
+    cy.task('deleteFile', fileUri);
   });
 
   it('Officer should be able to download all FAP meetings in excel stfc', function () {
@@ -4212,8 +4225,11 @@ context('Fap meeting exports test', () => {
       .find('[aria-label="Export Fap Data"]')
       .click();
 
+    cy.get('[data-cy=preparing-download-dialog').should('not.exist');
+
     const downloadsFolder = Cypress.config('downloadsFolder');
     const fileName = `${updatedCall.shortCode}_FAP_Results.xlsx`;
+    const fileUri = `${downloadsFolder}/${fileName}`;
 
     cy.readFile(`${downloadsFolder}/${fileName}`)
       .should('exist')
@@ -4228,6 +4244,8 @@ context('Fap meeting exports test', () => {
           }
         );
       });
+
+    cy.task('deleteFile', fileUri);
   });
 
   it('Expired proposals should not appear in exports', function () {
@@ -4246,9 +4264,11 @@ context('Fap meeting exports test', () => {
     cy.visit('/FapPage/2?tab=4&call=1');
 
     cy.get('button[aria-label="Export in Excel"]').click();
+    cy.get('[data-cy=preparing-download-dialog').should('not.exist');
 
     const downloadsFolder = Cypress.config('downloadsFolder');
     const fileName = `Fap-${fap1.code}-${updatedCall.shortCode}.xlsx`;
+    const fileUri = `${downloadsFolder}/${fileName}`;
 
     cy.readFile(`${downloadsFolder}/${fileName}`)
       .should('exist')
@@ -4263,5 +4283,7 @@ context('Fap meeting exports test', () => {
           }
         );
       });
+
+    cy.task('deleteFile', fileUri);
   });
 });

--- a/apps/e2e/cypress/e2e/pdfTemplates.cy.ts
+++ b/apps/e2e/cypress/e2e/pdfTemplates.cy.ts
@@ -115,7 +115,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="templateData"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -128,7 +128,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="templateHeader"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -141,7 +141,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="templateFooter"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -154,7 +154,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="templateSampleDeclaration"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -167,7 +167,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="dummyData"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -233,7 +233,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="templateData"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -246,7 +246,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="templateHeader"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -259,7 +259,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="templateFooter"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -272,7 +272,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="templateSampleDeclaration"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });
@@ -285,7 +285,7 @@ context('PDF template tests', () => {
 
       cy.get('[data-cy="dummyData"] .cm-content')
         .first()
-        .type(pdfTemplateData)
+        .invoke('text', pdfTemplateData)
         .should(($p) => {
           expect($p).to.contain(pdfTemplateData);
         });

--- a/apps/e2e/cypress/support/fileUtilTasks.ts
+++ b/apps/e2e/cypress/support/fileUtilTasks.ts
@@ -68,3 +68,11 @@ export const convertXlsxToJson = (filePath: string) => {
 
   return jsonData;
 };
+
+export const deleteFile = (filePath: string) => {
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+
+  return null;
+};

--- a/apps/e2e/package-lock.json
+++ b/apps/e2e/package-lock.json
@@ -41,7 +41,7 @@
       },
       "engines": {
         "node": ">=20.0.0",
-        "npm": ">=10.8.2"
+        "npm": ">=10.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -75,7 +75,7 @@
       },
       "engines": {
         "node": ">=20.0.0",
-        "npm": ">=10.8.2"
+        "npm": ">=10.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
## Description
This PR updates the muhammara library to version 5.3.0 and the npm engine to version 10.9.2. as well as updates some E2E tests that started to fail due to different race conditions

## Motivation and Context
The previous version of muhammara (4.1.0) and npm engine (10.8.2) were outdated. Updating these ensures that we are using the latest features, security updates, and bug fixes provided by these versions.

## Changes
- Updated muhammara from version 4.1.0 to 5.3.0. This may introduce new features, improve performance, and fix potential bugs present in the previous version.
- Updated npm engine from version 10.8.2 to 10.9.2. This ensures compatibility with the latest npm features and updates.
- Updated dependencies of muhammara to their latest respective versions. This includes updates to "@mapbox/node-pre-gyp", "@xmldom/xmldom", "linebreak", and "memory-streams". These updates ensure that our application is taking advantage of the latest updates and bug fixes in these libraries.
- Updated flaky tests

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated