### PR TITLE
feat: Allow for instruments to be add to call without being selectable

### DIFF
--- a/apps/backend/db_patches/0180_MarkInstrumentsAsUnselectable.sql
+++ b/apps/backend/db_patches/0180_MarkInstrumentsAsUnselectable.sql
@@ -1,0 +1,14 @@
+DO
+$$
+BEGIN
+	IF register_patch('0180_MarkInstrumentsAsUnselectable.sql', 'TCMeldrum', 'Mark instruments as unselecable for instrument picker', '2025-05-25') THEN
+	BEGIN
+
+    ALTER TABLE instruments
+    ADD COLUMN selectable boolean DEFAULT true; 
+
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/backend/src/datasources/InstrumentDataSource.ts
+++ b/apps/backend/src/datasources/InstrumentDataSource.ts
@@ -19,7 +19,8 @@ export interface InstrumentDataSource {
   ): Promise<{ totalCount: number; instruments: Instrument[] }>;
   getUserInstruments(userId: number): Promise<Instrument[]>;
   getInstrumentsByCallId(
-    callIds: number[]
+    callIds: number[],
+    selectableOnly?: boolean
   ): Promise<InstrumentWithAvailabilityTime[]>;
   getCallsByInstrumentId(
     instrumentId: number,

--- a/apps/backend/src/datasources/postgres/InstrumentDataSource.ts
+++ b/apps/backend/src/datasources/postgres/InstrumentDataSource.ts
@@ -41,7 +41,8 @@ export default class PostgresInstrumentDataSource
       instrument.name,
       instrument.short_code,
       instrument.description,
-      instrument.manager_user_id
+      instrument.manager_user_id,
+      instrument.selectable
     );
   }
 
@@ -80,6 +81,7 @@ export default class PostgresInstrumentDataSource
         short_code: args.shortCode,
         description: args.description,
         manager_user_id: args.managerUserId,
+        selectable: !!args.selectable,
       })
       .into('instruments')
       .returning('*');
@@ -153,7 +155,8 @@ export default class PostgresInstrumentDataSource
   }
 
   async getInstrumentsByCallId(
-    callIds: number[]
+    callIds: number[],
+    selectableOnly?: boolean
   ): Promise<InstrumentWithAvailabilityTime[]> {
     return database
       .select([
@@ -170,6 +173,11 @@ export default class PostgresInstrumentDataSource
         'i.instrument_id': 'chi.instrument_id',
       })
       .whereIn('chi.call_id', callIds)
+      .modify((query) => {
+        if (selectableOnly) {
+          query.andWhere('i.selectable', true);
+        }
+      })
       .distinct('i.instrument_id')
       .then((instruments: InstrumentWithAvailabilityTimeRecord[]) => {
         const result = instruments.map((instrument) =>
@@ -286,6 +294,7 @@ export default class PostgresInstrumentDataSource
           short_code: instrument.shortCode,
           description: instrument.description,
           manager_user_id: instrument.managerUserId,
+          selectable: instrument.selectable ?? false,
         },
         ['*']
       )

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -484,6 +484,7 @@ export interface InstrumentRecord {
   readonly description: string;
   readonly manager_user_id: number;
   readonly full_count: number;
+  readonly selectable: boolean;
 }
 
 export interface InstrumentHasProposalRecord {
@@ -823,7 +824,8 @@ export const createInstrumentObject = (instrument: InstrumentRecord) => {
     instrument.name,
     instrument.short_code,
     instrument.description,
-    instrument.manager_user_id
+    instrument.manager_user_id,
+    instrument.selectable
   );
 };
 

--- a/apps/backend/src/models/Instrument.ts
+++ b/apps/backend/src/models/Instrument.ts
@@ -4,7 +4,8 @@ export class Instrument {
     public name: string,
     public shortCode: string,
     public description: string,
-    public managerUserId: number
+    public managerUserId: number,
+    public selectable?: boolean
   ) {}
 }
 

--- a/apps/backend/src/models/questionTypes/InstrumentPicker.ts
+++ b/apps/backend/src/models/questionTypes/InstrumentPicker.ts
@@ -64,9 +64,10 @@ export const instrumentPickerDefinition: Question<DataType.INSTRUMENT_PICKER> =
           Tokens.InstrumentDataSource
         );
 
