### PR TITLE
POC:  Dynamic role creation

### DIFF
--- a/apps/backend/db_patches/0180_CreateUserRoles
+++ b/apps/backend/db_patches/0180_CreateUserRoles
@@ -1,0 +1,17 @@
+DO
+$$
+BEGIN
+	IF register_patch('0180_RenameXpressFeature.sql', 'Fredrik Bolmsten', 'Create dynamic user roles', '2025-05-06') THEN
+	BEGIN
+
+    ALTER TABLE roles
+    ADD COLUMN permissions TEXT[] NOT NULL DEFAULT '{}';
+
+    ALTER TABLE roles
+    ADD COLUMN data_access TEXT[] NOT NULL DEFAULT '{}';
+    
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/backend/src/auth/ProposalAuthorization.spec.ts
+++ b/apps/backend/src/auth/ProposalAuthorization.spec.ts
@@ -114,6 +114,8 @@ test('A instrument sci cannot access proposals they are not on', async () => {
           title: 'Instrument Scientist',
           shortCode: 'instrument_scientist',
           description: '',
+          permissions: [],
+          dataAccess: [],
         },
       },
       1

--- a/apps/backend/src/datasources/UserDataSource.ts
+++ b/apps/backend/src/datasources/UserDataSource.ts
@@ -3,6 +3,7 @@ import { Institution } from '../models/Institution';
 import { Role, Roles } from '../models/Role';
 import { BasicUserDetails, User, UserRole } from '../models/User';
 import { AddUserRoleArgs } from '../resolvers/mutations/AddUserRoleMutation';
+import { CreateRoleArgs } from '../resolvers/mutations/CreateRoleMutation';
 import { CreateUserByEmailInviteArgs } from '../resolvers/mutations/CreateUserByEmailInviteMutation';
 import { UpdateUserArgs } from '../resolvers/mutations/UpdateUserMutation';
 import { UsersArgs } from '../resolvers/queries/UsersQuery';
@@ -97,4 +98,7 @@ export interface UserDataSource {
   ): Promise<boolean>;
   getRoleByShortCode(roleShortCode: Roles): Promise<Role>;
   mergeUsers(fromUserId: number, intoUserId: number): Promise<void>;
+  createRole(args: CreateRoleArgs): Promise<Role>;
+  updateRole(args: CreateRoleArgs): Promise<Role>;
+  deleteRole(id: number): Promise<Role | null>;
 }

--- a/apps/backend/src/datasources/mockups/FapDataSource.ts
+++ b/apps/backend/src/datasources/mockups/FapDataSource.ts
@@ -435,6 +435,8 @@ export class FapDataSourceMock implements FapDataSource {
       shortCode: 'fap_chair',
       title: 'Fap Chair',
       description: '',
+      permissions: [],
+      dataAccess: [],
     };
   }
 

--- a/apps/backend/src/datasources/mockups/UserDataSource.ts
+++ b/apps/backend/src/datasources/mockups/UserDataSource.ts
@@ -8,6 +8,7 @@ import {
   UserWithRole,
 } from '../../models/User';
 import { AddUserRoleArgs } from '../../resolvers/mutations/AddUserRoleMutation';
+import { CreateRoleArgs } from '../../resolvers/mutations/CreateRoleMutation';
 import { CreateUserByEmailInviteArgs } from '../../resolvers/mutations/CreateUserByEmailInviteMutation';
 import { UpdateUserArgs } from '../../resolvers/mutations/UpdateUserMutation';
 import { UsersArgs } from '../../resolvers/queries/UsersQuery';
