### PR TITLE
fix: test disabling internal caching in Dataloader

### DIFF
--- a/apps/backend/src/loaders/BasicUserDetailsLoader.ts
+++ b/apps/backend/src/loaders/BasicUserDetailsLoader.ts
@@ -10,17 +10,20 @@ export default class BasicUserDetailsLoader {
   constructor(
     @inject(Tokens.UserDataSource) private userDataSource: UserDataSource
   ) {}
-  batchLoader = new DataLoader(async (keys: readonly number[]) => {
-    logger.logInfo(
-      `Inside batch loading function fetching the basic user details for user id(s)  ${keys}`,
-      {}
-    );
+  batchLoader = new DataLoader(
+    async (keys: readonly number[]) => {
+      logger.logInfo(
+        `Inside batch loading function fetching the basic user details for user id(s)  ${keys}`,
+        {}
+      );
 
-    const usersList = await this.userDataSource.getBasicUsersInfo(keys);
-    const result = keys.map((id) => {
-      return usersList?.find((user) => user.id === id);
-    });
+      const usersList = await this.userDataSource.getBasicUsersInfo(keys);
+      const result = keys.map((id) => {
+        return usersList?.find((user) => user.id === id);
+      });
 
-    return result;
-  });
+      return result;
+    },
+    { cache: false }
+  );
 }

--- a/apps/backend/src/loaders/UsersLoader.ts
+++ b/apps/backend/src/loaders/UsersLoader.ts
@@ -10,17 +10,20 @@ export default class UsersLoader {
   constructor(
     @inject(Tokens.UserDataSource) private userDataSource: UserDataSource
   ) {}
-  batchLoader = new DataLoader(async (keys: readonly number[]) => {
-    logger.logInfo(
-      `Inside batch loading function fetching the user details for user id(s)  ${keys}`,
-      {}
-    );
+  batchLoader = new DataLoader(
+    async (keys: readonly number[]) => {
+      logger.logInfo(
+        `Inside batch loading function fetching the user details for user id(s)  ${keys}`,
+        {}
+      );
 
-    const usersList = await this.userDataSource.getUsersByUserNumbers(keys);
-    const result = keys.map((id) => {
-      return usersList?.find((user) => user.id === id);
-    });
+      const usersList = await this.userDataSource.getUsersByUserNumbers(keys);
+      const result = keys.map((id) => {
+        return usersList?.find((user) => user.id === id);
+      });
 
-    return result;
-  });
+      return result;
+    },
+    { cache: false }
+  );
 }


### PR DESCRIPTION
## Description
This PR disables internal caching in Dataloader for fetching user details. 

## Motivation and Context
The change is required to address potential issues with data integrity and consistency when fetching user details. Disabling the cache ensures that the most updated user details are retrieved from the database instead of serving potentially outdated data from cache.

## Changes
1. Disabled caching in the `batchLoader` function within `BasicUserDetailsLoader.ts` file.
2. Applied the same change in `UsersLoader.ts`, disabling caching when user details are fetched.

These changes ensure that every time we fetch user details, we are hitting the database directly, ensuring the data's freshness and consistency.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated