### PR TITLE
fix: deleted the outdated patch, that led to error

### DIFF
--- a/apps/backend/db_patches/0177_AddInstrumentIdToTechRevInPropsalTableView.sql
+++ b/apps/backend/db_patches/0177_AddInstrumentIdToTechRevInPropsalTableView.sql
@@ -1,7 +1,7 @@
 DO
 $$
 BEGIN
-	IF register_patch('0170_AddInstrumentIdToTechRevInPropsalTableView.sql', 'Tom Cottee Meldrum', 'Add Instrument Id to Techreview Review in proposal table view', '2024-08-16') THEN
+	IF register_patch('0177_AddInstrumentIdToTechRevInPropsalTableView.sql', 'Tom Cottee Meldrum', 'Add Instrument Id to Techreview Review in proposal table view', '2025-04-15') THEN
 	BEGIN	
 			-- drop view to allow recreating it
     	DROP VIEW proposal_table_view;
@@ -13,8 +13,8 @@ BEGIN
 				p.title,
 				p.proposer_id AS principal_investigator,
 				p.status_id AS proposal_status_id,
-				ps.name AS proposal_status_name,
-				ps.description AS proposal_status_description,
+				s.name AS proposal_status_name,
+				s.description AS proposal_status_description,
 				p.proposal_id,
 				p.final_status,
 				p.notified,
@@ -30,7 +30,7 @@ BEGIN
 				c.call_id,
 				c.proposal_workflow_id
 			FROM proposals p
-			LEFT JOIN proposal_statuses ps ON ps.proposal_status_id = p.status_id
+			LEFT JOIN statuses s ON s.status_id = p.status_id
 			LEFT JOIN call c ON c.call_id = p.call_id
 			LEFT JOIN (
 				SELECT


### PR DESCRIPTION
deleted the outdated patch, that led to error, since it is depending on the table that does not exist. replaced the outdated one with newer one with latest run number

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

After merging the PR https://github.com/UserOfficeProject/user-office-core/pull/978, the system started to fail while running db patches. Apparently, this is bcoz of the db patch file, that became outdated due to increased commit activities. As it became outdated, the patch has gone unaware of the table rename(proposal_statuses to statuses) and hence the deployment of systems started failing. As an effort of quick fix, the patch has been renamed to make it latest in the chronological order. As a long fix, we will discuss further on how to tackle this situation. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manually

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
