### PR TITLE
fix: bugfix for searchText use in jsonb_path_exists()

### DIFF
--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -373,12 +373,10 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     return query;
   }
 
-  safeEscapeRegexForJsonPath(input: string): string {
-    if (!input) return '""';
-    // Escape regex special characters
-    const escaped = input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  safeEscapeRegexExpression(expression: string): string {
+    const escaped = expression.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-    return `"${escaped}"`;
+    return escaped;
   }
   async getProposalsFromView(
     filter?: ProposalsFilter,
@@ -440,9 +438,9 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
           searchText !== null &&
           searchText !== undefined
         ) {
-          const regexLiteral = this.safeEscapeRegexForJsonPath(searchText);
+          const regexLiteral = this.safeEscapeRegexExpression(searchText);
           // NOTE: Using jsonpath we check the jsonb (instruments) field if it contains object with name equal to searchText case insensitive
-          const jsonPathPattern = `$[*] ? (@.name.type() == "string" && @.name like_regex ${regexLiteral} flag "i")`;
+          const jsonPathPattern = `$[*] ? (@.name.type() == "string" && @.name like_regex "${regexLiteral}" flag "i")`;
 
           query.andWhere((qb) =>
             qb

--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -373,6 +373,13 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     return query;
   }
 
+  safeEscapeRegexForJsonPath(input: string): string {
+    if (!input) return '""';
+    // Escape regex special characters
+    const escaped = input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    return `"${escaped}"`;
+  }
   async getProposalsFromView(
     filter?: ProposalsFilter,
     first?: number,
@@ -433,20 +440,22 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
           searchText !== null &&
           searchText !== undefined
         ) {
+          const regexLiteral = this.safeEscapeRegexForJsonPath(searchText);
+          // NOTE: Using jsonpath we check the jsonb (instruments) field if it contains object with name equal to searchText case insensitive
+          const jsonPathPattern = `$[*] ? (@.name.type() == "string" && @.name like_regex ${regexLiteral} flag "i")`;
+
           query.andWhere((qb) =>
             qb
-              .orWhereRaw('proposal_id ILIKE ?', `%${searchText}%`)
-              .orWhereRaw('title ILIKE ?', `%${searchText}%`)
-              .orWhereRaw('proposal_status_name ILIKE ?', `%${searchText}%`)
+              .orWhereRaw('proposal_id ILIKE ?', [`%${searchText}%`])
+              .orWhereRaw('title ILIKE ?', [`%${searchText}%`])
+              .orWhereRaw('proposal_status_name ILIKE ?', [`%${searchText}%`])
               .orWhere('users.email', 'ilike', `%${searchText}%`)
               .orWhere('users.firstname', 'ilike', `%${searchText}%`)
               .orWhere('users.lastname', 'ilike', `%${searchText}%`)
               .orWhere('principal_investigator', 'in', principalInvestigator)
-              // NOTE: Using jsonpath we check the jsonb (instruments) field if it contains object with name equal to searchText case insensitive
-              .orWhereRaw(
-                'jsonb_path_exists(instruments, \'$[*].name \\? (@.type() == "string" && @ like_regex :searchText: flag "i")\')',
-                { searchText }
-              )
+              .orWhereRaw('jsonb_path_exists(instruments, ?)', [
+                jsonPathPattern,
+              ])
           );
         }
 


### PR DESCRIPTION
## Description
This PR fixes a bug in the `searchText` use in `jsonb_path_exists()` function.

## Motivation and Context
The current implementation of the search functionality in the `jsonb_path_exists()` function does not properly handle special characters, leading to exceptions when searching the proposals table (see exception below). This PR introduces a change to escape special characters. Due to syntax requirements of Knex I had to also change the way jsonPathPattern is constructed

```json
{
  "exception": {
    "name": "error",
    "message": "select *, count(*) OVER() AS full_count from \"proposal_table_view\" inner join \"users\" on \"users\".\"user_id\" = \"proposal_table_view\".\"principal_investigator\" where (proposal_id ILIKE $1 or title ILIKE $2 or proposal_status_name ILIKE $3 or \"users\".\"email\" ilike $4 or \"users\".\"firstname\" ilike $5 or \"users\".\"lastname\" ilike $6 or 1 = $7 or jsonb_path_exists(instruments, '$[*].name '%test.user%' (@.type() == \"string\" && @ like_regex \"test\".\"user\" flag \"i\")')) limit $8 - syntax error at or near \".\" of jsonpath input",
    "stack": "error: select *, count(*) OVER() AS full_count from \"proposal_table_view\" inner join \"users\" on \"users\".\"user_id\" = \"proposal_table_view\".\"principal_investigator\" where (proposal_id ILIKE $1 or title ILIKE $2 or proposal_status_name ILIKE $3 or \"users\".\"email\" ilike $4 or \"users\".\"firstname\" ilike $5 or \"users\".\"lastname\" ilike $6 or 1 = $7 or jsonb_path_exists(instruments, '$[*].name '%test.user%' (@.type() == \"string\" && @ like_regex \"test\".\"user\" flag \"i\")')) limit $8 - syntax error at or near \".\" of jsonpath input\n    at Parser.parseErrorMessage (/home/node/app/node_modules/pg-protocol/dist/parser.js:283:98)\n    at Parser.handlePacket (/home/node/app/node_modules/pg-protocol/dist/parser.js:122:29)\n    at Parser.parse (/home/node/app/node_modules/pg-protocol/dist/parser.js:35:38)\n    at Socket.<anonymous> (/home/node/app/node_modules/pg-protocol/dist/index.js:11:42)\n    at Socket.emit (node:events:517:28)\n    at addChunk (node:internal/streams/readable:335:12)\n    at readableAddChunk (node:internal/streams/readable:308:9)\n    at Readable.push (node:internal/streams/readable:245:10)\n    at TCP.onStreamRead (node:internal/stream_base_commons:190:23)"
  },
  "filter": {
    "instrumentFilter": {
      "instrumentId": null,
      "showMultiInstrumentProposals": false,
      "showAllProposals": true
    }
  }
}

```
## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4610](https://jira.esss.lu.se/browse/SWAP-4610)

