### PR TITLE
fix: add null check on fields which can be null for some legacy proposals

### DIFF
--- a/apps/backend/src/asyncJobs/jobs/checkAllCallsEnded.ts
+++ b/apps/backend/src/asyncJobs/jobs/checkAllCallsEnded.ts
@@ -16,7 +16,7 @@ const checkCallsEnded = async (dataSource: CallDataSource) => {
     const currentDate = new Date();
 
     const callsThatShouldEnd = notEndedCalls.filter(
-      (notEndedCall) => notEndedCall.endCall.getTime() <= currentDate.getTime()
+      (notEndedCall) => notEndedCall.endCall?.getTime() <= currentDate.getTime()
     );
 
     for (const callThatShouldEnd of callsThatShouldEnd) {
@@ -53,7 +53,7 @@ const checkCallsEndedInternal = async (dataSource: CallDataSource) => {
 
     const callsThatShouldEndInternal = notEndedInternalCalls.filter(
       (notEndedCall) =>
-        notEndedCall.endCallInternal.getTime() <= currentDate.getTime()
+        notEndedCall.endCallInternal?.getTime() <= currentDate.getTime()
     );
 
     for (const callThatShouldEndInternal of callsThatShouldEndInternal) {

--- a/apps/backend/src/asyncJobs/jobs/checkCallsFAPReviewEnded.ts
+++ b/apps/backend/src/asyncJobs/jobs/checkCallsFAPReviewEnded.ts
@@ -21,7 +21,7 @@ const checkAndNotifyFapReviewersBeforeReviewEnds = async (
   const eventBus = resolveApplicationEventBus();
   const callsThatShouldSendEmailsToFapReviewers = fapReviewNotEndedCalls.filter(
     (fapReviewNotEndedCall) =>
-      fapReviewNotEndedCall.endFapReview.getTime() <=
+      fapReviewNotEndedCall.endFapReview?.getTime() <=
       currentDate
         .plus({ days: DAYS_BEFORE_SENDING_NOTIFICATION_EMAILS })
         .toMillis()
@@ -56,7 +56,7 @@ const checkCallsFapReviewEnded = async (dataSource: CallDataSource) => {
 
     const callsThatShouldEndFapReview = fapReviewNotEndedCalls.filter(
       (fapReviewNotEndedCall) =>
-        fapReviewNotEndedCall.endFapReview.getTime() <= currentDate.toMillis()
+          fapReviewNotEndedCall.endFapReview?.getTime() <= currentDate.toMillis()
     );
 
     // NOTE: Check if there is any Fap review that is not submitted 2 days before the Fap review ends on a call.

--- a/apps/backend/src/asyncJobs/jobs/checkCallsReviewEnded.ts
+++ b/apps/backend/src/asyncJobs/jobs/checkCallsReviewEnded.ts
@@ -17,7 +17,7 @@ const checkCallsReviewEnded = async (dataSource: CallDataSource) => {
 
     const callsThatShouldEndReview = reviewNotEndedCalls.filter(
       (reviewNotEndedCall) =>
-        reviewNotEndedCall.endReview.getTime() <= currentDate.getTime()
+        reviewNotEndedCall.endReview?.getTime() <= currentDate.getTime()
     );
 
     const updatedCalls = [];


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
This PR adds a null check for date fields - `endCall`, `endCallInternal`, `endFapReview`, `endReview` when executing the async job 
`checkAllCallsEnded`, `checkCallsReviewEndedJob` and `checkCallsFAPReviewEndedJob`
<!--- Describe your changes in detail -->

## Motivation and Context
It was found that ISIS_Direct 2024_2 did not move automatically on the proposal workflow from FAP_REVIEW to Submitted Locked status because it could not find the date to end the FAP review period for some of the calls. These calls were set up for legacy proposals, so were added with minimal data. 
![image](https://github.com/user-attachments/assets/0ba43f33-e2ab-4301-9b06-80c19cf9bc2a)

<!--- Why is this change required? What problem does it solve? -->


## How Has This Been Tested
Manually tested the changes in local.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1102
## Changes

- apps/backend/src/asyncJobs/jobs/checkAllCallsEnded.ts
- apps/backend/src/asyncJobs/jobs/checkCallsFAPReviewEnded.ts
- apps/backend/src/asyncJobs/jobs/checkCallsReviewEnded.ts

<!--- What types of changes does your code introduce? In what place? -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