@@ -74,6 +75,8 @@ export const dummyUserOfficerWithRole: UserWithRole = {
     title: 'User Officer',
     shortCode: 'user_officer',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
@@ -111,12 +114,21 @@ export const dummyPrincipalInvestigatorWithRole: UserWithRole = {
     title: 'Principal investigator',
     shortCode: 'user',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
 export const dummyUserWithRole: UserWithRole = {
   ...dummyUser,
-  currentRole: { id: 1, title: 'User', shortCode: 'user', description: '' },
+  currentRole: {
+    id: 1,
+    title: 'User',
+    shortCode: 'user',
+    description: '',
+    permissions: [],
+    dataAccess: [],
+  },
 };
 
 export const dummyFapChairWithRole: UserWithRole = {
@@ -126,6 +138,8 @@ export const dummyFapChairWithRole: UserWithRole = {
     title: 'Fap Chair',
     shortCode: 'fap_chair',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
@@ -136,6 +150,8 @@ export const dummyFapSecretaryWithRole: UserWithRole = {
     title: 'Fap Secretary',
     shortCode: 'fap_secretary',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
@@ -146,6 +162,8 @@ export const dummyFapReviewerWithRole: UserWithRole = {
     title: 'Fap Reviewer',
     shortCode: 'fap_reviewer',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
@@ -156,6 +174,8 @@ export const dummySampleReviewer: UserWithRole = {
     title: 'Experiment Safety Reviewer',
     shortCode: 'experiment_safety_reviewer',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
@@ -166,6 +186,8 @@ export const dummyInternalReviewer: UserWithRole = {
     title: 'Internal Reviewer',
     shortCode: 'internal_reviewer',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
@@ -177,6 +199,8 @@ export const dummyInstrumentScientist: UserWithRole = {
     title: 'Instrument Scientist',
     shortCode: 'instrument_scientist',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
@@ -188,6 +212,8 @@ export const dummyVisitorWithRole: UserWithRole = {
     title: 'Visitor',
     shortCode: 'user',
     description: '',
+    permissions: [],
+    dataAccess: [],
   },
 };
 
@@ -245,10 +271,26 @@ export const dummyUserNotOnProposal = new User(
 
 export const dummyUserNotOnProposalWithRole: UserWithRole = {
   ...dummyUserNotOnProposal,
-  currentRole: { id: 1, title: 'User', shortCode: 'user', description: '' },
+  currentRole: {
+    id: 1,
+    title: 'User',
+    shortCode: 'user',
+    description: '',
+    permissions: [],
+    dataAccess: [],
+  },
 };
 
 export class UserDataSourceMock implements UserDataSource {
+  createRole(args: CreateRoleArgs): Promise<Role> {
+    throw new Error('Method not implemented.');
+  }
+  updateRole(args: CreateRoleArgs): Promise<Role> {
+    throw new Error('Method not implemented.');
+  }
+  deleteRole(id: number): Promise<Role | null> {
+    throw new Error('Method not implemented.');
+  }
   async delete(id: number): Promise<User | null> {
     return dummyUser;
   }
@@ -331,6 +373,8 @@ export class UserDataSourceMock implements UserDataSource {
           shortCode: 'user_officer',
           title: 'User Officer',
           description: '',
+          permissions: [],
+          dataAccess: [],
         },
       ];
     } else if (id === dummyInstrumentScientist.id) {
@@ -340,6 +384,8 @@ export class UserDataSourceMock implements UserDataSource {
           title: 'Instrument Scientist',
           shortCode: 'instrument_scientist',
           description: '',
+          permissions: [],
+          dataAccess: [],
         },
       ];
     } else if (id === 1001) {
@@ -349,14 +395,32 @@ export class UserDataSourceMock implements UserDataSource {
           shortCode: 'fap_reviewer',
           title: 'Fap Reviewer',
           description: '',
+          permissions: [],
+          dataAccess: [],
         },
       ];
     } else if (id === dummyFapChairWithRole.id) {
       return [
-        { id: 4, shortCode: 'fap_chair', title: 'Fap Chair', description: '' },
+        {
+          id: 4,
+          shortCode: 'fap_chair',
+          title: 'Fap Chair',
+          description: '',
+          permissions: [],
+          dataAccess: [],
+        },
       ];
     } else {
-      return [{ id: 2, shortCode: 'user', title: 'User', description: '' }];
+      return [
+        {
+          id: 2,
+          shortCode: 'user',
+          title: 'User',
+          description: '',
+          permissions: [],
+          dataAccess: [],
+        },
+      ];
     }
   }
 
@@ -367,8 +431,17 @@ export class UserDataSourceMock implements UserDataSource {
         shortCode: 'user_officer',
         title: 'User Officer',
         description: '',
+        permissions: [],
+        dataAccess: [],
       },
-      { id: 2, shortCode: 'user', title: 'User', description: '' },
+      {
+        id: 2,
+        shortCode: 'user',
+        title: 'User',
+        description: '',
+        permissions: [],
+        dataAccess: [],
+      },
     ];
   }
 
@@ -482,6 +555,8 @@ export class UserDataSourceMock implements UserDataSource {
       shortCode: 'user_officer',
       title: 'User Officer',
       description: '',
+      permissions: [],
+      dataAccess: [],
     };
   }
 

--- a/apps/backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/backend/src/datasources/postgres/UserDataSource.ts
@@ -883,6 +883,7 @@ export default class PostgresUserDataSource implements UserDataSource {
   async deleteRole(id: number): Promise<Role | null> {
     const [deletedRole] = await database('roles')
       .where('role_id', id)
+      .del()
       .returning('*');
 
     if (!deletedRole) {

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -262,6 +262,8 @@ export interface RoleRecord {
   readonly short_code: string;
   readonly title: string;
   readonly description: string;
+  readonly permissions: string[]; // Changed from string to string[]
+  readonly data_access: string[]; // Changed from string to string[]
 }
 
 export interface ReviewRecord {
@@ -1175,7 +1177,14 @@ export const createFapReviewerObject = (fapMember: FapReviewerRecord) => {
 };
 
 export const createRoleObject = (role: RoleRecord) => {
-  return new Role(role.role_id, role.short_code, role.title, role.description);
+  return new Role(
+    role.role_id,
+    role.short_code,
+    role.title,
+    role.description,
+    role.permissions,
+    role.data_access
+  );
 };
 
 export const createVisitObject = (visit: VisitRecord) => {

--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.spec.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.spec.ts
@@ -144,9 +144,16 @@ describe('Role tests', () => {
     const mockGetRoles = jest.spyOn(StfcUserDataSource.prototype, 'getRoles');
     mockGetRoles.mockImplementation(() =>
       Promise.resolve([
-        new Role(1, Roles.USER, 'User', ''),
-        new Role(2, Roles.USER_OFFICER, 'User Officer', ''),
-        new Role(3, Roles.INSTRUMENT_SCIENTIST, 'Instrument Scientist', ''),
+        new Role(1, Roles.USER, 'User', '', [], []),
+        new Role(2, Roles.USER_OFFICER, 'User Officer', '', [], []),
+        new Role(
+          3,
+          Roles.INSTRUMENT_SCIENTIST,
+          'Instrument Scientist',
+          '',
+          [],
+          []
+        ),
       ])
     );
 
@@ -169,7 +176,7 @@ describe('Role tests', () => {
 
     return expect(roles[0]).toEqual(
       expect.objectContaining(
-        new Role(expect.any(Number), Roles.USER, 'User', '')
+        new Role(expect.any(Number), Roles.USER, 'User', '', [], [])
       )
     );
   });
@@ -181,9 +188,16 @@ describe('Role tests', () => {
       userdataSource.getUserRoles(dummyUserNumber)
     ).resolves.toEqual(
       expect.arrayContaining([
-        new Role(1, Roles.USER, 'User', ''),
-        new Role(2, Roles.USER_OFFICER, 'User Officer', ''),
-        new Role(3, Roles.INSTRUMENT_SCIENTIST, 'Instrument Scientist', ''),
+        new Role(1, Roles.USER, 'User', '', [], []),
+        new Role(2, Roles.USER_OFFICER, 'User Officer', '', [], []),
+        new Role(
+          3,
+          Roles.INSTRUMENT_SCIENTIST,
+          'Instrument Scientist',
+          '',
+          [],
+          []
+        ),
       ])
     );
   });

--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -7,6 +7,7 @@ import { Institution } from '../../models/Institution';
 import { Role, Roles } from '../../models/Role';
 import { BasicUserDetails, User } from '../../models/User';
 import { AddUserRoleArgs } from '../../resolvers/mutations/AddUserRoleMutation';
+import { CreateRoleArgs } from '../../resolvers/mutations/CreateRoleMutation';
 import { CreateUserByEmailInviteArgs } from '../../resolvers/mutations/CreateUserByEmailInviteMutation';
 import { UpdateUserArgs } from '../../resolvers/mutations/UpdateUserMutation';
 import { UsersArgs } from '../../resolvers/queries/UsersQuery';
@@ -135,6 +136,15 @@ function toEssUser(stfcUser: StfcBasicPersonDetails): User {
 }
 
 export class StfcUserDataSource implements UserDataSource {
+  createRole(args: CreateRoleArgs): Promise<Role> {
+    throw new Error('Method not implemented.');
+  }
+  updateRole(args: CreateRoleArgs): Promise<Role> {
+    throw new Error('Method not implemented.');
+  }
+  deleteRole(id: number): Promise<Role | null> {
+    throw new Error('Method not implemented.');
+  }
   private static readonly userDetailsCacheMaxElements = 1000;
   private static readonly userDetailsCacheSecondsToLive = 600; // 10 minutes
   private static readonly rolesCacheMaxElements = 1000;

--- a/apps/backend/src/decorators/Authorized.ts
+++ b/apps/backend/src/decorators/Authorized.ts
@@ -17,7 +17,6 @@ const Authorized = (roles: Roles[] = []) => {
     }
   ) => {
     const originalMethod = descriptor.value;
-
     descriptor.value = async function (...args) {
       const [agent] = args;
       const isMutation = target.constructor.name.includes('Mutation');
@@ -57,6 +56,14 @@ const Authorized = (roles: Roles[] = []) => {
         (role) => role === agent.currentRole?.shortCode
       );
 
+      //check if user has dynamic role with permissions for this method
+      if (
+        agent.currentRole?.permissions.some(
+          (permission) => permission === `${target.constructor.name}.${name}`
+        )
+      ) {
+        return await originalMethod?.apply(this, args);
+      }
       if (hasAccessRights) {
         return await originalMethod?.apply(this, args);
       } else {

--- a/apps/backend/src/models/Role.ts
+++ b/apps/backend/src/models/Role.ts
@@ -3,7 +3,9 @@ export class Role {
     public id: number,
     public shortCode: string,
     public title: string,
-    public description: string
+    public description: string,
+    public permissions: string[], // New field for permissions
+    public dataAccess: string[] // New field for data access
   ) {}
 }
 

--- a/apps/backend/src/mutations/UserMutations.ts
+++ b/apps/backend/src/mutations/UserMutations.ts
@@ -26,7 +26,9 @@ import {
   UserWithRole,
 } from '../models/User';
 import { AddUserRoleArgs } from '../resolvers/mutations/AddUserRoleMutation';
+import { CreateRoleArgs } from '../resolvers/mutations/CreateRoleMutation';
 import { CreateUserByEmailInviteArgs } from '../resolvers/mutations/CreateUserByEmailInviteMutation';
+import { UpdateRoleArgs } from '../resolvers/mutations/UpdateRoleMutation';
 import {
   UpdateUserArgs,
   UpdateUserRolesArgs,
@@ -455,5 +457,44 @@ export default class UserMutations {
     id: number
   ): Promise<User | null> {
     return this.dataSource.setUserNotPlaceholder(id);
+  }
+
+  @Authorized([Roles.USER_OFFICER])
+  async createRole(
+    _: UserWithRole | null,
+    args: CreateRoleArgs
+  ): Promise<Role | Rejection> {
+    try {
+      const role = await this.dataSource.createRole(args);
+
+      return role;
+    } catch (err) {
+      return rejection('Could not create role', { args }, err);
+    }
+  }
+
+  @Authorized([Roles.USER_OFFICER])
+  async updateRole(
+    _: UserWithRole | null,
+    args: UpdateRoleArgs
+  ): Promise<Role | Rejection> {
+    try {
+      const role = await this.dataSource.updateRole(args);
+
+      return role;
+    } catch (err) {
+      return rejection('Could not update role', { args }, err);
+    }
+  }
+
+  @Authorized([Roles.USER_OFFICER])
+  async deleteRole(_: UserWithRole | null, id: number): Promise<Role | null> {
+    try {
+      const role = await this.dataSource.deleteRole(id);
+
+      return role;
+    } catch (err) {
+      return null;
+    }
   }
 }

--- a/apps/backend/src/queries/ProposalQueries.ts
+++ b/apps/backend/src/queries/ProposalQueries.ts
@@ -102,6 +102,7 @@ export default class ProposalQueries {
     try {
       // leave await here because getProposalsFromView might thrown an exception
       // and we want to handle it here
+
       return await this.dataSource.getProposalsFromView(
         filter,
         first,

--- a/apps/backend/src/resolvers/mutations/CreateRoleMutation.ts
+++ b/apps/backend/src/resolvers/mutations/CreateRoleMutation.ts
@@ -1,0 +1,57 @@
+import { Field, InputType, ObjectType } from 'type-graphql';
+import { Resolver, Mutation, Arg, Ctx } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { Role } from '../types/Role'; // Adjust the path as necessary
+
+@InputType()
+export class CreateRoleArgs {
+  @Field()
+  shortCode: string;
+
+  @Field()
+  title: string;
+
+  @Field()
+  description: string;
+
+  @Field(() => [String])
+  permissions: string[];
+
+  @Field(() => [String])
+  dataAccess: string[];
+}
+
+@ObjectType()
+export class CreateRoleResponse {
+  @Field()
+  success: boolean;
+
+  @Field(() => Role, { nullable: true })
+  role?: Role;
+}
+
+@Resolver()
+export class CreateRoleMutation {
+  @Mutation(() => CreateRoleResponse)
+  async createRole(
+    @Arg('args') args: CreateRoleArgs,
+    @Ctx() context: ResolverContext
+  ): Promise<CreateRoleResponse> {
+    const role = (await context.mutations.user.createRole(
+      context.user,
+      args
+    )) as Role | Error;
+    if (role instanceof Error) {
+      return {
+        success: false,
+        role: undefined,
+      };
+    }
+
+    return {
+      success: true,
+      role,
+    };
+  }
+}

--- a/apps/backend/src/resolvers/mutations/DeleteRoleMutation.ts
+++ b/apps/backend/src/resolvers/mutations/DeleteRoleMutation.ts
@@ -1,0 +1,15 @@
+import { Arg, Ctx, Int, Mutation, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { Role } from '../types/Role';
+
+@Resolver()
+export class DeleteRoleMutation {
+  @Mutation(() => Role)
+  deleteRole(
+    @Arg('roleId', () => Int) roleId: number,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.mutations.user.deleteRole(context.user, roleId);
+  }
+}

--- a/apps/backend/src/resolvers/mutations/UpdateRoleMutation.ts
+++ b/apps/backend/src/resolvers/mutations/UpdateRoleMutation.ts
@@ -1,0 +1,60 @@
+import { Field, InputType, Int, ObjectType } from 'type-graphql';
+import { Resolver, Mutation, Arg, Ctx } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { Role } from '../types/Role'; // Adjust the path as necessary
+
+@InputType()
+export class UpdateRoleArgs {
+  @Field(() => Int)
+  public roleID: number;
+
+  @Field()
+  shortCode: string;
+
+  @Field()
+  title: string;
+
+  @Field()
+  description: string;
+
+  @Field(() => [String])
+  permissions: string[];
+
+  @Field(() => [String])
+  dataAccess: string[];
+}
+
+@ObjectType()
+export class UpdateRoleResponse {
+  @Field()
+  success: boolean;
+
+  @Field(() => Role, { nullable: true })
+  role?: Role;
+}
+
+@Resolver()
+export class UpdateRoleMutation {
+  @Mutation(() => UpdateRoleResponse)
+  async updateRole(
+    @Arg('args') args: UpdateRoleArgs,
+    @Ctx() context: ResolverContext
+  ): Promise<UpdateRoleResponse> {
+    const role = (await context.mutations.user.updateRole(
+      context.user,
+      args
+    )) as Role | Error;
+    if (role instanceof Error) {
+      return {
+        success: false,
+        role: undefined,
+      };
+    }
+
+    return {
+      success: true,
+      role,
+    };
+  }
+}

--- a/apps/backend/src/resolvers/types/Role.ts
+++ b/apps/backend/src/resolvers/types/Role.ts
@@ -1,8 +1,10 @@
 import 'reflect-metadata';
 import { Field, ObjectType, Int } from 'type-graphql';
 
+import { Role as RoleOrigin } from '../../models/Role';
+
 @ObjectType()
-export class Role {
+export class Role implements Partial<RoleOrigin> {
   @Field(() => Int)
   public id: number;
 
@@ -15,11 +17,19 @@ export class Role {
   @Field()
   public description: string;
 
+  @Field(() => [String])
+  public dataAccess: string[];
+
+  @Field(() => [String])
+  public permissions: string[];
+
   constructor(initObj: {
     id: number;
     shortCode: string;
     title: string;
     description: string;
+    dataAccess: string[];
+    permissions: string[];
   }) {
     Object.assign(this, initObj);
   }

--- a/apps/frontend/src/components/AppRoutes.tsx
+++ b/apps/frontend/src/components/AppRoutes.tsx
@@ -9,6 +9,7 @@ import { FeatureId, UserRole, WorkflowType } from 'generated/sdk';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
 import { useTechniqueProposalAccess } from 'hooks/common/useTechniqueProposalAccess';
 
+import RoleManagement from './admin/RoleManagement';
 import ChangeRole from './common/ChangeRole';
 import OverviewPage from './pages/OverviewPage';
 import ProposalPage from './proposal/ProposalPage';
@@ -207,6 +208,14 @@ const AppRoutes = () => {
             element={<TitledRoute title="People" element={<PeoplePage />} />}
           />
         )}
+
+        <Route
+          path="/admin/roles"
+          element={
+            <TitledRoute title="Role creation" element={<RoleManagement />} />
+          }
+        />
+
         <Route
           path="/Proposals"
           element={<TitledRoute title="Proposals" element={<ProposalPage />} />}

--- a/apps/frontend/src/components/AppToolbar/RoleSelection.tsx
+++ b/apps/frontend/src/components/AppToolbar/RoleSelection.tsx
@@ -1,11 +1,11 @@
 import MaterialTable, { Column } from '@material-table/core';
 import Button from '@mui/material/Button';
-import React, { useContext, useState, useEffect } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import React, { useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { UserContext } from 'context/UserContextProvider';
 import { Role } from 'generated/sdk';
-import { getUniqueArrayBy } from 'utils/helperFunctions';
+import { useMeData } from 'hooks/user/useMeData';
 import { tableIcons } from 'utils/materialIcons';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 import { FunctionType } from 'utils/utilTypes';
@@ -30,36 +30,10 @@ const RoleSelection = ({ onClose }: { onClose: FunctionType }) => {
   const [loading, setLoading] = useState(false);
   const { api } = useDataApiWithFeedback();
   const navigate = useNavigate();
-  const [roles, setRoles] = useState<Role[]>([]);
+  const { meData, loading: meDataLoading } = useMeData();
 
-  useEffect(() => {
-    let unmounted = false;
-
-    const getUserInformation = async () => {
-      setLoading(true);
-      const data = await api().getMyRoles();
-      if (unmounted) {
-        return;
-      }
-
-      if (data?.me) {
-        /** NOTE: We have roles that are duplicated in role_id and user_id but different only in fap_id
-         *  which is used to determine if the user with that role is member of a Fap.
-         */
-        setRoles(getUniqueArrayBy(data.me?.roles, 'id'));
-        setLoading(false);
-      }
-    };
-    getUserInformation();
-
-    return () => {
-      unmounted = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  if (!roles) {
-    return <Navigate to="/SignIn" />;
+  if (!meData) {
+    return <p> Loading...</p>;
   }
 
   const selectUserRole = async (role: Role) => {
@@ -98,7 +72,7 @@ const RoleSelection = ({ onClose }: { onClose: FunctionType }) => {
     </>
   );
 
-  const rolesWithRoleAction = roles.map((role) => ({
+  const rolesWithRoleAction = meData.roles.map((role) => ({
     ...role,
     roleAction: RoleAction(role),
   }));
@@ -110,7 +84,7 @@ const RoleSelection = ({ onClose }: { onClose: FunctionType }) => {
         title="User roles"
         columns={columns}
         data={rolesWithRoleAction}
-        isLoading={loading}
+        isLoading={loading || meDataLoading}
         options={{
           search: false,
           paging: false,

--- a/apps/frontend/src/components/admin/RoleManagement.tsx
+++ b/apps/frontend/src/components/admin/RoleManagement.tsx
@@ -1,0 +1,153 @@
+import { Typography } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+
+import SuperMaterialTable from 'components/common/SuperMaterialTable';
+import { Role } from 'generated/sdk';
+import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
+import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
+import { FunctionType } from 'utils/utilTypes';
+
+import RoleModal from './RoleModal';
+
+const RoleManagement: React.FC = () => {
+  const [roles, setRoles] = useState<
+    {
+      id: number;
+      shortCode: string;
+      title: string;
+      description: string;
+      dataAccess: string[];
+      permissions: string[];
+    }[]
+  >([]);
+
+  const { api } = useDataApiWithFeedback();
+
+  useEffect(() => {
+    const fetchRoles = async () => {
+      try {
+        const response = await api().getRoles();
+        setRoles(
+          (response.roles || []).map((role) => ({
+            ...role,
+            dataAccess: role.dataAccess || undefined,
+            permissions: role.permissions || undefined,
+          }))
+        );
+      } catch (error) {
+        console.error('Error fetching roles:', error);
+      }
+    };
+
+    fetchRoles();
+  }, [api]);
+
+  const handleRoleSubmit = async () => {
+    // Refresh roles after create/update
+    api()
+      .getRoles()
+      .then((response) =>
+        setRoles(
+          (response.roles || []).map((role) => ({
+            ...role,
+            dataAccess: role.dataAccess || undefined,
+            permissions: role.permissions || undefined,
+          }))
+        )
+      );
+  };
+
+  interface RoleRow {
+    id: number;
+    shortCode: string;
+    title: string;
+    description: string;
+    dataAccess: string[];
+    permissions: string[];
+  }
+
+  const columns: Array<{
+    title: string;
+    field: keyof RoleRow;
+    render?: (rowData: RoleRow) => React.ReactNode;
+  }> = [
+    { title: 'Short Code', field: 'shortCode' },
+    { title: 'Title', field: 'title' },
+    { title: 'Description', field: 'description' },
+    {
+      title: 'Data Access',
+      field: 'dataAccess',
+      render: (rowData) => rowData.dataAccess?.join(', ') || '-',
+    },
+    {
+      title: 'Permissions',
+      field: 'permissions',
+      render: (rowData) => rowData.permissions?.join(', ') || '-',
+    },
+  ];
+  const deleteRole = async (id: number | string) => {
+    try {
+      await api({
+        toastSuccessMessage: 'Call deleted successfully',
+      }).deleteRole({
+        id: id as number,
+      });
+      const newObjectsArray = roles.filter(
+        (objectItem) => objectItem.id !== id
+      );
+      setRoles(newObjectsArray);
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  };
+
+  const createModal = (
+    onUpdate: FunctionType<void, [Role | null]>,
+    onCreate: FunctionType<void, [Role | null]>,
+    editRole: Role | null
+  ) => (
+    <RoleModal
+      open={!!editRole || true} // Ensure modal opens for both create and update
+      onClose={() => (!!editRole ? onUpdate(null) : onCreate(null))}
+      role={editRole} // Pass `null` for create mode, or the role object for update mode
+      onSubmit={() => {
+        handleRoleSubmit();
+        !!editRole ? onUpdate(null) : onCreate(null);
+      }}
+    />
+  );
+
+  return (
+    <StyledContainer maxWidth={false}>
+      <StyledPaper>
+        <Typography variant="h4">Role Management</Typography>
+        <SuperMaterialTable
+          createModal={createModal}
+          setData={setRoles}
+          delete={deleteRole}
+          hasAccess={{
+            create: true,
+            update: true,
+            remove: true,
+          }}
+          title={
+            <Typography variant="h6" component="h2">
+              Existing Roles
+            </Typography>
+          }
+          columns={columns}
+          data={roles}
+          isLoading={false}
+          options={{
+            search: true,
+            paging: true,
+          }}
+        />
+      </StyledPaper>
+    </StyledContainer>
+  );
+};
+
+export default RoleManagement;

--- a/apps/frontend/src/components/admin/RoleModal.tsx
+++ b/apps/frontend/src/components/admin/RoleModal.tsx
@@ -1,0 +1,277 @@
+import {
+  Dialog,
+  DialogContent,
+  Typography,
+  TextField,
+  Button,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormLabel,
+  Grid,
+} from '@mui/material';
+import React, { useState, useEffect } from 'react';
+
+import { useQueriesMutationsAndServicesData } from 'hooks/admin/useQueriesMutationsAndServicesData';
+import { useInstrumentsData } from 'hooks/instrument/useInstrumentsData';
+import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
+
+interface RoleModalProps {
+  open: boolean;
+  onClose: () => void;
+  role: {
+    id: number;
+    shortCode: string;
+    title: string;
+    description: string;
+    dataAccess?: string[];
+    permissions?: string[];
+  } | null;
+  onSubmit: () => void;
+}
+
+const RoleModal: React.FC<RoleModalProps> = ({
+  open,
+  onClose,
+  role,
+  onSubmit,
+}) => {
+  const isEditMode = !!role;
+  const [shortCode, setShortCode] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [dataAccess, setDataAccess] = useState<string[]>([]);
+  const [permissions, setPermissions] = useState<string[]>([]);
+  const { api } = useDataApiWithFeedback();
+  const { queriesMutationsAndServices, loadingQueriesMutationsAndServices } =
+    useQueriesMutationsAndServicesData();
+  const { instruments, loadingInstruments } = useInstrumentsData();
+
+  useEffect(() => {
+    if (isEditMode && role) {
+      setShortCode(role.shortCode || '');
+      setTitle(role.title || '');
+      setDescription(role.description || '');
+      setDataAccess(role.dataAccess || []);
+      setPermissions(role.permissions || []);
+    } else {
+      setShortCode('');
+      setTitle('');
+      setDescription('');
+      setDataAccess([]);
+      setPermissions([]);
+    }
+  }, [isEditMode, role]);
+
+  const handleSubmit = async () => {
+    const apiCall = isEditMode
+      ? api({
+          toastSuccessMessage: 'Role updated successfully',
+        }).updateRole({
+          args: {
+            roleID: role.id,
+            shortCode,
+            title,
+            description,
+            dataAccess,
+            permissions,
+          },
+        })
+      : api({
+          toastSuccessMessage: 'Role created successfully',
+        }).createRole({
+          args: {
+            shortCode,
+            title,
+            description,
+            dataAccess,
+            permissions,
+          },
+        });
+
+    try {
+      await apiCall;
+      onSubmit();
+      onClose();
+    } catch (error) {
+      console.error(error);
+      alert(
+        `An error occurred while ${
+          isEditMode ? 'updating' : 'creating'
+        } the role.`
+      );
+    }
+  };
+
+  const renderPermissions = () => {
+    if (loadingQueriesMutationsAndServices) {
+      return <Typography>Loading permissions...</Typography>;
+    }
+
+    return (
+      <FormControl component="fieldset" variant="standard" fullWidth>
+        <FormLabel component="legend">Permissions</FormLabel>
+        <FormGroup>
+          <Typography variant="subtitle1" gutterBottom>
+            Queries
+          </Typography>
+          <Grid container spacing={1}>
+            {queriesMutationsAndServices.queries.map((group, groupIndex) =>
+              group.items.map((query, index) => (
+                <Grid item md={6} xs={12} key={`${groupIndex}-${index}`}>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={permissions.includes(query)}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            setPermissions([...permissions, query]);
+                          } else {
+                            setPermissions(
+                              permissions.filter((perm) => perm !== query)
+                            );
+                          }
+                        }}
+                      />
+                    }
+                    label={query}
+                  />
+                </Grid>
+              ))
+            )}
+          </Grid>
+          <Typography
+            variant="subtitle1"
+            gutterBottom
+            style={{ marginTop: '20px' }}
+          >
+            Mutations
+          </Typography>
+          <Grid container spacing={1}>
+            {queriesMutationsAndServices.mutations.map((group, groupIndex) =>
+              group.items.map((mutation, index) => (
+                <Grid item md={6} xs={12} key={`${groupIndex}-${index}`}>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={permissions.includes(mutation)}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            setPermissions([...permissions, mutation]);
+                          } else {
+                            setPermissions(
+                              permissions.filter((perm) => perm !== mutation)
+                            );
+                          }
+                        }}
+                      />
+                    }
+                    label={mutation}
+                  />
+                </Grid>
+              ))
+            )}
+          </Grid>
+        </FormGroup>
+      </FormControl>
+    );
+  };
+
+  const renderDataAccess = () => {
+    if (loadingInstruments) {
+      return <Typography>Loading data access options...</Typography>;
+    }
+
+    return (
+      <FormControl component="fieldset" variant="standard" fullWidth>
+        <FormLabel component="legend">Data Access</FormLabel>
+        <FormGroup>
+          <Grid container spacing={1}>
+            {instruments.map((instrument, index) => (
+              <Grid item md={6} xs={12} key={index}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={dataAccess.includes(instrument.name)}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setDataAccess([...dataAccess, instrument.name]);
+                        } else {
+                          setDataAccess(
+                            dataAccess.filter(
+                              (access) => access !== instrument.name
+                            )
+                          );
+                        }
+                      }}
+                    />
+                  }
+                  label={instrument.name}
+                />
+              </Grid>
+            ))}
+          </Grid>
+        </FormGroup>
+      </FormControl>
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="role-dialog"
+      maxWidth="lg" // Set the maximum width to medium
+      fullWidth // Ensure the dialog takes the full width
+    >
+      <DialogContent>
+        <Typography variant="h6">
+          {isEditMode ? 'Update Role' : 'Create New Role'}
+        </Typography>
+        <TextField
+          label="Short Code"
+          value={shortCode}
+          onChange={(e) => setShortCode(e.target.value)}
+          fullWidth
+          margin="normal"
+          disabled={isEditMode}
+        />
+        <TextField
+          label="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          fullWidth
+          margin="normal"
+        />
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          fullWidth
+          margin="normal"
+        />
+        {/* Permissions Section */}
+        <div>
+          <Typography variant="h6">Permissions</Typography>
+          {renderPermissions()}
+        </div>
+        {/* Data Access Section */}
+        <div>
+          <Typography variant="h6">Data Access</Typography>
+          {renderDataAccess()}
+        </div>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          color="primary"
+          style={{ marginTop: '20px' }}
+        >
+          {isEditMode ? 'Update Role' : 'Create Role'}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default RoleModal;

--- a/apps/frontend/src/components/menu/MenuItems.tsx
+++ b/apps/frontend/src/components/menu/MenuItems.tsx
@@ -25,11 +25,11 @@ import {
 } from 'components/experiment/DateFilter';
 import { TimeSpan } from 'components/experiment/PresetDateSelector';
 import { FeatureContext } from 'context/FeatureContextProvider';
-import { UserContext } from 'context/UserContextProvider';
 import { FeatureId, SettingsId, UserRole } from 'generated/sdk';
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
 import { CallsDataQuantity, useCallsData } from 'hooks/call/useCallsData';
 import { useTechniqueProposalAccess } from 'hooks/common/useTechniqueProposalAccess';
+import { useMeData } from 'hooks/user/useMeData';
 
 import SettingsMenuListItem from './SettingsMenuListItem';
 import { TemplateMenuListItem } from './TemplateMenuListItem';
@@ -69,8 +69,7 @@ const ProposalsMenuListItem = () => {
 
 const MenuItems = ({ currentRole }: MenuItemsProps) => {
   const context = useContext(FeatureContext);
-  const userInfo = useContext(UserContext);
-
+  const { meData } = useMeData();
   const { t } = useTranslation();
   const { format } = useFormattedDateTime({
     settingsFormatToUse: SettingsId.DATE_FORMAT,
@@ -102,14 +101,17 @@ const MenuItems = ({ currentRole }: MenuItemsProps) => {
     CallsDataQuantity.MINIMAL
   ).calls;
 
-  const currentRoleInfo = userInfo.roles.find((role) => {
-    if (
-      role.shortCode.toLocaleLowerCase() === currentRole?.toLocaleLowerCase()
-    ) {
-      return true;
-    }
-  });
+  let currentRoleInfo = null;
 
+  if (meData) {
+    currentRoleInfo = meData.roles.find((role) => {
+      if (
+        role.shortCode.toLocaleLowerCase() === currentRole?.toLocaleLowerCase()
+      ) {
+        return true;
+      }
+    });
+  }
   const permissions = currentRoleInfo?.permissions;
   let dynamicMenuItems: React.ReactNode = null;
   const openCall = calls?.find((call) => call.isActive);

--- a/apps/frontend/src/components/menu/SettingsMenuListItem.tsx
+++ b/apps/frontend/src/components/menu/SettingsMenuListItem.tsx
@@ -3,6 +3,7 @@ import DisplaySettingsIcon from '@mui/icons-material/DisplaySettings';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import FunctionsIcon from '@mui/icons-material/Functions';
+import People from '@mui/icons-material/People';
 import Settings from '@mui/icons-material/Settings';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import VpnKey from '@mui/icons-material/VpnKey';
@@ -28,6 +29,7 @@ const menuMap = {
   ApiAccessTokens: '/ApiAccessTokens',
   Features: '/Features',
   Settings: '/Settings',
+  RoleManagement: '/admin/roles',
   SampleEsiTemplates: '/SampleEsiTemplates',
 };
 
@@ -133,6 +135,14 @@ const SettingsMenuListItem = () => {
               <VpnKey />
             </ListItemIcon>
             <ListItemText primary="API access tokens" />
+          </ListItemButton>
+        </Tooltip>
+        <Tooltip title="Role management">
+          <ListItemButton component={NavLink} to={menuMap['RoleManagement']}>
+            <ListItemIcon>
+              <People />
+            </ListItemIcon>
+            <ListItemText primary="Role management" />
           </ListItemButton>
         </Tooltip>
         <Tooltip title="Features">

--- a/apps/frontend/src/components/pages/OverviewPage.tsx
+++ b/apps/frontend/src/components/pages/OverviewPage.tsx
@@ -24,6 +24,7 @@ const Paper = ({ children }: { children: React.ReactNode }) => (
 );
 
 export default function OverviewPage(props: { userRole: UserRole }) {
+  console.log('OverviewPage', props.userRole);
   const [loadingContent, pageContent] = useGetPageContent(
     props.userRole === UserRole.USER ? PageName.HOMEPAGE : PageName.REVIEWPAGE
   );

--- a/apps/frontend/src/graphql/admin/createRole.graphql
+++ b/apps/frontend/src/graphql/admin/createRole.graphql
@@ -1,0 +1,5 @@
+mutation createRole($args: CreateRoleArgs!) {
+  createRole(args: $args) {
+    success
+  }
+}

--- a/apps/frontend/src/graphql/admin/deleteRole.graphql
+++ b/apps/frontend/src/graphql/admin/deleteRole.graphql
@@ -1,0 +1,5 @@
+mutation deleteRole($id: Int!) {
+  deleteRole(roleId: $id) {
+    id
+  }
+}

--- a/apps/frontend/src/graphql/admin/updateRole.graphql
+++ b/apps/frontend/src/graphql/admin/updateRole.graphql
@@ -1,0 +1,5 @@
+mutation updateRole($args: UpdateRoleArgs!) {
+  updateRole(args: $args) {
+    success
+  }
+}

--- a/apps/frontend/src/graphql/user/getMyRoles.graphql
+++ b/apps/frontend/src/graphql/user/getMyRoles.graphql
@@ -7,6 +7,8 @@ query getMyRoles {
       shortCode
       title
       description
+      dataAccess
+      permissions
     }
   }
 }

--- a/apps/frontend/src/graphql/user/getRoles.graphql
+++ b/apps/frontend/src/graphql/user/getRoles.graphql
@@ -4,5 +4,7 @@ query getRoles {
     shortCode
     title
     description
+    dataAccess
+    permissions
   }
 }

--- a/apps/frontend/src/graphql/user/getUserWithRoles.graphql
+++ b/apps/frontend/src/graphql/user/getUserWithRoles.graphql
@@ -7,6 +7,8 @@ query getUserWithRoles($userId: Int!) {
       shortCode
       title
       description
+      dataAccess
+      permissions
     }
   }
 }

--- a/apps/frontend/src/hooks/user/useMeData.ts
+++ b/apps/frontend/src/hooks/user/useMeData.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+import { GetMyRolesQuery } from 'generated/sdk';
+import { useDataApi } from 'hooks/common/useDataApi';
+
+export function useMeData() {
+  const api = useDataApi();
+  const [meData, setMeData] = useState<GetMyRolesQuery['me']>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let unmounted = false;
+
+    setLoading(true);
+    api()
+      .getMyRoles()
+      .then((data) => {
+        if (unmounted) {
+          return;
+        }
+
+        setMeData(data.me);
+        setLoading(false);
+      });
+
+    return () => {
+      unmounted = true;
+    };
+  }, [api]);
+
+  return { loading, meData, setMeData } as const;
+}


### PR DESCRIPTION
## Description
This PR introduces dynamic role creation in the system, it is very much a proof of concept but the basic functionality works. A new role can be created and a certain set of data access and permissions can be attached. The permissions are the same as are set for the API token and data access is based upon instruments. One could imagine to have a broader set of data access such as techniques or call. 


## Motivation and Context
The purpose of this change is to provide a more flexible and scalable user permissions management system. This will allow roles to be created dynamically, along with their associated permissions and data access rules, thereby enhancing the system's ability to adapt to changing requirements.

## Changes
1. Modified the 'roles' table in the database to include 'permissions' and 'data_access' fields.
2. Updated the UserDataSource interface and its mock implementation to include methods for creating, updating, and deleting roles.
3. Implemented checks for data access permissions in the ProposalAuthorization class. This includes retrieving the instruments associated with a proposal and checking if the user's current role has data access rights for those instruments.
4. Updated the Role model and its usage across various files to include the new 'permissions' and 'data_access' fields.

## Screenshots

![Screenshot 2025-05-08 at 15 15 06](https://github.com/user-attachments/assets/f4631879-9236-401f-80fa-31d07bcca30a)
![Screenshot 2025-05-08 at 15 14 50](https://github.com/user-attachments/assets/769e142c-bafb-4683-ae14-7112dd3959e2)
![Screenshot 2025-05-08 at 15 14 36](https://github.com/user-attachments/assets/7290c60e-36ac-4a6f-a33a-3f71b694af9d)
![Screenshot 2025-05-08 at 15 14 20](https://github.com/user-attachments/assets/3c115ef2-7c53-4f12-a791-42450f87ea38)
