### PR TITLE
fix: update visit status icons for better clarity and consistency

### DIFF
--- a/apps/frontend/src/components/visit/VisitStatusIcon.tsx
+++ b/apps/frontend/src/components/visit/VisitStatusIcon.tsx
@@ -1,5 +1,5 @@
 import ClearOutlinedIcon from '@mui/icons-material/Clear';
-import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import NoteAltOutlinedIcon from '@mui/icons-material/NoteAltOutlined';
 import RestorePageOutlinedIcon from '@mui/icons-material/RestorePageOutlined';
 import TaskOutlinedIcon from '@mui/icons-material/TaskOutlined';
@@ -26,7 +26,7 @@ export default function VisitStatusOutlinedIcon(props: IVisitStatusIconProps) {
             },
           }}
         >
-          <InsertDriveFileOutlinedIcon />
+          <DescriptionOutlinedIcon />
         </DotBadge>
       );
     case VisitRegistrationStatus.APPROVED:

--- a/apps/frontend/src/components/visit/VisitStatusIcon.tsx
+++ b/apps/frontend/src/components/visit/VisitStatusIcon.tsx
@@ -1,26 +1,52 @@
-import CheckBoxIcon from '@mui/icons-material/CheckBox';
-import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
-import DisabledByDefaultIcon from '@mui/icons-material/DisabledByDefault';
-import { TimeIcon } from '@mui/x-date-pickers';
+import ClearOutlinedIcon from '@mui/icons-material/Clear';
+import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import NoteAltOutlinedIcon from '@mui/icons-material/NoteAltOutlined';
+import RestorePageOutlinedIcon from '@mui/icons-material/RestorePageOutlined';
+import TaskOutlinedIcon from '@mui/icons-material/TaskOutlined';
 import React from 'react';
 
+import DotBadge from 'components/proposalBooking/DotBadge';
 import { VisitRegistrationStatus } from 'generated/sdk';
 
 interface IVisitStatusIconProps {
   status: VisitRegistrationStatus;
 }
 
-export default function VisitStatusIcon(props: IVisitStatusIconProps) {
+export default function VisitStatusOutlinedIcon(props: IVisitStatusIconProps) {
   switch (props.status) {
     case VisitRegistrationStatus.DRAFTED:
-      return <TimeIcon />;
+      return <NoteAltOutlinedIcon />;
     case VisitRegistrationStatus.SUBMITTED:
-      return <CheckBoxOutlineBlankIcon style={{ color: 'gray' }} />;
+      return (
+        <DotBadge
+          sx={{
+            '& .MuiBadge-dot': {
+              background: '#eb1a6c',
+              boxShadow: '-1px 1px 0 white',
+            },
+          }}
+        >
+          <InsertDriveFileOutlinedIcon />
+        </DotBadge>
+      );
     case VisitRegistrationStatus.APPROVED:
-      return <CheckBoxIcon style={{ color: 'green' }} />;
+      return (
+        <DotBadge
+          sx={{
+            '& .MuiBadge-dot': {
+              background: '#22d131',
+              boxShadow: '-1px 1px 0 white',
+            },
+          }}
+        >
+          <TaskOutlinedIcon />
+        </DotBadge>
+      );
     case VisitRegistrationStatus.CANCELLED_BY_USER:
     case VisitRegistrationStatus.CANCELLED_BY_FACILITY:
-      return <DisabledByDefaultIcon style={{ color: 'black' }} />;
+      return <ClearOutlinedIcon />;
+    case VisitRegistrationStatus.CHANGE_REQUESTED:
+      return <RestorePageOutlinedIcon />;
     default:
       return null;
   }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR updates icons for visits that are visible by user officer
![image](https://github.com/user-attachments/assets/e36d229f-eaaf-49ea-a0fb-9d3f369aca0f)



## Motivation and Context

Previously icons were a little misleading especially SUBMITTED state icon which was empty rectangle.
Now icons are more descriptive and following the same language what user sees that redish dot means it needs action




