### PR TITLE
fix: improve questionary resolver for Samples

### DIFF
--- a/apps/backend/src/resolvers/types/Sample.ts
+++ b/apps/backend/src/resolvers/types/Sample.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from 'graphql';
 import {
   Ctx,
   Field,
@@ -10,7 +11,6 @@ import {
 
 import { ResolverContext } from '../../context';
 import { Sample as SampleOrigin, SampleStatus } from '../../models/Sample';
-import { TemplateCategoryId } from '../../models/Template';
 import { Proposal } from './Proposal';
 import { Questionary } from './Questionary';
 
@@ -54,11 +54,19 @@ export class SampleResolver {
     @Root() sample: Sample,
     @Ctx() context: ResolverContext
   ): Promise<Questionary> {
-    return context.queries.questionary.getQuestionaryOrDefault(
+    const questionary = await context.queries.questionary.getQuestionary(
       context.user,
-      sample.questionaryId,
-      TemplateCategoryId.SAMPLE_DECLARATION
+      sample.questionaryId
     );
+
+    if (!questionary) {
+      // This should never happen because questionary is created when sample is created
+      throw new GraphQLError(
+        `Questionary for sample ${sample.id} was not found`
+      );
+    }
+
+    return questionary;
   }
 
   @FieldResolver(() => Proposal)


### PR DESCRIPTION
## Description
This PR improves the questionary resolver for Samples in the backend.

## Motivation and Context
The previous implementation was using deprecated function call. This upgrade should address the issue reported in SWAP-4581 if it still existed.

## Changes
1. Import `GraphQLError` from 'graphql' to handle errors in a GraphQL-compliant way.
2. Modify the `Questionary` field resolver in `SampleResolver` to not use the deprecated `getQuestionaryOrDefault` method

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4581](https://jira.esss.lu.se/browse/SWAP-4581)

