### PR TITLE
fix: amend code to allow fap specific proposal count

### DIFF
--- a/apps/backend/src/datasources/FapDataSource.ts
+++ b/apps/backend/src/datasources/FapDataSource.ts
@@ -83,7 +83,10 @@ export interface FapDataSource {
   getFapProposalCount(fapId: number): Promise<number>;
   getCurrentFapProposalCount(fapId: number): Promise<number>;
   getFapReviewerProposalCount(reviewerId: number): Promise<number>;
-  getCurrentFapReviewerProposalCount(reviewerId: number): Promise<number>;
+  getCurrentFapReviewerProposalCount(
+    reviewerId: number,
+    fapId: number
+  ): Promise<number>;
   getFapProposal(
     fapId: number,
     proposalPk: number,

--- a/apps/backend/src/datasources/mockups/FapDataSource.ts
+++ b/apps/backend/src/datasources/mockups/FapDataSource.ts
@@ -358,7 +358,7 @@ export class FapDataSourceMock implements FapDataSource {
     return dummyFapProposals.length;
   }
 
-  async getCurrentFapReviewerProposalCount(reviewerId: number) {
+  async getCurrentFapReviewerProposalCount(reviewerId: number, fapId: number) {
     return dummyFapProposals.length;
   }
 

--- a/apps/backend/src/datasources/postgres/FapDataSource.ts
+++ b/apps/backend/src/datasources/postgres/FapDataSource.ts
@@ -406,7 +406,8 @@ export default class PostgresFapDataSource implements FapDataSource {
   }
 
   async getCurrentFapReviewerProposalCount(
-    reviewerId: number
+    reviewerId: number,
+    fapId: number
   ): Promise<number> {
     const callFilter = {
       isFapReviewEnded: false,
@@ -424,6 +425,7 @@ export default class PostgresFapDataSource implements FapDataSource {
       })
       .whereIn('fp.call_id', callIds)
       .andWhere('fr.user_id', reviewerId)
+      .andWhere('fr.fap_id', fapId)
       .groupBy('fr.user_id')
       .first()
       .then((result: { count?: string | undefined } | undefined) => {

--- a/apps/backend/src/resolvers/types/Fap.ts
+++ b/apps/backend/src/resolvers/types/Fap.ts
@@ -81,7 +81,8 @@ export class FapResolvers {
         userId: fapChairUserId,
         count:
           context.queries.fap.dataSource.getCurrentFapReviewerProposalCount(
-            fapChairUserId
+            fapChairUserId,
+            fap.id
           ),
       };
     });
@@ -112,7 +113,8 @@ export class FapResolvers {
         userId: fapSecretariesUserId,
         count:
           context.queries.fap.dataSource.getCurrentFapReviewerProposalCount(
-            fapSecretariesUserId
+            fapSecretariesUserId,
+            fap.id
           ),
       };
     });

--- a/apps/backend/src/resolvers/types/FapReviewers.ts
+++ b/apps/backend/src/resolvers/types/FapReviewers.ts
@@ -53,7 +53,8 @@ export class FapUserResolver {
     @Ctx() context: ResolverContext
   ) {
     return context.queries.fap.dataSource.getCurrentFapReviewerProposalCount(
-      fapMember.userId
+      fapMember.userId,
+      fapMember.fapId
     );
   }
 }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Closes [#1398](https://github.com/UserOfficeProject/issue-tracker/issues/1398)
## Description

<!--- Describe your changes in detail -->
This change updates the logic of how proposal counts are displayed for FAP members. Previously, the proposal count was being aggregated across multiple FAPs, causing the same member to show the combined proposal count across all FAPs they belong to. With this update, the proposal count is now FAP-specific, ensuring that each FAP's proposal count is correctly displayed for the respective member.

![image](https://github.com/user-attachments/assets/0bf19d2d-7366-4d08-a570-db1ff827d268)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required because the previous logic was incorrectly summing proposal counts across multiple FAPs. For example, if a user is assigned 2 proposals in FAP1 and 3 proposals in FAP2, the system was showing 5 proposals in both FAP1 and FAP2, which was inaccurate. The new logic ensures the proposal count is FAP-specific, reflecting the correct number of proposals for each FAP a user is part of.


## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
