### PR TITLE
refactor: merge fap reviews and fap assignment table

### DIFF
--- a/apps/backend/db_patches/0178_MergeFapReviewsFapAssignments.sql
+++ b/apps/backend/db_patches/0178_MergeFapReviewsFapAssignments.sql
@@ -1,0 +1,32 @@
+DO
+$$
+BEGIN
+  IF register_patch('0178_MergeFapReviewsFapAssignments.sql', 'TCMeldrum', 'Merge Fap Reviews and Fap Assignments table', '2025-04-22') THEN
+    BEGIN
+
+      AlTER TABLE fap_reviews
+      ADD COLUMN date_assigned TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      ADD COLUMN reassigned boolean DEFAULT false,
+      ADD COLUMN date_reassigned TIMESTAMPTZ DEFAULT null,
+      ADD COLUMN email_sent boolean DEFAULT false,
+      ADD COLUMN rank INTEGER;
+
+
+      UPDATE fap_reviews as fr
+      SET
+        date_assigned = fa.date_assigned,
+        reassigned = fa.reassigned,
+        date_reassigned = fa.date_reassigned,
+        email_sent = fa.email_sent,
+        rank = fa.rank
+      FROM fap_assignments fa
+      WHERE fa.fap_proposal_id = fr.fap_proposal_id
+        AND fa.fap_member_user_id = fr.user_id;
+
+      DROP TABLE fap_assignments;
+
+    END;
+  END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/backend/src/datasources/FapDataSource.ts
+++ b/apps/backend/src/datasources/FapDataSource.ts
@@ -153,7 +153,7 @@ export interface FapDataSource {
     instrumentId?: number | null
   ): Promise<boolean>;
   setReviewerRank(
-    proposalPk: number,
+    fapReviewId: number,
     reviewerId: number,
     rank: number
   ): Promise<boolean>;

