### PR TITLE
test: address common flaky failing test

### DIFF
--- a/apps/e2e/cypress/e2e/FAPs.cy.ts
+++ b/apps/e2e/cypress/e2e/FAPs.cy.ts
@@ -1726,6 +1726,8 @@ context('Fap reviews tests', () => {
 
       cy.closeModal();
 
+      cy.contains(proposal1.title).closest('tr').contains('Submitted');
+
       cy.get('[data-cy="submit-proposal-reviews"]').click();
       cy.get('[data-cy="confirm-ok"]').click();
 


### PR DESCRIPTION
## Description
This PR addresses a common flaky failing E2E test case in our test suite.
The issue with the test is that it tried clicking too quickly to bulk submit a review before the previous interaction had received the response, thus having the OK button disabled, as UI was trying to prevent human error.

## Motivation and Context
This fix should make pipelines have fewer false positives.

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4619](https://jira.esss.lu.se/browse/SWAP-4619)

