### PR TITLE
chore: remove depreciated option

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged --shell
+npx lint-staged


### PR DESCRIPTION
The pre commit hook has been upated and the `--shell` option has been removed: https://github.com/lint-staged/lint-staged/releases/tag/v16.0.0. As far as I can tell the `--shell` options was only useful if we were running shell commands in our pre commit hooks but I don't think we are: https://github.com/UserOfficeProject/user-office-core/blob/develop/.lintstagedrc.json

I have just removed the `--shell` option but let me know if there is a reason we needed it.