--- a/apps/backend/src/datasources/mockups/FapDataSource.ts
+++ b/apps/backend/src/datasources/mockups/FapDataSource.ts
@@ -99,7 +99,12 @@ export const dummyFapReview = new Review(
   7,
   0,
   1,
-  1
+  1,
+  new Date('2020-04-20 08:25:12.23043+00'),
+  false,
+  null,
+  false,
+  null
 );
 
 export const dummyFapProposal = new FapProposal(
@@ -544,7 +549,7 @@ export class FapDataSourceMock implements FapDataSource {
   }
 
   async setReviewerRank(
-    proposalPk: number,
+    fapReviewId: number,
     reviewer_id: number,
     rank: number
   ): Promise<boolean> {

--- a/apps/backend/src/datasources/mockups/ReviewDataSource.ts
+++ b/apps/backend/src/datasources/mockups/ReviewDataSource.ts
@@ -11,7 +11,21 @@ import { TechnicalReviewsFilter } from '../../resolvers/queries/TechnicalReviews
 import { ReviewDataSource } from '../ReviewDataSource';
 import { dummyProposalTechnicalReview } from './ProposalDataSource';
 
-export const dummyReview = new Review(4, 10, 1, 'Good proposal', 9, 0, 1, 1);
+export const dummyReview = new Review(
+  4,
+  10,
+  1,
+  'Good proposal',
+  9,
+  0,
+  1,
+  1,
+  new Date('2020-04-20 08:25:12.23043+00'),
+  false,
+  null,
+  false,
+  null
+);
 export const dummySubmittedReview = new Review(
   5,
   10,
@@ -20,7 +34,12 @@ export const dummySubmittedReview = new Review(
   9,
   1,
   1,
-  1
+  1,
+  new Date('2020-04-20 08:25:12.23043+00'),
+  false,
+  null,
+  false,
+  null
 );
 
 export const dummyTechnicalReview = new TechnicalReview(
@@ -38,7 +57,21 @@ export const dummyTechnicalReview = new TechnicalReview(
   1
 );
 
-export const dummyReviewBad = new Review(1, 9, 1, 'bad proposal', 1, 0, 1, 1);
+export const dummyReviewBad = new Review(
+  1,
+  9,
+  1,
+  'bad proposal',
+  1,
+  0,
+  1,
+  1,
+  new Date('2020-04-20 08:25:12.23043+00'),
+  false,
+  null,
+  false,
+  null
+);
 
 export class ReviewDataSourceMock implements ReviewDataSource {
   async getProposalInstrumentTechnicalReview(
@@ -78,10 +111,38 @@ export class ReviewDataSourceMock implements ReviewDataSource {
   async addUserForReview(args: AddUserForReviewArgs): Promise<Review> {
     const { proposalPk, userID } = args;
 
-    return new Review(1, proposalPk, userID, ' ', 1, 1, 1, 1);
+    return new Review(
+      1,
+      proposalPk,
+      userID,
+      ' ',
+      1,
+      1,
+      1,
+      1,
+      new Date('2020-04-20 08:25:12.23043+00'),
+      false,
+      null,
+      false,
+      null
+    );
   }
   async removeUserForReview(id: number): Promise<Review> {
-    return new Review(1, 1, 1, ' ', 1, 1, 1, 1);
+    return new Review(
+      1,
+      1,
+      1,
+      ' ',
+      1,
+      1,
+      1,
+      1,
+      new Date('2020-04-20 08:25:12.23043+00'),
+      false,
+      null,
+      false,
+      null
+    );
   }
   async getReview(id: number): Promise<Review | null> {
     if (id === 1) {

--- a/apps/backend/src/datasources/postgres/ReviewDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ReviewDataSource.ts
@@ -210,7 +210,7 @@ export default class PostgresReviewDataSource implements ReviewDataSource {
       .then((review: ReviewRecord) => createReviewObject(review));
   }
 
-  getReviews(
+  async getReviews(
     filter?: ReviewsFilter,
     first?: number,
     offset?: number
@@ -279,7 +279,7 @@ export default class PostgresReviewDataSource implements ReviewDataSource {
   }
 
   async updateReview(args: UpdateReviewArgs): Promise<Review> {
-    const { reviewID, comment, grade, status, fapID, questionaryID } = args;
+    const { reviewID, comment, grade, status } = args;
 
     return database
       .update(
@@ -293,16 +293,7 @@ export default class PostgresReviewDataSource implements ReviewDataSource {
       .from('fap_reviews')
       .where('review_id', reviewID)
       .then((review: ReviewRecord[]) => {
-        return new Review(
-          reviewID,
-          review[0].proposal_pk,
-          review[0].user_id,
-          comment,
-          grade,
-          status,
-          fapID,
-          questionaryID
-        );
+        return createReviewObject(review[0]);
       });
   }
 
@@ -313,10 +304,6 @@ export default class PostgresReviewDataSource implements ReviewDataSource {
     const subQuery = database
       .select('*')
       .from('fap_reviews as fr')
-      .join('fap_assignments', {
-        'fap_assignments.proposal_pk': 'fr.proposal_pk',
-        'fap_assignments.fap_member_user_id': 'fr.user_id',
-      })
       .distinctOn('fr.review_id')
       .where('fr.proposal_pk', proposalPk)
       .modify((query) => {

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -274,6 +274,11 @@ export interface ReviewRecord {
   readonly fap_id: number;
   readonly questionary_id: number;
   readonly full_count: number;
+  readonly date_assigned: Date;
+  readonly reassigned: boolean;
+  readonly date_reassigned: Date;
+  readonly email_sent: boolean;
+  readonly rank: number | null;
 }
 
 export interface TechnicalReviewRecord {
@@ -803,7 +808,12 @@ export const createReviewObject = (review: ReviewRecord) => {
     review.grade,
     review.status,
     review.fap_id,
-    review.questionary_id
+    review.questionary_id,
+    review.date_assigned,
+    review.reassigned,
+    review.date_reassigned,
+    review.email_sent,
+    review.rank
   );
 };
 
@@ -1147,12 +1157,10 @@ export const createFapProposalObject = (fapProposal: FapProposalRecord) => {
     fapProposal.fap_meeting_instrument_submitted
   );
 };
-export const createFapAssignmentObject = (
-  fapAssignment: FapAssignmentRecord
-) => {
+export const createFapAssignmentObject = (fapAssignment: ReviewRecord) => {
   return new FapAssignment(
     fapAssignment.proposal_pk,
-    fapAssignment.fap_member_user_id,
+    fapAssignment.user_id,
     fapAssignment.fap_id,
     fapAssignment.date_assigned,
     fapAssignment.reassigned,

--- a/apps/backend/src/models/Review.ts
+++ b/apps/backend/src/models/Review.ts
@@ -7,7 +7,12 @@ export class Review {
     public grade: number,
     public status: number,
     public fapID: number,
-    public questionaryID: number
+    public questionaryID: number,
+    public dateAssigned: Date,
+    public reassigned: boolean,
+    public dateReassigned: Date | null,
+    public emailSent: boolean,
+    public rank: number | null
   ) {}
 }
 

--- a/apps/backend/src/resolvers/mutations/SaveReviewerRankMutation.ts
+++ b/apps/backend/src/resolvers/mutations/SaveReviewerRankMutation.ts
@@ -13,7 +13,7 @@ import { ResolverContext } from '../../context';
 @ArgsType()
 export class SaveReviewerRankArg {
   @Field(() => Int)
-  public proposalPk: number;
+  public fapReviewId: number;
 
   @Field(() => Int)
   public reviewerId: number;

--- a/apps/backend/src/resolvers/types/Review.ts
+++ b/apps/backend/src/resolvers/types/Review.ts
@@ -40,6 +40,21 @@ export class Review implements Partial<ReviewOrigin> {
 
   @Field(() => Int)
   public questionaryID: number;
+
+  @Field(() => Date)
+  public dateAssigned: Date;
+
+  @Field(() => Boolean)
+  public reassigned: boolean;
+
+  @Field(() => Date, { nullable: true })
+  public dateReassigned: Date | null;
+
+  @Field(() => Boolean)
+  public emailSent: boolean;
+
+  @Field(() => Int, { nullable: true })
+  public rank: number | null;
 }
 
 @Resolver(() => Review)

--- a/apps/frontend/src/components/fap/Proposals/FapAssignedReviewersTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapAssignedReviewersTable.tsx
@@ -78,7 +78,7 @@ const FapAssignedReviewersTable = ({
   ]);
   const [rankReviewer, setRankReviewer] = useState<null | {
     reviewer: number | null;
-    proposal: number;
+    fapReviewId: number;
     rank: number | null;
   }>(null);
   const { toFormattedDateTime } = useFormattedDateTime({
@@ -184,7 +184,7 @@ const FapAssignedReviewersTable = ({
           onClose={() => setRankReviewer(null)}
           onSubmit={async (value) => {
             await api().saveReviewerRank({
-              proposalPk: rankReviewer?.proposal as number,
+              fapReviewId: rankReviewer?.fapReviewId as number,
               reviewerId: rankReviewer?.reviewer as number,
               rank: value,
             });
@@ -192,7 +192,7 @@ const FapAssignedReviewersTable = ({
               fapAssignmentsWithIdAndFormattedDate.map((fa) => ({
                 ...fa,
                 rank:
-                  fa.proposalPk === rankReviewer?.proposal &&
+                  fa.review?.id === rankReviewer?.fapReviewId &&
                   fa.fapMemberUserId === rankReviewer.reviewer
                     ? value
                     : fa.rank,
@@ -201,7 +201,7 @@ const FapAssignedReviewersTable = ({
             setFapAssignmentsWithIdAndFormattedDate(
               fapAssignmentsWithUpdatedRank
             );
-            updateView(rankReviewer?.proposal as number);
+            updateView(rankReviewer?.fapReviewId as number);
           }}
           currentRank={rankReviewer?.rank}
           totalReviewers={fapProposal.assignments?.length ?? 0}
@@ -264,7 +264,7 @@ const FapAssignedReviewersTable = ({
             icon: () => <FormatListNumberedIcon data-cy="rank-reviewer" />,
             onClick: () => {
               setRankReviewer({
-                proposal: rowData.proposalPk,
+                fapReviewId: rowData.review?.id as number,
                 reviewer: rowData.fapMemberUserId,
                 rank: rowData.rank,
               });

--- a/apps/frontend/src/components/fap/Proposals/FapAssignedReviewersTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapAssignedReviewersTable.tsx
@@ -201,7 +201,7 @@ const FapAssignedReviewersTable = ({
             setFapAssignmentsWithIdAndFormattedDate(
               fapAssignmentsWithUpdatedRank
             );
-            updateView(rankReviewer.fapReviewId);
+            updateView(fapProposal.proposalPk);
           }}
           currentRank={rankReviewer.rank}
           totalReviewers={fapProposal.assignments?.length ?? 0}

--- a/apps/frontend/src/components/fap/Proposals/FapAssignedReviewersTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapAssignedReviewersTable.tsx
@@ -184,15 +184,15 @@ const FapAssignedReviewersTable = ({
           onClose={() => setRankReviewer(null)}
           onSubmit={async (value) => {
             await api().saveReviewerRank({
-              fapReviewId: rankReviewer?.fapReviewId as number,
-              reviewerId: rankReviewer?.reviewer as number,
+              fapReviewId: rankReviewer.fapReviewId,
+              reviewerId: rankReviewer.reviewer as number, //Should be a number as it set from row data from the Assigned reviewers table
               rank: value,
             });
             const fapAssignmentsWithUpdatedRank =
               fapAssignmentsWithIdAndFormattedDate.map((fa) => ({
                 ...fa,
                 rank:
-                  fa.review?.id === rankReviewer?.fapReviewId &&
+                  fa.review?.id === rankReviewer.fapReviewId &&
                   fa.fapMemberUserId === rankReviewer.reviewer
                     ? value
                     : fa.rank,
@@ -201,9 +201,9 @@ const FapAssignedReviewersTable = ({
             setFapAssignmentsWithIdAndFormattedDate(
               fapAssignmentsWithUpdatedRank
             );
-            updateView(rankReviewer?.fapReviewId as number);
+            updateView(rankReviewer.fapReviewId);
           }}
-          currentRank={rankReviewer?.rank}
+          currentRank={rankReviewer.rank}
           totalReviewers={fapProposal.assignments?.length ?? 0}
           takenRanks={
             fapProposal.assignments
@@ -243,7 +243,7 @@ const FapAssignedReviewersTable = ({
                   );
                 searchParams.set(
                   'modalTab',
-                  isDraftStatus(rowData?.review?.status)
+                  isDraftStatus(rowData.review?.status)
                     ? reviewProposalTabNames
                         .indexOf(PROPOSAL_MODAL_TAB_NAMES.GRADE)
                         .toString()
@@ -256,7 +256,7 @@ const FapAssignedReviewersTable = ({
               });
               setOpenProposalPk(fapProposal.proposalPk);
             },
-            tooltip: isDraftStatus(rowData?.review?.status)
+            tooltip: isDraftStatus(rowData.review?.status)
               ? 'Grade proposal'
               : 'View review',
           }),

--- a/apps/frontend/src/graphql/fap/setReviewerRank.graphql
+++ b/apps/frontend/src/graphql/fap/setReviewerRank.graphql
@@ -1,6 +1,6 @@
-mutation saveReviewerRank($proposalPk: Int!, $reviewerId: Int!, $rank: Int!) {
+mutation saveReviewerRank($fapReviewId: Int!, $reviewerId: Int!, $rank: Int!) {
   saveReviewerRank(
-    proposalPk: $proposalPk
+    fapReviewId: $fapReviewId
     reviewerId: $reviewerId
     rank: $rank
   )


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1231

## Description
This PR merges the Fap Reviews and Fap Assignments tables into one, they served the same purpose and needed to be updated simultausly. 

## Motivation and Context
The Fap Reviews and Fap Assignments tables had similar structures and were being used for similar purposes, leading to redundancy. Merging these tables eliminates this redundancy, simplifies the database structure and makes it easier to manage and manipulate data. 

## Changes
1. Created a new SQL script to merge the Fap Reviews and Fap Assignments tables, copying data from the Fap Assignments table to the Fap Reviews table and then dropping the Fap Assignments table.
2. Updated the FapDataSource.ts file to reflect the changes in the database structure. The methods that previously interacted with the Fap Assignments table now interact with the Fap Reviews table.
3. Updated mock data in the FapDataSource.ts and ReviewDataSource.ts files to reflect the changes in the database structure.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated