### PR TITLE
fix: ensure final status is always returned regardless of proposal notification

### DIFF
--- a/apps/backend/src/queries/ProposalQueries.spec.ts
+++ b/apps/backend/src/queries/ProposalQueries.spec.ts
@@ -32,12 +32,7 @@ test('A user on the proposal can get a proposal it belongs to', () => {
   ).resolves.toStrictEqual(
     dummyProposal.notified
       ? omit(dummyProposal, 'commentForManagement')
-      : omit(
-          dummyProposal,
-          'commentForManagement',
-          'finalStatus',
-          'commentForUser'
-        )
+      : omit(dummyProposal, 'commentForManagement', 'commentForUser')
   );
 });
 

--- a/apps/backend/src/queries/ProposalQueries.ts
+++ b/apps/backend/src/queries/ProposalQueries.ts
@@ -46,7 +46,7 @@ export default class ProposalQueries {
 
     // If user not notified remove finalStatus and comment as these are not confirmed and it is not user officer
     if (!this.userAuth.isUserOfficer(agent) && !proposal.notified) {
-      proposal = omit(proposal, 'finalStatus', 'commentForUser') as Proposal;
+      proposal = omit(proposal, 'commentForUser') as Proposal;
     }
     if ((await this.hasReadRights(agent, proposal)) === true) {
       return proposal;


### PR DESCRIPTION
ensure final status is always returned regardless of proposal notification

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This change ensures that the final status is always returned, regardless of whether the proposal has been notified. Previously, the return behavior depended on the notification status, which could lead to inconsistencies in response handling.

## Motivation and Context

This fix standardizes the response behavior by always returning the final status. It prevents potential issues where consumers of the API or system logic depend on the final status being available.

## How Has This Been Tested

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
