### PR TITLE
fix: disable DataLoader internal caching

### DIFF
--- a/apps/backend/src/loaders/BasicUserDetailsLoader.ts
+++ b/apps/backend/src/loaders/BasicUserDetailsLoader.ts
@@ -10,17 +10,20 @@ export default class BasicUserDetailsLoader {
   constructor(
     @inject(Tokens.UserDataSource) private userDataSource: UserDataSource
   ) {}
-  batchLoader = new DataLoader(async (keys: readonly number[]) => {
-    logger.logInfo(
-      `Inside batch loading function fetching the basic user details for user id(s)  ${keys}`,
-      {}
-    );
+  batchLoader = new DataLoader(
+    async (keys: readonly number[]) => {
+      logger.logInfo(
+        `Inside batch loading function fetching the basic user details for user id(s)  ${keys}`,
+        {}
+      );
 
-    const usersList = await this.userDataSource.getBasicUsersInfo(keys);
-    const result = keys.map((id) => {
-      return usersList?.find((user) => user.id === id);
-    });
+      const usersList = await this.userDataSource.getBasicUsersInfo(keys);
+      const result = keys.map((id) => {
+        return usersList?.find((user) => user.id === id);
+      });
 
-    return result;
-  });
+      return result;
+    },
+    { cache: false }
+  );
 }

--- a/apps/backend/src/loaders/UsersLoader.ts
+++ b/apps/backend/src/loaders/UsersLoader.ts
@@ -10,17 +10,20 @@ export default class UsersLoader {
   constructor(
     @inject(Tokens.UserDataSource) private userDataSource: UserDataSource
   ) {}
-  batchLoader = new DataLoader(async (keys: readonly number[]) => {
-    logger.logInfo(
-      `Inside batch loading function fetching the user details for user id(s)  ${keys}`,
-      {}
-    );
+  batchLoader = new DataLoader(
+    async (keys: readonly number[]) => {
+      logger.logInfo(
+        `Inside batch loading function fetching the user details for user id(s)  ${keys}`,
+        {}
+      );
 
-    const usersList = await this.userDataSource.getUsersByUserNumbers(keys);
-    const result = keys.map((id) => {
-      return usersList?.find((user) => user.id === id);
-    });
+      const usersList = await this.userDataSource.getUsersByUserNumbers(keys);
+      const result = keys.map((id) => {
+        return usersList?.find((user) => user.id === id);
+      });
 
-    return result;
-  });
+      return result;
+    },
+    { cache: false }
+  );
 }


### PR DESCRIPTION
Hotfix release:
The user details were also being cached internally by a dependency DataLoader, apart from our normal caches. And these record seems to be staying there for the entire time the particular pod/app is up. This PR is to disable this internal caching for now, as this will not be reflecting any user details changes (first name, lastname etc) until a pod/app is restarted.