### PR TITLE
fix: add impersonation logs

### DIFF
--- a/apps/backend/db_patches/0182_AddImpersonatingUserIdToEventLogs.sql
+++ b/apps/backend/db_patches/0182_AddImpersonatingUserIdToEventLogs.sql
@@ -1,0 +1,12 @@
+DO
+$$
+BEGIN
+	IF register_patch('AddImpersonatingUserIdToEventLogs.sql', 'RasmiaKulan', 'Add impersonating user id column to the event logs table', '2025-06-09') THEN
+		BEGIN
+    	ALTER TABLE event_logs 
+            ADD COLUMN impersonating_user_id INTEGER;
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/backend/src/datasources/EventLogsDataSource.ts
+++ b/apps/backend/src/datasources/EventLogsDataSource.ts
@@ -6,7 +6,8 @@ export interface EventLogsDataSource {
     eventType: string,
     rowData: string,
     changedObjectId: string,
-    description?: string
+    description?: string,
+    impersonatingUserId?: number
   ): Promise<EventLog>;
   get(filter: EventLogFilter): Promise<EventLog[]>;
 }

--- a/apps/backend/src/datasources/postgres/EventLogsDataSource.ts
+++ b/apps/backend/src/datasources/postgres/EventLogsDataSource.ts
@@ -32,7 +32,7 @@ export default class PostgresEventLogsDataSource
     const actingUserId = impersonatingUserId ?? changedBy;
 
     const updatedDescription = isImpersonating
-      ? `${description || ''} (${impersonatingUserId} impersonating ${changedBy})`
+      ? `${description || ''} (userId:${impersonatingUserId} impersonating userId:${changedBy})`
       : description;
 
     return database
@@ -42,6 +42,7 @@ export default class PostgresEventLogsDataSource
         row_data: rowData,
         changed_object_id: changedObjectId,
         description: updatedDescription,
+        impersonating_user_id: impersonatingUserId,
       })
       .returning('*')
       .into('event_logs')

--- a/apps/backend/src/decorators/EventBus.ts
+++ b/apps/backend/src/decorators/EventBus.ts
@@ -39,6 +39,8 @@ const EventBusDecorator = (eventType: Event) => {
           loggedInUserId: loggedInUser ? loggedInUser.id : null,
           isRejection: isRejection(result),
           inputArgs: JSON.stringify(restArgs),
+          description: result.description,
+          impersonatingUserId: loggedInUser.impersonatingUserId,
         } as ApplicationEvent;
 
         const eventBus = resolveApplicationEventBus();

--- a/apps/backend/src/decorators/EventBus.ts
+++ b/apps/backend/src/decorators/EventBus.ts
@@ -39,7 +39,6 @@ const EventBusDecorator = (eventType: Event) => {
           loggedInUserId: loggedInUser ? loggedInUser.id : null,
           isRejection: isRejection(result),
           inputArgs: JSON.stringify(restArgs),
-          description: result.description,
           impersonatingUserId: loggedInUser.impersonatingUserId,
         } as ApplicationEvent;
 

--- a/apps/backend/src/eventHandlers/logging.ts
+++ b/apps/backend/src/eventHandlers/logging.ts
@@ -96,7 +96,8 @@ export default function createLoggingHandler() {
                   event.type,
                   json,
                   proposalPk.toString(),
-                  description
+                  description,
+                  event.impersonatingUserId
                 );
               }
             )
@@ -117,7 +118,8 @@ export default function createLoggingHandler() {
                 event.type,
                 json,
                 proposalPk.toString(),
-                description
+                description,
+                event.impersonatingUserId
               );
             })
           );
@@ -138,7 +140,8 @@ export default function createLoggingHandler() {
                 event.type,
                 json,
                 fapProposal.proposalPk.toString(),
-                description
+                description,
+                event.impersonatingUserId
               );
             })
           );
@@ -158,7 +161,8 @@ export default function createLoggingHandler() {
                 event.type,
                 json,
                 proposal.primaryKey.toString(),
-                description
+                description,
+                event.impersonatingUserId
               );
             })
           );
@@ -184,7 +188,8 @@ export default function createLoggingHandler() {
                   event.type,
                   json,
                   proposalPk.toString(),
-                  description
+                  description,
+                  event.impersonatingUserId
                 );
               }
             )
@@ -206,7 +211,8 @@ export default function createLoggingHandler() {
                   event.type,
                   json,
                   proposalPk.toString(),
-                  description
+                  description,
+                  event.impersonatingUserId
                 );
               }
             )
@@ -254,7 +260,8 @@ export default function createLoggingHandler() {
                 event.type,
                 json,
                 obj[0].techniqueId,
-                description
+                description,
+                event.impersonatingUserId
               );
             }
           }
@@ -280,7 +287,8 @@ export default function createLoggingHandler() {
                 event.type,
                 json,
                 obj[0].techniqueId,
-                description
+                description,
+                event.impersonatingUserId
               );
             }
           }
@@ -303,7 +311,8 @@ export default function createLoggingHandler() {
                 event.type,
                 json,
                 obj[0].proposalPk,
-                description
+                description,
+                event.impersonatingUserId
               );
             }
           }
