### PR TITLE
fix: backfill the submitted date field in the proposals table

### DIFF
--- a/apps/backend/db_patches/0181_BackfillSubmittedDate.sql
+++ b/apps/backend/db_patches/0181_BackfillSubmittedDate.sql
@@ -1,0 +1,22 @@
+DO
+$$
+BEGIN
+	IF register_patch('0181_BackfillSubmittedDate.sql', 'ACLay', 'Set submitted date column on proposals that predate it', '2025-05-19') THEN
+	BEGIN
+
+    UPDATE proposals AS p 
+       SET submitted_date = (SELECT MAX(logs.event_tstamp)
+                               FROM event_logs logs
+                              WHERE logs.changed_object_id = CAST(p.proposal_pk AS VARCHAR)
+                                    AND logs.event_type = 'PROPOSAL_SUBMITTED')
+     WHERE p.submitted
+           AND p.submitted_date IS NULL
+           AND CAST(p.proposal_pk AS VARCHAR) IN (SELECT changed_object_id
+                                                    FROM event_logs
+                                                   WHERE event_type = 'PROPOSAL_SUBMITTED');
+
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Adds a database patch to fill in missing values from the submitted_date column in the proposals table using values from the event log.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It ensures that our data is consistent, simplifying any queries we perform so that they don't have to be aware of historic ways to store/query submission dates.

## How Has This Been Tested

I've run the patch against my local install, using a combination of manually inserted dummy events, and complete copies of our production database.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1353

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
