### PR TITLE
fix: failure of automatic fap assignments during instrument picker selection fixed

### DIFF
--- a/apps/backend/src/decorators/EventBus.ts
+++ b/apps/backend/src/decorators/EventBus.ts
@@ -11,7 +11,10 @@ const EventBusDecorator = (eventType: Event) => {
     target: any,
     name: string,
     descriptor: {
-      value?: (agent: UserWithRole, args: any) => Promise<Rejection | any>;
+      value?: (
+        agent: UserWithRole | null,
+        args: any
+      ) => Promise<Rejection | any>;
     }
   ) => {
     const originalMethod = descriptor.value;
@@ -39,7 +42,9 @@ const EventBusDecorator = (eventType: Event) => {
           loggedInUserId: loggedInUser ? loggedInUser.id : null,
           isRejection: isRejection(result),
           inputArgs: JSON.stringify(restArgs),
-          impersonatingUserId: loggedInUser.impersonatingUserId,
+          impersonatingUserId: loggedInUser
+            ? loggedInUser.impersonatingUserId
+            : null,
         } as ApplicationEvent;
 
         const eventBus = resolveApplicationEventBus();


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

When Selecting Instruments through Instrument Picker, the corresponding FAP,(if associated), is supposed to be attached to the corresponding Proposal through Event mechanism. 

With the recent changes to the Event Bus(https://github.com/UserOfficeProject/user-office-core/pull/1086), this functionality was no more working with the error thrown. It has been fixed by handling the error. In addition to that, the corresponding e2e tests for the functionality has also been created, so that it is caught during the CI/CD. In more addition to that, the type definition for the event argument has been optimized, so that during build time, the error could be caught improving developer experience

## Motivation and Context

Fix Event Bus Decorator Issue

## How Has This Been Tested

Attached the missing e2e test

## Fixes

https://github.com/UserOfficeProject/user-office-core/pull/1086

## Changes

Significant changes on src/decorators/EventBus.ts

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [*] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