@@ -318,7 +327,8 @@ export default function createLoggingHandler() {
                 event.type,
                 json,
                 event.visitregistration.visitId.toString(),
-                description
+                description,
+                event.impersonatingUserId
               );
             }
           }
@@ -332,7 +342,8 @@ export default function createLoggingHandler() {
                 event.type,
                 json,
                 event.visitregistration.visitId.toString(),
-                description
+                description,
+                event.impersonatingUserId
               );
             }
           }
@@ -353,7 +364,8 @@ export default function createLoggingHandler() {
             event.type,
             json,
             changedObjectId.toString(),
-            description
+            description,
+            event.impersonatingUserId
           );
           break;
         }

--- a/apps/backend/src/events/applicationEvents.ts
+++ b/apps/backend/src/events/applicationEvents.ts
@@ -21,6 +21,7 @@ interface GeneralEvent {
   isRejection: boolean;
   inputArgs?: string;
   description?: string;
+  impersonatingUserId?: number;
   exchange?: string;
 }
 

--- a/apps/backend/src/models/EventLog.ts
+++ b/apps/backend/src/models/EventLog.ts
@@ -6,6 +6,7 @@ export class EventLog {
     public rowData: string,
     public eventTStamp: Date,
     public changedObjectId: string,
-    public description: string
+    public description: string,
+    public impersonatingUserId?: number
   ) {}
 }

--- a/apps/backend/src/mutations/UserMutations.ts
+++ b/apps/backend/src/mutations/UserMutations.ts
@@ -1,3 +1,4 @@
+import { logger } from '@user-office-software/duo-logger';
 import {
   addUserRoleValidationSchema,
   createUserByEmailInviteValidationSchema,
@@ -289,6 +290,13 @@ export default class UserMutations {
       impersonatingUserId:
         isUserOfficer && shouldImpersonateUser ? agent?.id : undefined,
     });
+
+    if (isUserOfficer && shouldImpersonateUser && agent) {
+      logger.logInfo(
+        `User officer ${agent.id} impersonated user ${userId}`,
+        {}
+      );
+    }
 
     return token;
   }

--- a/apps/backend/src/mutations/UserMutations.ts
+++ b/apps/backend/src/mutations/UserMutations.ts
@@ -292,7 +292,7 @@ export default class UserMutations {
     });
 
     if (isUserOfficer && shouldImpersonateUser && agent) {
-      logger.logInfo(`userId ${agent.id} impersonating userId ${userId}`, {});
+      logger.logInfo(`userId: ${agent.id} impersonating userId: ${userId}`, {});
     }
 
     return token;

--- a/apps/backend/src/mutations/UserMutations.ts
+++ b/apps/backend/src/mutations/UserMutations.ts
@@ -292,10 +292,7 @@ export default class UserMutations {
     });
 
     if (isUserOfficer && shouldImpersonateUser && agent) {
-      logger.logInfo(
-        `User officer ${agent.id} impersonated user ${userId}`,
-        {}
-      );
+      logger.logInfo(`userId ${agent.id} impersonating userId ${userId}`, {});
     }
 
     return token;

--- a/apps/e2e/cypress/e2e/eventLogs.cy.ts
+++ b/apps/e2e/cypress/e2e/eventLogs.cy.ts
@@ -104,5 +104,38 @@ context('Event log tests', () => {
       cy.get('@lastRowText').should('contain', 'USER_UPDATED');
       cy.get('@lastRowText').should('contain', updateProfileDate);
     });
+
+    it('If user impersonates someone, it reflects in the action logs', () => {
+      cy.login('officer');
+      cy.visit('/People');
+
+      cy.finishedLoading();
+
+      cy.contains(user.firstName)
+        .parent()
+        .find('button[aria-label="Edit user"]')
+        .click();
+
+      cy.get('.MuiTabs-flexContainer > #horizontal-tab-1').click();
+      cy.get('[data-cy="add-role-button"]').click();
+      cy.get('input[type="checkbox"]').eq(1).check();
+      cy.get('[data-cy="assign-role-to-user"]').click();
+
+      cy.get('.MuiTabs-flexContainer > #horizontal-tab-0').click();
+      cy.get('[data-cy="impersonate-user-button"]').click();
+
+      cy.get('[data-cy="profile-page-btn"]').click();
+      cy.get('[data-cy="change-roles-button"]').click();
+      cy.get('[data-cy="select-role-user_officer"]').click();
+
+      cy.get('[href="/Faps"]').click();
+      cy.get('[aria-label="Edit"]').click();
+      cy.get('.MuiTabs-flexContainer > #horizontal-tab-1').click();
+      cy.get('[data-cy="add-participant-button"]').click();
+      cy.get('input[type="checkbox"]').eq(0).check();
+      cy.get('[data-cy="assign-selected-users"]').click();
+      cy.get('.MuiTabs-flexContainer > #horizontal-tab-6').click();
+      cy.contains('2 impersonating 1');
+    });
   });
 });