-        const instruments = await instrumentDataSource.getInstrumentsByCallId([
-          callId,
-        ]);
+        const instruments = await instrumentDataSource.getInstrumentsByCallId(
+          [callId],
+          true
+        );
 
         return {
           ...config,

--- a/apps/backend/src/resolvers/mutations/CreateInstrumentMutation.ts
+++ b/apps/backend/src/resolvers/mutations/CreateInstrumentMutation.ts
@@ -24,6 +24,9 @@ export class CreateInstrumentArgs {
 
   @Field(() => Int)
   public managerUserId: number;
+
+  @Field(() => Boolean, { nullable: true, defaultValue: true })
+  public selectable?: boolean;
 }
 
 @Resolver()

--- a/apps/backend/src/resolvers/mutations/UpdateInstrumentMutation.ts
+++ b/apps/backend/src/resolvers/mutations/UpdateInstrumentMutation.ts
@@ -31,6 +31,9 @@ export class UpdateInstrumentArgs {
 
   @Field(() => Boolean)
   public updateTechReview: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  public selectable?: boolean;
 }
 
 @ArgsType()

--- a/apps/backend/src/resolvers/types/Instrument.ts
+++ b/apps/backend/src/resolvers/types/Instrument.ts
@@ -32,6 +32,9 @@ export class Instrument implements Partial<InstrumentOrigin> {
 
   @Field(() => Int)
   public managerUserId: number;
+
+  @Field(() => Boolean, { nullable: true })
+  public selectable?: boolean;
 }
 
 @ObjectType()

--- a/apps/frontend/src/components/instrument/CreateUpdateInstrument.tsx
+++ b/apps/frontend/src/components/instrument/CreateUpdateInstrument.tsx
@@ -48,7 +48,9 @@ const CreateUpdateInstrument = ({
   const [usersData, setUsersData] = useState(
     instrument?.instrumentContact ? [instrument?.instrumentContact] : []
   );
-  const [isChecked, setIsChecked] = useState(false);
+  const [isReviewerUpdateChecked, setIsReviewerUpdateChecked] = useState(false);
+
+  console.log(instrument);
 
   const initialValues = instrument
     ? { ...instrument, surname: '' }
@@ -58,6 +60,7 @@ const CreateUpdateInstrument = ({
         description: '',
         managerUserId: null,
         surname: '',
+        selectable: true,
       };
 
   useEffect(() => {
@@ -136,7 +139,10 @@ const CreateUpdateInstrument = ({
         return;
       }
 
-      if (values.managerUserId !== instrument.managerUserId && isChecked) {
+      if (
+        values.managerUserId !== instrument.managerUserId &&
+        isReviewerUpdateChecked
+      ) {
         confirm(
           async () => {
             try {
@@ -164,6 +170,7 @@ const CreateUpdateInstrument = ({
                 description: updatedValues.description,
                 managerUserId: updatedValues.managerUserId,
                 updateTechReview: true,
+                selectable: updatedValues.selectable,
               });
 
               close(updateInstrument);
@@ -188,6 +195,7 @@ const CreateUpdateInstrument = ({
             description: updatedValues.description,
             managerUserId: updatedValues.managerUserId,
             updateTechReview: false,
+            selectable: updatedValues.selectable,
           });
 
           close(updateInstrument);
@@ -262,6 +270,16 @@ const CreateUpdateInstrument = ({
             disabled={isExecutingCall}
             required
           />
+          <FormControlLabel
+            control={
+              <Checkbox
+                icon={<CheckBoxOutlineBlankIcon />}
+                checkedIcon={<CheckBoxIcon />}
+                checked={formikProps.values.selectable}
+              />
+            }
+            label="Allow this instrument to be selectable in proposal submission"
+          />
           <SurnameSearchField {...formikProps} />
           <FormikUIAutocomplete
             name="managerUserId"
@@ -287,8 +305,10 @@ const CreateUpdateInstrument = ({
                   <Checkbox
                     icon={<CheckBoxOutlineBlankIcon />}
                     checkedIcon={<CheckBoxIcon />}
-                    checked={isChecked}
-                    onChange={(event) => setIsChecked(event.target.checked)}
+                    checked={isReviewerUpdateChecked}
+                    onChange={(event) =>
+                      setIsReviewerUpdateChecked(event.target.checked)
+                    }
                   />
                 }
                 label="Update all un-assigned technical reviews to new contact"

--- a/apps/frontend/src/graphql/instrument/createInstrument.graphql
+++ b/apps/frontend/src/graphql/instrument/createInstrument.graphql
@@ -3,12 +3,14 @@ mutation createInstrument(
   $shortCode: String!
   $description: String!
   $managerUserId: Int!
+  $selectable: Boolean
 ) {
   createInstrument(
     name: $name
     shortCode: $shortCode
     description: $description
     managerUserId: $managerUserId
+    selectable: $selectable
   ) {
     ...instrument
   }

--- a/apps/frontend/src/graphql/instrument/instrument.fragment.graphql
+++ b/apps/frontend/src/graphql/instrument/instrument.fragment.graphql
@@ -4,6 +4,7 @@ fragment instrument on Instrument {
   shortCode
   description
   managerUserId
+  selectable
   instrumentContact {
     ...basicUserDetails
   }

--- a/apps/frontend/src/graphql/instrument/updateInstrument.graphql
+++ b/apps/frontend/src/graphql/instrument/updateInstrument.graphql
@@ -5,6 +5,7 @@ mutation updateInstrument(
   $description: String!
   $managerUserId: Int!
   $updateTechReview: Boolean!
+  $selectable: Boolean
 ) {
   updateInstrument(
     id: $id
@@ -13,6 +14,7 @@ mutation updateInstrument(
     description: $description
     managerUserId: $managerUserId
     updateTechReview: $updateTechReview
+    selectable: $selectable
   ) {
     ...instrument
   }


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1238

## Description

Since the facilities work #1020 is still being reviewed and the Role Based permissions is in Proof of concept https://github.com/UserOfficeProject/user-office-core/pull/1054 STFC need a work around to allow instrument scienctist access to proposal data while not being on a instrument on the call. This PR allows us to add instruments to calls without having them be selectable to users. We then will have all the other instrument scientists on one of these "hidden" instruments. At STFC we have it set up currently so that instrument scientists can see all the proposasl on the calls that thier instruments are on (this logic would be simplified with facilitys) they will then be able to see proposals data.

This is a work around that I would remove once we have facilities or the role based permissions set up. 

## Motivation and Context

At STFC we need to have people who are not on instruments to be able to see proposals.

## How Has This Been Tested

Manual testing

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

- Adds a selectable column to the instrument table that then instument picker question will filter out all the un-selectable instruments

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
