### PR TITLE
feat: add 'cancelled' state to action buttons and update related tests

### DIFF
--- a/apps/e2e/cypress/e2e/visits.cy.ts
+++ b/apps/e2e/cypress/e2e/visits.cy.ts
@@ -152,7 +152,7 @@ context('visits tests', () => {
       cy.contains(/Upcoming experiments/i).should('exist');
 
       cy.testActionButton(cyTagDefineVisit, 'active');
-      cy.testActionButton(cyTagRegisterVisit, 'inactive');
+      cy.testActionButton(cyTagRegisterVisit, 'cancelled');
       cy.testActionButton(cyTagDeclareShipment, 'neutral');
     });
 
@@ -175,7 +175,7 @@ context('visits tests', () => {
 
       // test that that actions has correct state
       cy.testActionButton(cyTagDefineVisit, 'active');
-      cy.testActionButton(cyTagRegisterVisit, 'inactive');
+      cy.testActionButton(cyTagRegisterVisit, 'cancelled');
       cy.testActionButton(cyTagDeclareShipment, 'neutral');
 
       // create visit

--- a/apps/e2e/cypress/support/utils.ts
+++ b/apps/e2e/cypress/support/utils.ts
@@ -231,7 +231,13 @@ const getButtonByIconCyTag = (cyTag: string) =>
 
 const testActionButton = (
   iconCyTag: string,
-  state: 'completed' | 'active' | 'inactive' | 'neutral' | 'invisible'
+  state:
+    | 'completed'
+    | 'active'
+    | 'inactive'
+    | 'neutral'
+    | 'invisible'
+    | 'cancelled'
 ) => {
   switch (state) {
     case 'completed':

--- a/apps/e2e/cypress/types/utils.d.ts
+++ b/apps/e2e/cypress/types/utils.d.ts
@@ -117,7 +117,13 @@ declare global {
           | 'declare-shipment-icon'
           | 'finish-experiment-safety-form-icon'
           | 'provide-feedback-icon',
-        state: 'completed' | 'active' | 'inactive' | 'neutral' | 'invisible'
+        state:
+          | 'completed'
+          | 'active'
+          | 'inactive'
+          | 'neutral'
+          | 'invisible'
+          | 'cancelled'
       ) => void;
 
       /**

--- a/apps/frontend/src/components/proposalBooking/ActionButton.tsx
+++ b/apps/frontend/src/components/proposalBooking/ActionButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import CancelBadge from './CancelBadge';
 import CheckBadge from './CheckBadge';
 import DotBadge from './DotBadge';
 
@@ -9,7 +10,8 @@ export type ActionButtonState =
   | 'inactive'
   | 'neutral'
   | 'pending'
-  | 'invisible';
+  | 'invisible'
+  | 'cancelled';
 
 interface ActionButtonProps {
   children: React.ReactNode;
@@ -53,7 +55,7 @@ const ActionButton = ({ children, variant: state }: ActionButtonProps) => {
       return (
         <DotBadge
           sx={{
-            color: '#BBB',
+            color: '#bbb',
           }}
         >
           {children}
@@ -88,6 +90,23 @@ const ActionButton = ({ children, variant: state }: ActionButtonProps) => {
       );
     case 'invisible':
       return <DotBadge />;
+    case 'cancelled':
+      return (
+        <CancelBadge
+          sx={{
+            color: '#bbb',
+            marginRight: '2px',
+            marginTop: '2px',
+            '& .MuiBadge-badge': {
+              fontSize: '17px',
+              color: '#bbb',
+              textShadow: '-1px 2px 0 white',
+            },
+          }}
+        >
+          {children}
+        </CancelBadge>
+      );
   }
 };
 

--- a/apps/frontend/src/components/proposalBooking/CancelBadge.tsx
+++ b/apps/frontend/src/components/proposalBooking/CancelBadge.tsx
@@ -1,0 +1,12 @@
+import { BadgeProps, Badge } from '@mui/material';
+import React from 'react';
+
+const CancelBadge = ({ children, ...rest }: BadgeProps) => {
+  return (
+    <Badge badgeContent="✖" overlap="circular" {...rest}>
+      {children}
+    </Badge>
+  );
+};
+
+export default CancelBadge;

--- a/apps/frontend/src/hooks/proposalBooking/useActionButtons.tsx
+++ b/apps/frontend/src/hooks/proposalBooking/useActionButtons.tsx
@@ -59,7 +59,6 @@ const createActionButton = (
   // eslint-disable-next-line
   icon: () => <ActionButton variant={state}>{icon}</ActionButton>,
   hidden: state === 'invisible',
-  disabled: state === 'inactive',
   onClick: ['completed', 'active', 'neutral', 'pending'].includes(state)
     ? onClick
     : () => {},
@@ -175,9 +174,9 @@ export function useActionButtons(args: UseActionButtonsArgs) {
             break;
           case VisitRegistrationStatus.CANCELLED_BY_USER:
           case VisitRegistrationStatus.CANCELLED_BY_FACILITY:
-            buttonState = 'inactive';
+            buttonState = 'cancelled';
             stateReason =
-              'This action is disabled because registration is cancelled';
+              'This action is disabled because your registration for visit is cancelled';
             break;
         }
       }
@@ -187,7 +186,7 @@ export function useActionButtons(args: UseActionButtonsArgs) {
     }
 
     return createActionButton(
-      `Define your own visit ${stateReason ? '(' + stateReason + ')' : ''}`,
+      `Define your visit ${stateReason ? '(' + stateReason + ')' : ''}`,
       <FlightTakeoffIcon data-cy="register-visit-icon" />,
       buttonState,
       () => {


### PR DESCRIPTION
## Description
This PR introduces the 'cancelled' state to the action buttons and uses it for the visit registration.

## Motivation and Context
The change is required to provide a visual representation of a 'cancelled' state in the visit registration, as it wasn't very clear why is the icon disabled.

Additionally the hovering the icon now shows the tool tip, which was not visible before.

![image](https://github.com/user-attachments/assets/6f07c616-8e6a-41fd-af4e-1dcda3c79aaa)
![image](https://github.com/user-attachments/assets/0d11d138-9457-4173-8e79-a115e7169908)


## How Has This Been Tested?

Manually and updated e2e tests.

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4649](https://jira.esss.lu.se/browse/SWAP-4649)