--- a/apps/e2e/cypress/e2e/eventLogs.cy.ts
+++ b/apps/e2e/cypress/e2e/eventLogs.cy.ts
@@ -135,7 +135,7 @@ context('Event log tests', () => {
       cy.get('input[type="checkbox"]').eq(0).check();
       cy.get('[data-cy="assign-selected-users"]').click();
       cy.get('.MuiTabs-flexContainer > #horizontal-tab-6').click();
-      cy.contains('2 impersonating 1');
+      cy.contains('userId:2 impersonating userId:1');
     });
   });
 });

--- a/apps/frontend/src/components/review/ProposalReviewContent.tsx
+++ b/apps/frontend/src/components/review/ProposalReviewContent.tsx
@@ -18,6 +18,7 @@ import {
   CoreTechnicalReviewFragment,
   InstrumentWithManagementTime,
   Review,
+  TechnicalReview,
   UserRole,
 } from 'generated/sdk';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
@@ -31,6 +32,7 @@ import { getFullUserName } from 'utils/user';
 import ProposalReviewContainer from './ProposalReviewContainer';
 import ProposalTechnicalReviewerAssignment from './ProposalTechnicalReviewerAssignment';
 import TechnicalReviewContainer from './TechnicalReviewContainer';
+import TechnicalReviewInformation from './TechnicalReviewInformation';
 import TechnicalReviewQuestionaryReview from './TechnicalReviewQuestionaryReview';
 import InternalReviews from '../internalReview/InternalReviews';
 
@@ -184,13 +186,11 @@ const ProposalReviewContent = ({
             ></TechnicalReviewContainer>
           </Paper>
         </Fragment>
+      ) : !isUserOfficer && !isFapSec ? (
+        <TechnicalReviewInformation data={technicalReview as TechnicalReview} />
       ) : (
         <TechnicalReviewQuestionaryReview
-          data={
-            (!isUserOfficer && !isFapSec
-              ? { ...technicalReview, comment: null }
-              : technicalReview) as TechnicalReviewWithQuestionary
-          }
+          data={technicalReview as TechnicalReviewWithQuestionary}
         />
       );
     }

--- a/apps/frontend/src/components/user/RoleTable.tsx
+++ b/apps/frontend/src/components/user/RoleTable.tsx
@@ -55,7 +55,7 @@ const RoleTable = ({ add, activeRoles }: RoleTableProps) => {
           type="button"
           onClick={() => add(selectedRoles)}
           disabled={selectedRoles.length === 0 || loading}
-          data-cy="assign-instrument-to-call"
+          data-cy="assign-role-to-user"
         >
           Update
         </Button>

--- a/apps/frontend/src/components/user/UpdateUserInformation.tsx
+++ b/apps/frontend/src/components/user/UpdateUserInformation.tsx
@@ -331,7 +331,7 @@ export default function UpdateUserInformation(
               <ImpersonateButton
                 userId={props.id}
                 startIcon={<SwitchAccountOutlinedIcon />}
-                data-cy="impersonate-button"
+                data-cy="impersonate-user-button"
               >
                 Connect as this user...
               </ImpersonateButton>

--- a/apps/frontend/src/components/user/UpdateUserInformation.tsx
+++ b/apps/frontend/src/components/user/UpdateUserInformation.tsx
@@ -331,6 +331,7 @@ export default function UpdateUserInformation(
               <ImpersonateButton
                 userId={props.id}
                 startIcon={<SwitchAccountOutlinedIcon />}
+                data-cy="impersonate-button"
               >
                 Connect as this user...
               </ImpersonateButton>


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1406
<!--- Describe your changes in detail -->
This PR ensures that the event log correctly reflects actions taken by an impersonating user, rather than attributing those actions to the impersonated user. It also explicitly mentions impersonated actions in the event logs which provides accurate accountability.

![image](https://github.com/user-attachments/assets/4b83935a-32bc-4e0b-b7fb-e53b73dcecce)



## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Previously, the event logs would misleadingly show the impersonated user as the actor for actions, obscuring the identity of the actual user taking those actions. 
## How Has This Been Tested
This PR adds a new Cypress test to verify that the correct user (impersonator) is recorded in the event logs when actions are taken during an impersonation session.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Changes

1. Introduced an `impersonatingUserId` field in the `EventLogsDataSource` and implemented logic to detect impersonation, ensuring the event log descriptions accurately reflect the impersonating user when applicable.
2. Updated the `EventBus` to include `impersonatingUserId` when creating an `ApplicationEvent`. This ensures that events triggered through the bus correctly capture impersonation context for improved traceability.
3. Updated the `logging` to include impersonatingUserId in all relevent event logging calls.
4. Updated the `EventLog` model to add  `impersonatingUserId`.
5. Added a test in the `eventLogs.cy.ts`.
6. Fixed and added cy tags for improved understanding of test implementation.
7. Updated `UserMutations` with backend logs when `Connect as this user...` is clicked:

![image](https://github.com/user-attachments/assets/12e78ed2-8e3e-40ef-96f9-36337548cd32)


<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
