### PR TITLE
fix: bugfix for mistakenly invoking  rabbitMQ status action when emailAction is selected

### DIFF
--- a/apps/backend/src/config/Tokens.ts
+++ b/apps/backend/src/config/Tokens.ts
@@ -16,6 +16,7 @@ export const Tokens = {
   InviteDataSource: Symbol('InviteDataSource'),
   TechniqueDataSource: Symbol('TechniqueDataSource'),
   ListenToMessageQueue: Symbol('ListenToMessageQueue'),
+  LoggingHandler: Symbol('LoggingHandler'),
   MailService: Symbol('MailService'),
   PdfTemplateDataSource: Symbol('PdfTemplateDataSource'),
   PostToMessageQueue: Symbol('PostToMessageQueue'),

--- a/apps/backend/src/config/dependencyConfigDefault.ts
+++ b/apps/backend/src/config/dependencyConfigDefault.ts
@@ -40,6 +40,7 @@ import PostgresUnitDataSource from '../datasources/postgres/UnitDataSource';
 import PostgresUserDataSource from '../datasources/postgres/UserDataSource';
 import PostgresVisitDataSource from '../datasources/postgres/VisitDataSource';
 import PostgresWorkflowDataSource from '../datasources/postgres/WorkflowDataSource';
+import { createSkipLoggingHandler } from '../eventHandlers/logging';
 import { SkipSendMailService } from '../eventHandlers/MailService/SkipSendMailService';
 import {
   createSkipListeningHandler,
@@ -118,6 +119,7 @@ mapValue(Tokens.PopulateCallRow, callFapPopulateRow);
 mapValue(Tokens.EmailEventHandler, skipEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createSkipPostingHandler());
+mapValue(Tokens.LoggingHandler, createSkipLoggingHandler());
 mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 

--- a/apps/backend/src/config/dependencyConfigE2E.ts
+++ b/apps/backend/src/config/dependencyConfigE2E.ts
@@ -37,7 +37,7 @@ import PostgresUserDataSource from '../datasources/postgres/UserDataSource';
 import PostgresVisitDataSource from '../datasources/postgres/VisitDataSource';
 import PostgresWorkflowDataSource from '../datasources/postgres/WorkflowDataSource';
 import { essEmailHandler } from '../eventHandlers/email/essEmailHandler';
-import { createSkipLoggingHandler } from '../eventHandlers/logging';
+import createLoggingHandler from '../eventHandlers/logging';
 import { SkipSendMailService } from '../eventHandlers/MailService/SkipSendMailService';
 import {
   createSkipListeningHandler,
@@ -111,7 +111,7 @@ mapValue(Tokens.PopulateCallRow, callFapPopulateRow);
 mapValue(Tokens.EmailEventHandler, essEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createSkipPostingHandler());
-mapValue(Tokens.LoggingHandler, createSkipLoggingHandler());
+mapValue(Tokens.LoggingHandler, createLoggingHandler());
 mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 

--- a/apps/backend/src/config/dependencyConfigE2E.ts
+++ b/apps/backend/src/config/dependencyConfigE2E.ts
@@ -37,6 +37,7 @@ import PostgresUserDataSource from '../datasources/postgres/UserDataSource';
 import PostgresVisitDataSource from '../datasources/postgres/VisitDataSource';
 import PostgresWorkflowDataSource from '../datasources/postgres/WorkflowDataSource';
 import { essEmailHandler } from '../eventHandlers/email/essEmailHandler';
+import { createSkipLoggingHandler } from '../eventHandlers/logging';
 import { SkipSendMailService } from '../eventHandlers/MailService/SkipSendMailService';
 import {
   createSkipListeningHandler,
@@ -110,6 +111,7 @@ mapValue(Tokens.PopulateCallRow, callFapPopulateRow);
 mapValue(Tokens.EmailEventHandler, essEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createSkipPostingHandler());
+mapValue(Tokens.LoggingHandler, createSkipLoggingHandler());
 mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 

--- a/apps/backend/src/config/dependencyConfigELI.ts
+++ b/apps/backend/src/config/dependencyConfigELI.ts
@@ -36,6 +36,7 @@ import PostgresUserDataSource from '../datasources/postgres/UserDataSource';
 import PostgresVisitDataSource from '../datasources/postgres/VisitDataSource';
 import PostgresWorkflowDataSource from '../datasources/postgres/WorkflowDataSource';
 import { eliEmailHandler } from '../eventHandlers/email/eliEmailHandler';
+import createLoggingHandler from '../eventHandlers/logging';
 import { SMTPMailService } from '../eventHandlers/MailService/SMTPMailService';
 import {
   createListenToRabbitMQHandler,
@@ -113,6 +114,7 @@ mapValue(Tokens.PopulateCallRow, callFapPopulateRow);
 mapValue(Tokens.EmailEventHandler, eliEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createPostToRabbitMQHandler());
+mapValue(Tokens.LoggingHandler, createLoggingHandler());
 mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createListenToRabbitMQHandler());
 

--- a/apps/backend/src/config/dependencyConfigESS.ts
+++ b/apps/backend/src/config/dependencyConfigESS.ts
@@ -37,6 +37,7 @@ import PostgresUserDataSource from '../datasources/postgres/UserDataSource';
 import PostgresVisitDataSource from '../datasources/postgres/VisitDataSource';
 import PostgresWorkflowDataSource from '../datasources/postgres/WorkflowDataSource';
 import { essEmailHandler } from '../eventHandlers/email/essEmailHandler';
+import createLoggingHandler from '../eventHandlers/logging';
 import { SparkPostMailService } from '../eventHandlers/MailService/SparkPostMailService';
 import {
   createListenToRabbitMQHandler,
@@ -114,6 +115,7 @@ mapValue(Tokens.PopulateCallRow, callFapPopulateRow);
 mapValue(Tokens.EmailEventHandler, essEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createPostToRabbitMQHandler());
+mapValue(Tokens.LoggingHandler, createLoggingHandler());
 mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createListenToRabbitMQHandler());
 

--- a/apps/backend/src/config/dependencyConfigSTFC.ts
+++ b/apps/backend/src/config/dependencyConfigSTFC.ts
@@ -37,6 +37,7 @@ import StfcProposalDataSource from '../datasources/stfc/StfcProposalDataSource';
 import StfcTechniqueDataSource from '../datasources/stfc/StfcTechniqueDataSource';
 import { StfcUserDataSource } from '../datasources/stfc/StfcUserDataSource';
 import { stfcEmailHandler } from '../eventHandlers/email/stfcEmailHandler';
+import createLoggingHandler from '../eventHandlers/logging';
 import { SMTPMailService } from '../eventHandlers/MailService/SMTPMailService';
 import {
   createPostToRabbitMQHandler,
@@ -110,6 +111,7 @@ mapValue(Tokens.PopulateCallRow, callFapStfcPopulateRow);
 mapValue(Tokens.EmailEventHandler, stfcEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createPostToRabbitMQHandler());
+mapValue(Tokens.LoggingHandler, createLoggingHandler());
 mapValue(Tokens.EventBus, createApplicationEventBus());
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 

--- a/apps/backend/src/config/dependencyConfigTest.ts
+++ b/apps/backend/src/config/dependencyConfigTest.ts
@@ -96,7 +96,7 @@ mapClass(Tokens.ProposalAuthorization, ProposalAuthorization);
 mapClass(Tokens.AssetRegistrar, SkipAssetRegistrar);
 
 mapValue(Tokens.PostToMessageQueue, createSkipPostingHandler());
-mapValue(Tokens.PostToMessageQueue, jest.mocked(new EventBus()));
+mapValue(Tokens.LoggingHandler, jest.mocked(new EventBus()));
 mapValue(Tokens.EventBus, jest.mocked(new EventBus()));
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 

--- a/apps/backend/src/config/dependencyConfigTest.ts
+++ b/apps/backend/src/config/dependencyConfigTest.ts
@@ -96,6 +96,7 @@ mapClass(Tokens.ProposalAuthorization, ProposalAuthorization);
 mapClass(Tokens.AssetRegistrar, SkipAssetRegistrar);
 
 mapValue(Tokens.PostToMessageQueue, createSkipPostingHandler());
+mapValue(Tokens.PostToMessageQueue, jest.mocked(new EventBus()));
 mapValue(Tokens.EventBus, jest.mocked(new EventBus()));
 mapValue(Tokens.ListenToMessageQueue, createSkipListeningHandler());
 

--- a/apps/backend/src/eventHandlers/index.ts
+++ b/apps/backend/src/eventHandlers/index.ts
@@ -3,7 +3,6 @@ import { container } from 'tsyringe';
 import { Tokens } from '../config/Tokens';
 import { ApplicationEvent } from '../events/applicationEvents';
 import createCustomHandler from './customHandler';
-import createLoggingHandler from './logging';
 import createProposalWorkflowHandler from './proposalWorkflow';
 
 export default function createEventHandlers() {
@@ -11,13 +10,17 @@ export default function createEventHandlers() {
     (event: ApplicationEvent) => Promise<void>
   >(Tokens.EmailEventHandler);
 
+  const loggingHandler = container.resolve<
+    (event: ApplicationEvent) => Promise<void>
+  >(Tokens.LoggingHandler);
+
   const postToQueueHandler = container.resolve<
     (event: ApplicationEvent) => Promise<void>
   >(Tokens.PostToMessageQueue);
 
   return [
     emailHandler,
-    createLoggingHandler(),
+    loggingHandler,
     postToQueueHandler,
     createProposalWorkflowHandler(),
     createCustomHandler(),

--- a/apps/backend/src/eventHandlers/index.ts
+++ b/apps/backend/src/eventHandlers/index.ts
@@ -4,7 +4,6 @@ import { Tokens } from '../config/Tokens';
 import { ApplicationEvent } from '../events/applicationEvents';
 import createCustomHandler from './customHandler';
 import createLoggingHandler from './logging';
-import { createPostToQueueHandler } from './messageBroker';
 import createProposalWorkflowHandler from './proposalWorkflow';
 
 export default function createEventHandlers() {
@@ -12,10 +11,14 @@ export default function createEventHandlers() {
     (event: ApplicationEvent) => Promise<void>
   >(Tokens.EmailEventHandler);
 
+  const postToQueueHandler = container.resolve<
+    (event: ApplicationEvent) => Promise<void>
+  >(Tokens.PostToMessageQueue);
+
   return [
     emailHandler,
     createLoggingHandler(),
-    createPostToQueueHandler(),
+    postToQueueHandler,
     createProposalWorkflowHandler(),
     createCustomHandler(),
   ];

--- a/apps/backend/src/eventHandlers/logging.ts
+++ b/apps/backend/src/eventHandlers/logging.ts
@@ -12,7 +12,7 @@ import { TechniqueDataSource } from '../datasources/TechniqueDataSource';
 import { ApplicationEvent } from '../events/applicationEvents';
 import { Event } from '../events/event.enum';
 
-export default function createHandler() {
+export default function createLoggingHandler() {
   const eventLogsDataSource = container.resolve<EventLogsDataSource>(
     Tokens.EventLogsDataSource
   );

--- a/apps/backend/src/eventHandlers/logging.ts
+++ b/apps/backend/src/eventHandlers/logging.ts
@@ -363,3 +363,9 @@ export default function createLoggingHandler() {
     }
   };
 }
+
+export const createSkipLoggingHandler = () => {
+  return async function skipLoggingHandler(event: ApplicationEvent) {
+    logger.logInfo('Skip logging event', { type: event.type });
+  };
+};

--- a/apps/backend/src/eventHandlers/messageBroker.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.ts
@@ -84,13 +84,6 @@ const createRabbitMQMessageBroker = async () => {
   }
 };
 
-export function createPostToQueueHandler() {
-  // return the mapped implementation
-  return container.resolve<EventHandler<ApplicationEvent>>(
-    Tokens.PostToMessageQueue
-  );
-}
-
 export function createListenToQueueHandler() {
   // return the mapped implementation
   return container.resolve<EventHandler<ApplicationEvent>>(

--- a/apps/backend/src/statusActionEngine/rabbitMQHandler.ts
+++ b/apps/backend/src/statusActionEngine/rabbitMQHandler.ts
@@ -1,12 +1,24 @@
+import { container } from 'tsyringe';
+
+import { Tokens } from '../config/Tokens';
+import { ApplicationEvent } from '../events/applicationEvents';
 import { ConnectionHasStatusAction } from '../models/StatusAction';
 import { RabbitMQActionConfig } from '../resolvers/types/StatusActionConfig';
 import { WorkflowEngineProposalType } from '../workflowEngine';
-import { publishMessageToTheEventBus } from './statusActionUtils';
+import { constructProposalStatusChangeEvent } from './statusActionUtils';
 
 export const rabbitMQActionHandler = async (
   statusAction: ConnectionHasStatusAction,
   proposals: WorkflowEngineProposalType[]
 ) => {
+  const postToMessageQueue = await container.resolve<
+    Promise<(event: ApplicationEvent) => Promise<void>>
+  >(Tokens.PostToMessageQueue);
+
+  const loggingHandler = container.resolve<
+    (event: ApplicationEvent) => Promise<void>
+  >(Tokens.LoggingHandler);
+
   const config = statusAction.config as RabbitMQActionConfig;
   if (!config.exchanges?.length) {
     return;
@@ -16,8 +28,17 @@ export const rabbitMQActionHandler = async (
     'Proposal event successfully sent to the message broker';
 
   return await Promise.all(
-    config.exchanges.map((exchange) =>
-      publishMessageToTheEventBus(proposals, messageDescription, exchange)
-    )
+    config.exchanges.map(async (exchange) => {
+      for (const proposal of proposals) {
+        const evt = constructProposalStatusChangeEvent(
+          proposal,
+          null,
+          messageDescription,
+          exchange
+        );
+        postToMessageQueue(evt);
+        loggingHandler(evt);
+      }
+    })
   );
 };

--- a/apps/backend/src/statusActionEngine/statusActionUtils.ts
+++ b/apps/backend/src/statusActionEngine/statusActionUtils.ts
@@ -479,13 +479,12 @@ export const getOtherAndFormatOutputForEmailSending = async (
   return Others;
 };
 
-export const publishProposalMessageToTheEventBus = async (
+export const constructProposalStatusChangeEvent = (
   proposal: WorkflowEngineProposalType,
+  loggedInUserId: number | null,
   messageDescription: string,
-  exchange?: string,
-  loggedInUserId?: number
+  exchange?: string
 ) => {
-  const eventBus = resolveApplicationEventBus();
   const event = {
     type: Event.PROPOSAL_STATUS_ACTION_EXECUTED,
     proposal: proposal,
@@ -495,6 +494,23 @@ export const publishProposalMessageToTheEventBus = async (
     description: messageDescription,
     exchange: exchange,
   } as ApplicationEvent;
+
+  return event;
+};
+
+export const publishProposalMessageToTheEventBus = async (
+  proposal: WorkflowEngineProposalType,
+  messageDescription: string,
+  exchange?: string,
+  loggedInUserId?: number
+) => {
+  const eventBus = resolveApplicationEventBus();
+  const event = constructProposalStatusChangeEvent(
+    proposal,
+    loggedInUserId || null,
+    messageDescription,
+    exchange
+  );
 
   return eventBus
     .publish(event)


### PR DESCRIPTION
## Description
This PR refactors the existing email action handler and prevents it from publishing messages to RabbitMQ.

## Motivation and Context
This change is required to address the bug.

## Changes
1. Created a new LoggingHandler and added it to the dependency configuration.
2. Refactored the email action handler to call the new LoggingHandler and the existing EmailEventHandler directly, instead of publishing messages to RabbitMQ.
3. Refactored the event handlers to use the new LoggingHandler and removed the now-unused createPostToQueueHandler function.

Previously, the EmailActionHandler was sending an event tothe  event bus to reach the logging handler and add some logs, but as a side-effect it reached postToQueueHandler which was set to listen to the same event
![image](https://github.com/user-attachments/assets/bf527049-99fb-4db5-8fce-c4d3f3cf12fa)

The logic has been changed so that EmailActionHandler does not post a message into the event bus but sends it directly to emailHandler and loggingHandler. This should preserve the current behavior while making sure the message is not sent to the postToQueue Handler.
![image](https://github.com/user-attachments/assets/6162b6bd-4665-4fba-a259-2a1da71a9873)



## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4612](https://jira.esss.lu.se/browse/SWAP-4612)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated