### PR TITLE
feat: implement Request Change functionality for visits

### DIFF
--- a/apps/backend/src/auth/questionary/VisitQuestionaryAuthorizer.ts
+++ b/apps/backend/src/auth/questionary/VisitQuestionaryAuthorizer.ts
@@ -66,7 +66,10 @@ export class VisitQuestionaryAuthorizer implements QuestionaryAuthorizer {
       return false;
     }
 
-    if (registration.status !== VisitRegistrationStatus.DRAFTED) {
+    if (
+      registration.status !== VisitRegistrationStatus.DRAFTED &&
+      registration.status !== VisitRegistrationStatus.CHANGE_REQUESTED
+    ) {
       logger.logError('User tried to update visit that is not draft', {
         agent,
         questionaryId,

--- a/apps/backend/src/auth/questionary/VisitQuestionaryAuthorizer.ts
+++ b/apps/backend/src/auth/questionary/VisitQuestionaryAuthorizer.ts
@@ -70,11 +70,14 @@ export class VisitQuestionaryAuthorizer implements QuestionaryAuthorizer {
       registration.status !== VisitRegistrationStatus.DRAFTED &&
       registration.status !== VisitRegistrationStatus.CHANGE_REQUESTED
     ) {
-      logger.logError('User tried to update visit that is not draft', {
-        agent,
-        questionaryId,
-        registration,
-      });
+      logger.logError(
+        `Can not update visit that is in ${registration.status} status`,
+        {
+          agent,
+          questionaryId,
+          registration,
+        }
+      );
 
       return false;
     }

--- a/apps/backend/src/mutations/VisitMutations.spec.ts
+++ b/apps/backend/src/mutations/VisitMutations.spec.ts
@@ -3,6 +3,7 @@ import { container } from 'tsyringe';
 
 import { Tokens } from '../config/Tokens';
 import {
+  dummyUserNotOnProposalWithRole,
   dummyUserOfficerWithRole,
   dummyUserWithRole,
 } from '../datasources/mockups/UserDataSource';
@@ -52,6 +53,16 @@ test('User can not create visit for someone elses proposal', async () => {
       team: [dummyUserWithRole.id],
     })
   ).resolves.toBeInstanceOf(Rejection);
+});
+
+test('User can not delete visit for someone elses proposal', async () => {
+  const result = await mutations.deleteVisit(dummyUserNotOnProposalWithRole, 1);
+
+  expect(result).toBeInstanceOf(Rejection);
+  expect(result).toHaveProperty(
+    'message',
+    'Can not update visit because of insufficient permissions'
+  );
 });
 
 test('User can update visit', async () => {
@@ -146,6 +157,47 @@ test('Not authorized user can not create visit registration', async () => {
   ).resolves.toBeInstanceOf(Rejection);
 });
 
+test('User can not set visit start date in past', async () => {
+  const registration = (await mutations.createVisitRegistration(
+    dummyUserWithRole,
+    1,
+    2
+  )) as VisitRegistration;
+
+  const result = await mutations.updateVisitRegistration(dummyUserWithRole, {
+    visitId: registration.visitId,
+    userId: registration.userId,
+    startsAt: new Date(Date.now() - 1000 * 60 * 60 * 24), // Set start date in the past
+  });
+
+  expect(result).toBeInstanceOf(Rejection);
+  expect(result).toHaveProperty(
+    'message',
+    'Could not update Visit Registration because the start date is in the past'
+  );
+});
+
+test('User can not set visit end date earlier than start date', async () => {
+  const registration = (await mutations.createVisitRegistration(
+    dummyUserWithRole,
+    1,
+    2
+  )) as VisitRegistration;
+
+  const result = await mutations.updateVisitRegistration(dummyUserWithRole, {
+    visitId: registration.visitId,
+    userId: registration.userId,
+    startsAt: new Date(Date.now() + 1000 * 60 * 60 * 24), // Set start date in the future
+    endsAt: new Date(Date.now() - 1000 * 60 * 60 * 24), // Set end date in the past
+  });
+
+  expect(result).toBeInstanceOf(Rejection);
+  expect(result).toHaveProperty(
+    'message',
+    'Could not update Visit Registration because the end date is before the start date'
+  );
+});
+
 describe('User officer can cancel the visit registration', () => {
   test.each([
     VisitRegistrationStatus.DRAFTED,
@@ -217,6 +269,51 @@ describe('User can cancel their visit registration', () => {
         visitId: registration.visitId,
         userId: registration.userId,
       });
+
+      await expect(
+        visitDataSource.getRegistration(
+          registration.userId,
+          registration.visitId
+        )
+      ).resolves.toHaveProperty('status', expectedStatus);
+    }
+  );
+});
+
+describe('User officer can request chanhes', () => {
+  test.each`
+    initialStatus                                    | expectedStatus
+    ${VisitRegistrationStatus.DRAFTED}               | ${VisitRegistrationStatus.DRAFTED}
+    ${VisitRegistrationStatus.SUBMITTED}             | ${VisitRegistrationStatus.CHANGE_REQUESTED}
+    ${VisitRegistrationStatus.APPROVED}              | ${VisitRegistrationStatus.APPROVED}
+    ${VisitRegistrationStatus.CHANGE_REQUESTED}      | ${VisitRegistrationStatus.CHANGE_REQUESTED}
+    ${VisitRegistrationStatus.CANCELLED_BY_USER}     | ${VisitRegistrationStatus.CANCELLED_BY_USER}
+    ${VisitRegistrationStatus.CANCELLED_BY_FACILITY} | ${VisitRegistrationStatus.CANCELLED_BY_FACILITY}
+  `(
+    'User can cancel registration with initial status $initialStatus resulting in $expectedStatus',
+    async ({ initialStatus, expectedStatus }) => {
+      // Create a registration (default status is DRAFTED)
+      const registration = (await mutations.createVisitRegistration(
+        dummyUserWithRole,
+        1,
+        2
+      )) as VisitRegistration;
+
+      // Update the registration status to the parameterized initial status
+      await visitDataSource.updateRegistration({
+        visitId: registration.visitId,
+        userId: registration.userId,
+        status: initialStatus,
+      });
+
+      // Attempt to cancel the registration as the user
+      await mutations.requestVisitRegistrationChanges(
+        dummyUserOfficerWithRole,
+        {
+          visitId: registration.visitId,
+          userId: registration.userId,
+        }
+      );
 
       await expect(
         visitDataSource.getRegistration(

--- a/apps/backend/src/mutations/VisitMutations.spec.ts
+++ b/apps/backend/src/mutations/VisitMutations.spec.ts
@@ -290,7 +290,7 @@ describe('User officer can request changes', () => {
     ${VisitRegistrationStatus.CANCELLED_BY_USER}     | ${VisitRegistrationStatus.CANCELLED_BY_USER}
     ${VisitRegistrationStatus.CANCELLED_BY_FACILITY} | ${VisitRegistrationStatus.CANCELLED_BY_FACILITY}
   `(
-    'User can cancel registration with initial status $initialStatus resulting in $expectedStatus',
+    'User officer trying request changes for visit in $initialStatus status should result visit having $expectedStatus status',
     async ({ initialStatus, expectedStatus }) => {
       // Create a registration (default status is DRAFTED)
       const registration = (await mutations.createVisitRegistration(

--- a/apps/backend/src/mutations/VisitMutations.spec.ts
+++ b/apps/backend/src/mutations/VisitMutations.spec.ts
@@ -355,6 +355,6 @@ test('User can not submit visit registration that has been cancelled by facility
   )) as VisitRegistration;
   expect(submitResult).toHaveProperty(
     'reason',
-    'Chould not submit Visit Registration due to insufficient permissions'
+    'Could not submit Visit Registration due to insufficient permissions'
   );
 });

--- a/apps/backend/src/mutations/VisitMutations.spec.ts
+++ b/apps/backend/src/mutations/VisitMutations.spec.ts
@@ -280,7 +280,7 @@ describe('User can cancel their visit registration', () => {
   );
 });
 
-describe('User officer can request chanhes', () => {
+describe('User officer can request changes', () => {
   test.each`
     initialStatus                                    | expectedStatus
     ${VisitRegistrationStatus.DRAFTED}               | ${VisitRegistrationStatus.DRAFTED}

--- a/apps/backend/src/mutations/VisitMutations.ts
+++ b/apps/backend/src/mutations/VisitMutations.ts
@@ -358,7 +358,7 @@ export default class VisitMutations {
       (await this.registrationAuth.hasCancelRights(agent, input));
     if (!hasCancelRights) {
       return rejection(
-        'Chould not cancel Visit Registration due to insufficient permissions',
+        'Could not cancel Visit Registration due to insufficient permissions',
         { args: input, user: agent }
       );
     }

--- a/apps/backend/src/mutations/VisitMutations.ts
+++ b/apps/backend/src/mutations/VisitMutations.ts
@@ -265,7 +265,7 @@ export default class VisitMutations {
     );
     if (hasWriteRights === false) {
       return rejection(
-        'Chould not update Visit Registration due to insufficient permissions',
+        'Could not update Visit Registration due to insufficient permissions',
         { args, user }
       );
     }
@@ -331,7 +331,7 @@ export default class VisitMutations {
     );
     if (hasWriteRights === false) {
       return rejection(
-        'Chould not submit Visit Registration due to insufficient permissions',
+        'Could not submit Visit Registration due to insufficient permissions',
         { args, user }
       );
     }
@@ -354,7 +354,7 @@ export default class VisitMutations {
     );
     if (!hasCancelRights) {
       return rejection(
-        'Chould not cancel Visit Registration due to insufficient permissions',
+        'Could not cancel Visit Registration due to insufficient permissions',
         { args: input, user }
       );
     }
@@ -408,14 +408,14 @@ export default class VisitMutations {
     );
     if (!visitRegistration) {
       return rejection(
-        'Could not approve Visit Registration because specified registration does not exist',
+        'Could not request changes for visit registration because specified registration does not exist',
         { visitRegistration: input }
       );
     }
 
     if (visitRegistration.status !== VisitRegistrationStatus.SUBMITTED) {
       return rejection(
-        'Could not request changes to Visit Registration because registration is not in submitted state',
+        'Could not request changes to visit registration because registration is not in submitted state',
         { visitRegistration: input }
       );
     }

--- a/apps/backend/src/mutations/VisitMutations.ts
+++ b/apps/backend/src/mutations/VisitMutations.ts
@@ -272,7 +272,7 @@ export default class VisitMutations {
     if (!hasWriteRights) {
       return rejection(
         'Could not update Visit Registration due to insufficient permissions',
-        { args, agent }
+        { args, user: agent }
       );
     }
     const TODAY_MIDNIGT = new Date(new Date().setHours(0, 0, 0, 0));
@@ -337,7 +337,7 @@ export default class VisitMutations {
     if (hasWriteRights === false) {
       return rejection(
         'Could not submit Visit Registration due to insufficient permissions',
-        { args, agent }
+        { args, user: agent }
       );
     }
 
@@ -359,7 +359,7 @@ export default class VisitMutations {
     if (!hasCancelRights) {
       return rejection(
         'Chould not cancel Visit Registration due to insufficient permissions',
-        { input, agent }
+        { args: input, user: agent }
       );
     }
 

--- a/apps/backend/src/mutations/VisitMutations.ts
+++ b/apps/backend/src/mutations/VisitMutations.ts
@@ -12,8 +12,7 @@ import { Authorized, EventBus } from '../decorators';
 import { resolveApplicationEventBus } from '../events';
 import { Event } from '../events/event.enum';
 import { ProposalEndStatus } from '../models/Proposal';
-import { rejection } from '../models/Rejection';
-import { Rejection } from '../models/Rejection';
+import { rejection, Rejection } from '../models/Rejection';
 import { Roles } from '../models/Role';
 import { TemplateGroupId } from '../models/Template';
 import { UserWithRole } from '../models/User';
@@ -25,6 +24,7 @@ import {
 import { ApproveVisitRegistrationInput } from '../resolvers/mutations/ApproveVisitRegistrationMutations';
 import { CancelVisitRegistrationInput } from '../resolvers/mutations/CancelVisitRegistrationMutation';
 import { CreateVisitArgs } from '../resolvers/mutations/CreateVisitMutation';
+import { RequestVisitRegistrationChangesInput } from '../resolvers/mutations/RequestVisitRegistrationChangesMutation';
 import { SubmitVisitRegistrationArgs } from '../resolvers/mutations/SubmitVisitRegistration';
 import { UpdateVisitArgs } from '../resolvers/mutations/UpdateVisitMutation';
 import { UpdateVisitRegistrationArgs } from '../resolvers/mutations/UpdateVisitRegistrationMutation';
@@ -394,6 +394,36 @@ export default class VisitMutations {
       userId: input.userId,
       visitId: input.visitId,
       status: newStatus,
+    });
+  }
+
+  @Authorized([Roles.USER_OFFICER])
+  async requestVisitRegistrationChanges(
+    user: UserWithRole | null,
+    input: RequestVisitRegistrationChangesInput
+  ) {
+    const visitRegistration = await this.dataSource.getRegistration(
+      input.userId,
+      input.visitId
+    );
+    if (!visitRegistration) {
+      return rejection(
+        'Could not approve Visit Registration because specified registration does not exist',
+        { visitRegistration: input }
+      );
+    }
+
+    if (visitRegistration.status !== VisitRegistrationStatus.SUBMITTED) {
+      return rejection(
+        'Could not approve Visit Registration because registration is not in submitted state',
+        { visitRegistration: input }
+      );
+    }
+
+    return this.dataSource.updateRegistration({
+      userId: input.userId,
+      visitId: input.visitId,
+      status: VisitRegistrationStatus.CHANGE_REQUESTED,
     });
   }
 }

--- a/apps/backend/src/mutations/VisitMutations.ts
+++ b/apps/backend/src/mutations/VisitMutations.ts
@@ -415,7 +415,7 @@ export default class VisitMutations {
 
     if (visitRegistration.status !== VisitRegistrationStatus.SUBMITTED) {
       return rejection(
-        'Could not approve Visit Registration because registration is not in submitted state',
+        'Could not request changes to Visit Registration because registration is not in submitted state',
         { visitRegistration: input }
       );
     }

--- a/apps/backend/src/resolvers/mutations/RequestVisitRegistrationChangesMutation.ts
+++ b/apps/backend/src/resolvers/mutations/RequestVisitRegistrationChangesMutation.ts
@@ -1,0 +1,38 @@
+import {
+  Arg,
+  Ctx,
+  Field,
+  InputType,
+  Int,
+  Mutation,
+  Resolver,
+} from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { VisitRegistration } from '../types/VisitRegistration';
+
+@InputType()
+export class RequestVisitRegistrationChangesInput
+  implements Partial<VisitRegistration>
+{
+  @Field(() => Int!)
+  public visitId: number;
+
+  @Field(() => Int!)
+  public userId: number;
+}
+
+@Resolver()
+export class RequestVisitRegistrationChangesMutation {
+  @Mutation(() => VisitRegistration)
+  requestVisitRegistrationChanges(
+    @Arg('visitRegistration', () => RequestVisitRegistrationChangesInput)
+    visitRegistration: RequestVisitRegistrationChangesInput,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.mutations.visit.requestVisitRegistrationChanges(
+      context.user,
+      visitRegistration
+    );
+  }
+}

--- a/apps/e2e/cypress/e2e/visits.cy.ts
+++ b/apps/e2e/cypress/e2e/visits.cy.ts
@@ -86,6 +86,53 @@ context('visits tests', () => {
       });
     });
 
+    it('User officer should be able request changes', () => {
+      cy.login('officer');
+      cy.visit('/ExperimentPage');
+
+      cy.finishedLoading();
+      cy.get('[data-cy=preset-date-selector]').contains('All').click();
+      cy.get('[data-testid="ChevronRightIcon"]')
+        .first()
+        .closest('button')
+        .click();
+      cy.get('[data-cy="request-visit-registration-changhes-button"]').click();
+      cy.get('[data-cy="confirm-ok"]').click();
+      cy.get('[data-cy="request-visit-registration-changhes-button"]').should(
+        'not.be.exist'
+      );
+
+      cy.logout();
+      cy.login(visitor);
+      cy.visit('/');
+
+      cy.finishedLoading();
+
+      cy.testActionButton(cyTagRegisterVisit, 'active');
+
+      cy.get(`[data-cy="${cyTagRegisterVisit}"]`)
+        .closest('button')
+        .first()
+        .click();
+
+      const startDateObj = faker.date.future();
+      const endDateObj = new Date(startDateObj.getTime() + 24 * 60 * 60 * 1000);
+
+      const startDate = DateTime.fromJSDate(startDateObj).toFormat(
+        initialDBData.getFormats().dateFormat
+      );
+      const endDate = DateTime.fromJSDate(endDateObj).toFormat(
+        initialDBData.getFormats().dateFormat
+      );
+
+      cy.contains(startQuestion).parent().find('input').clear().type(startDate);
+      cy.contains(endQuestion).parent().find('input').clear().type(endDate);
+      cy.get('[data-cy="save-and-continue-button"]').click();
+      cy.get('[data-cy="submit-visit-registration-button"]').click();
+      cy.get('[data-cy="confirm-ok"]').click();
+      cy.testActionButton(cyTagRegisterVisit, 'completed');
+    });
+
     it('User officer should be able to cancel visit registration', () => {
       cy.login('officer');
       cy.visit('/ExperimentPage');

--- a/apps/e2e/cypress/e2e/visits.cy.ts
+++ b/apps/e2e/cypress/e2e/visits.cy.ts
@@ -96,9 +96,9 @@ context('visits tests', () => {
         .first()
         .closest('button')
         .click();
-      cy.get('[data-cy="request-visit-registration-changhes-button"]').click();
+      cy.get('[data-cy="request-visit-registration-changes-button"]').click();
       cy.get('[data-cy="confirm-ok"]').click();
-      cy.get('[data-cy="request-visit-registration-changhes-button"]').should(
+      cy.get('[data-cy="request-visit-registration-changes-button"]').should(
         'not.be.exist'
       );
 

--- a/apps/frontend/src/components/experiment/ExperimentVisitsTable.tsx
+++ b/apps/frontend/src/components/experiment/ExperimentVisitsTable.tsx
@@ -212,7 +212,7 @@ function ExperimentVisitsTable(params: ExperimentDetailsTableProps) {
               onRequestChangesClick(rowData.visitId, rowData.userId)
             }
             component="button"
-            data-cy="request-visit-registration-changhes-button"
+            data-cy="request-visit-registration-changes-button"
           >
             <Tooltip title="Request visit registration changes">
               <ReplayIcon />

--- a/apps/frontend/src/components/experiment/ExperimentVisitsTable.tsx
+++ b/apps/frontend/src/components/experiment/ExperimentVisitsTable.tsx
@@ -3,6 +3,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import ClearIcon from '@mui/icons-material/Clear';
 import EditIcon from '@mui/icons-material/Edit';
 import MailIcon from '@mui/icons-material/Mail';
+import ReplayIcon from '@mui/icons-material/Replay';
 import { IconButton, styled, Tooltip } from '@mui/material';
 import Box from '@mui/material/Box';
 import React, { useContext, useState } from 'react';
@@ -126,6 +127,18 @@ function ExperimentVisitsTable(params: ExperimentDetailsTableProps) {
     replaceVisitRegistration(approvedRegistration);
   };
 
+  const requestVisitChanges = async (visitId: number, userId: number) => {
+    const updatedRegistration = (
+      await api().requestVisitRegistrationChanges({
+        visitRegistration: {
+          visitId,
+          userId,
+        },
+      })
+    ).requestVisitRegistrationChanges;
+    replaceVisitRegistration(updatedRegistration);
+  };
+
   const onApproveVisitClick = async (visitId: number, userId: number) => {
     confirm(async () => approveVisit(visitId, userId), {
       title: 'Approve visit registration',
@@ -137,6 +150,14 @@ function ExperimentVisitsTable(params: ExperimentDetailsTableProps) {
     confirm(async () => cancelVisit(visitId, userId), {
       title: 'Cancel visit registration',
       description: 'Are you sure you want to cancel this visit registration?',
+    })();
+  };
+
+  const onRequestChangesClick = async (visitId: number, userId: number) => {
+    confirm(async () => requestVisitChanges(visitId, userId), {
+      title: 'Request visit registration changes',
+      description:
+        'Are you sure you want to request visit registration changes?',
     })();
   };
 
@@ -185,6 +206,20 @@ function ExperimentVisitsTable(params: ExperimentDetailsTableProps) {
           </IconButton>
         );
 
+        const requestChangesButton = (
+          <IconButton
+            onClick={() =>
+              onRequestChangesClick(rowData.visitId, rowData.userId)
+            }
+            component="button"
+            data-cy="request-visit-registration-changhes-button"
+          >
+            <Tooltip title="Request visit registration changes">
+              <ReplayIcon />
+            </Tooltip>
+          </IconButton>
+        );
+
         const subject = organisationName
           ? `Important information regarding your experiment at ${organisationName}`
           : 'Important information regarding your experiment';
@@ -217,15 +252,26 @@ function ExperimentVisitsTable(params: ExperimentDetailsTableProps) {
             return (
               <ActionDiv>
                 {sendEmailButton}
+                {editButton}
                 {approveButton}
                 {cancelButton}
-                {editButton}
+                {requestChangesButton}
               </ActionDiv>
             );
           case VisitRegistrationStatus.APPROVED:
             return (
               <ActionDiv>
                 {sendEmailButton}
+                {cancelButton}
+              </ActionDiv>
+            );
+
+          case VisitRegistrationStatus.CHANGE_REQUESTED:
+            return (
+              <ActionDiv>
+                {sendEmailButton}
+                {editButton}
+                {approveButton}
                 {cancelButton}
               </ActionDiv>
             );

--- a/apps/frontend/src/components/questionary/questionaries/visitRegistration/VisitRegistrationQuestionaryDefinition.ts
+++ b/apps/frontend/src/components/questionary/questionaries/visitRegistration/VisitRegistrationQuestionaryDefinition.ts
@@ -18,11 +18,14 @@ export const visitRegistrationQuestionaryDefinition: QuestionaryDefinition = {
 
   wizardStepFactory: new DefaultWizardStepFactory(
     VisitRegistrationWizardStep,
-    new DefaultReviewWizardStep(
-      (state) =>
+    new DefaultReviewWizardStep((state) => {
+      return (
         (state as VisitRegistrationSubmissionState).registration.status !==
-        VisitRegistrationStatus.DRAFTED
-    )
+          VisitRegistrationStatus.DRAFTED &&
+        (state as VisitRegistrationSubmissionState).registration.status !==
+          VisitRegistrationStatus.CHANGE_REQUESTED
+      );
+    })
   ),
 
   getItemWithQuestionary(

--- a/apps/frontend/src/components/questionary/questionaries/visitRegistration/VisitRegistrationWizardStep.ts
+++ b/apps/frontend/src/components/questionary/questionaries/visitRegistration/VisitRegistrationWizardStep.ts
@@ -8,7 +8,10 @@ export class VisitRegistrationWizardStep extends QuestionaryWizardStep {
     const registrationState = state as VisitRegistrationSubmissionState;
 
     return (
-      registrationState.registration.status === VisitRegistrationStatus.DRAFTED
+      registrationState.registration.status ===
+        VisitRegistrationStatus.DRAFTED ||
+      registrationState.registration.status ===
+        VisitRegistrationStatus.CHANGE_REQUESTED
     );
   }
 }

--- a/apps/frontend/src/components/visit/VisitRegistrationReview.tsx
+++ b/apps/frontend/src/components/visit/VisitRegistrationReview.tsx
@@ -49,6 +49,20 @@ function VisitRegistrationReview({ confirm }: VisitRegistrationReviewProps) {
     },
   ];
 
+  const getSubmitButtonLabel = () => {
+    if (registration.status === VisitRegistrationStatus.DRAFTED) {
+      return 'Submit';
+    } else if (
+      registration.status === VisitRegistrationStatus.CHANGE_REQUESTED
+    ) {
+      return 'Submit changes';
+    } else if (registration.status === VisitRegistrationStatus.SUBMITTED) {
+      return '✔ Submitted';
+    }
+
+    return '';
+  };
+
   return (
     <div>
       <QuestionaryDetails
@@ -82,12 +96,15 @@ function VisitRegistrationReview({ confirm }: VisitRegistrationReviewProps) {
               }
             )()
           }
-          disabled={registration.status !== VisitRegistrationStatus.DRAFTED}
+          disabled={
+            ![
+              VisitRegistrationStatus.DRAFTED,
+              VisitRegistrationStatus.CHANGE_REQUESTED,
+            ].includes(registration.status)
+          }
           data-cy="submit-visit-registration-button"
         >
-          {registration.status === VisitRegistrationStatus.DRAFTED
-            ? 'Submit'
-            : '✔ Submitted'}
+          {getSubmitButtonLabel()}
         </NavigButton>
       </NavigationFragment>
     </div>

--- a/apps/frontend/src/graphql/visitRegistration/requestVisitRegistrationChanges.graphql
+++ b/apps/frontend/src/graphql/visitRegistration/requestVisitRegistrationChanges.graphql
@@ -1,0 +1,8 @@
+mutation requestVisitRegistrationChanges($visitRegistration: RequestVisitRegistrationChangesInput!) {
+  requestVisitRegistrationChanges(visitRegistration: $visitRegistration) {
+    ...visitRegistration
+    user {
+      ...basicUserDetails
+    }
+  }
+}

--- a/apps/frontend/src/hooks/proposalBooking/useActionButtons.tsx
+++ b/apps/frontend/src/hooks/proposalBooking/useActionButtons.tsx
@@ -162,8 +162,11 @@ export function useActionButtons(args: UseActionButtonsArgs) {
       } else {
         switch (registration.status) {
           case VisitRegistrationStatus.DRAFTED:
+            buttonState = 'active';
+            break;
           case VisitRegistrationStatus.CHANGE_REQUESTED:
             buttonState = 'active';
+            stateReason = 'Changes are requested for your registration';
             break;
           case VisitRegistrationStatus.SUBMITTED:
             buttonState = 'pending';


### PR DESCRIPTION
## Description
This PR implements the "Request Change" functionality for visits.
![image](https://github.com/user-attachments/assets/9fe354de-f198-453d-bbea-ee382a849fe3)


## Motivation and Context
The change is required to allow User Officers to request changes to a visit, if the specified dates are not feasible. 

## Changes
1. Making sure visit can modified in both states 'DRAFTED' or 'CHANGE_REQUESTED'.
2. Added new tests to cover the change as well as covering some lacking functionality for visits
3. Added E2E test


## Fixes Jira Issue

[https://jira.esss.lu.se/browse/SWAP-4652](https://jira.esss.lu.se/browse/SWAP-4652)

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
