### PR TITLE
fix: address getFullUserNameWithInstitution returning "null" as return value

### DIFF
--- a/apps/frontend/src/utils/user.ts
+++ b/apps/frontend/src/utils/user.ts
@@ -12,7 +12,7 @@ export const getFullUserNameWithEmail = (
   > | null
 ): string =>
   user
-    ? `${user.preferredname}`
+    ? user.preferredname
       ? `${user.preferredname} ${user.lastname} ${
           user.email ? `(${user.email})` : ''
         }`
@@ -25,7 +25,7 @@ export const getFullUserNameWithInstitution = (
   user?: BasicUserData | null
 ): string =>
   user
-    ? `${user.preferredname}`
+    ? user.preferredname
       ? `${user.preferredname} ${user.lastname}; ${
           user.institution ? `${user.institution}` : ''
         }`


### PR DESCRIPTION

## Description

This PR aims to address the issue where if preferred name is null, the output of getFullUserNameWithInstitution returns "null Lastname (institution)"

## Motivation and Context
The bug stems from how the code is checking whether user.preferredname exists. In the ternary operator, the expression " `${user.preferredname}` " is executed, which converts the value of preferredname to a string even if it is null. Since template string conversion of a null value produces the string "null", which is a non-empty string and thus truthy in JavaScript/TypeScript, the code always takes the branch that uses preferredname even when it's actually null. 

## How Has This Been Tested
Locally
