### PR TITLE
fix: add fap reviewer notified to proposal events table

### DIFF
--- a/apps/backend/db_patches/0180_AddFapReviewerNotifiedEvent.sql
+++ b/apps/backend/db_patches/0180_AddFapReviewerNotifiedEvent.sql
@@ -1,0 +1,11 @@
+DO
+$$
+BEGIN
+	IF register_patch('0180_AddFapReviewerNotifiedEvent.sql', 'TCMeldrum', 'Add missing FAP_REVIEWER_NOTIFIED', '2025-05-01') THEN
+        BEGIN
+            ALTER TABLE proposal_events ADD COLUMN FAP_REVIEWER_NOTIFIED BOOLEAN DEFAULT FALSE;
+        END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1394

## Description

After https://github.com/UserOfficeProject/user-office-core/pull/1006 fixed the checkCallsFapReviewEndedJob we got a massive error spike of db errors as the FAP_REVIEWER_NOTIFIED event was trying to be added to the proposals-events table but the column does not exist. This PR just adds it.

I checked the other Application events and this was the only one that could be added to the proposals-events table what was missing ..... as far as I can tell.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
