### PR TITLE
feat: add DB constraint instrumentID not null for technical_review

### DIFF
--- a/apps/backend/db_patches/0177_AddTechnicalReviewInstrumentNotNull.sql
+++ b/apps/backend/db_patches/0177_AddTechnicalReviewInstrumentNotNull.sql
@@ -1,0 +1,13 @@
+DO
+$$
+BEGIN
+  -- Check if there are any rows with NULL instrument_id
+  IF EXISTS (SELECT 1 FROM technical_review WHERE instrument_id IS NULL) THEN
+    RAISE EXCEPTION 'Cannot make instrument_id NOT NULL: There are technical reviews with NULL instrument_id values. Please fix these entries first.';
+  END IF;
+
+  -- Add NOT NULL constraint to instrument_id column
+  ALTER TABLE technical_review ALTER COLUMN instrument_id SET NOT NULL;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/frontend/src/components/review/TechnicalReviewSummary.tsx
+++ b/apps/frontend/src/components/review/TechnicalReviewSummary.tsx
@@ -53,7 +53,7 @@ function TechnicalReviewSummary({ confirm }: TechnicalReviewSummaryProps) {
     state.technicalReview.proposal?.call?.endCall
   );
   const isCallActiveInternal =
-    state.technicalReview?.call?.isActiveInternal ?? true;
+    state.technicalReview.call?.isActiveInternal ?? true;
   const [loadingSubmitMessage, setLoadingSubmitMessage] =
     useState<boolean>(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -181,18 +181,18 @@ function TechnicalReviewSummary({ confirm }: TechnicalReviewSummaryProps) {
                     const { addTechnicalReview } = await api({
                       toastSuccessMessage: 'Updated',
                     }).addTechnicalReview({
-                      proposalPk: state?.technicalReview.proposalPk,
+                      proposalPk: state.technicalReview.proposalPk,
                       timeAllocation: +(
-                        state?.technicalReview.timeAllocation || 0
+                        state.technicalReview.timeAllocation || 0
                       ),
-                      comment: state?.technicalReview.comment,
-                      publicComment: state?.technicalReview.publicComment,
-                      status: state?.technicalReview.status,
-                      submitted: state?.technicalReview.submitted,
+                      comment: state.technicalReview.comment,
+                      publicComment: state.technicalReview.publicComment,
+                      status: state.technicalReview.status,
+                      submitted: state.technicalReview.submitted,
                       reviewerId: user.id,
-                      files: state?.technicalReview.files,
-                      instrumentId: state?.technicalReview.instrumentId,
-                      questionaryId: state?.technicalReview.questionaryId,
+                      files: state.technicalReview.files,
+                      instrumentId: state.technicalReview.instrumentId,
+                      questionaryId: state.technicalReview.questionaryId,
                     });
 
                     dispatch({
@@ -219,18 +219,18 @@ function TechnicalReviewSummary({ confirm }: TechnicalReviewSummaryProps) {
                       setIsSubmitting(true);
                       try {
                         const submittedTechnicalReview = {
-                          proposalPk: state?.technicalReview.proposalPk,
+                          proposalPk: state.technicalReview.proposalPk,
                           timeAllocation: +(
-                            state?.technicalReview.timeAllocation || 0
+                            state.technicalReview.timeAllocation || 0
                           ),
-                          comment: state?.technicalReview.comment,
-                          publicComment: state?.technicalReview.publicComment,
-                          status: state?.technicalReview.status,
+                          comment: state.technicalReview.comment,
+                          publicComment: state.technicalReview.publicComment,
+                          status: state.technicalReview.status,
                           submitted: true,
                           reviewerId: user.id,
-                          files: state?.technicalReview.files,
-                          instrumentId: state?.technicalReview.instrumentId,
-                          questionaryId: state?.technicalReview.questionaryId,
+                          files: state.technicalReview.files,
+                          instrumentId: state.technicalReview.instrumentId,
+                          questionaryId: state.technicalReview.questionaryId,
                         };
 
                         const submittedTechnicalReviewsInput: SubmitTechnicalReviewInput[] =


### PR DESCRIPTION
## Description

It should not be possible to set `instrument_id` to `null` in `technical_review` table. When `technical_review` is crated it does not allow null values, and backend model `TechnicalReview` expects this value to not be `null`. If it is `null` the graphql exception will be thrown.

This PR makes sure that inconsistent data can not be stored in the database. 

Note: while investigating I found out that there is unnecessary optional chaining in the frontend `apps/frontend/src/components/review/TechnicalReviewSummary.tsx` and given the small scope of this PR i took a liberty to address it with this PR.

## Motivation and Context

Improve data integrity

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4582](https://jira.esss.lu.se/browse/SWAP-4582)

