### PR TITLE
feat: add country detail in proposal information view tab

### DIFF
--- a/apps/frontend/src/components/review/ProposalQuestionaryReview.tsx
+++ b/apps/frontend/src/components/review/ProposalQuestionaryReview.tsx
@@ -6,7 +6,7 @@ import ProposalQuestionaryDetails from 'components/proposal/ProposalQuestionaryD
 import { TableRowData } from 'components/questionary/QuestionaryDetails';
 import { BasicUserDetails } from 'generated/sdk';
 import { ProposalWithQuestionary } from 'models/questionary/proposal/ProposalWithQuestionary';
-import { getFullUserNameWithEmail } from 'utils/user';
+import { getFullUserNameWithBasicDetails } from 'utils/user';
 
 export default function ProposalQuestionaryReview(
   props: {
@@ -34,12 +34,12 @@ export default function ProposalQuestionaryReview(
     { label: 'Abstract', value: data.abstract },
     {
       label: 'Principal Investigator',
-      value: getFullUserNameWithEmail(data.proposer),
+      value: getFullUserNameWithBasicDetails(data.proposer),
     },
     {
       label: 'Co-Proposers',
       value: users
-        .map((user: BasicUserDetails) => getFullUserNameWithEmail(user))
+        .map((user: BasicUserDetails) => getFullUserNameWithBasicDetails(user))
         .join(', '),
     },
     ...(data.coProposerInvites?.length > 0

--- a/apps/frontend/src/utils/user.ts
+++ b/apps/frontend/src/utils/user.ts
@@ -33,3 +33,28 @@ export const getFullUserNameWithInstitution = (
           user.institution ? `${user.institution}` : ''
         }`
     : 'None';
+
+export const getFullUserNameWithBasicDetails = (
+  user?: Pick<
+    BasicUserDetails,
+    | 'preferredname'
+    | 'lastname'
+    | 'email'
+    | 'firstname'
+    | 'institution'
+    | 'country'
+  > | null
+): string =>
+  user
+    ? user.preferredname
+      ? `${user.preferredname} ${user.lastname} ${
+          user.email ? `(${user.email})` : ''
+        } ${user.institution ? `(${user.institution})` : ''} ${
+          user.country ? `(${user.country})` : ''
+        }`
+      : `${user.firstname} ${user.lastname} ${
+          user.email ? `(${user.email})` : ''
+        } ${user.institution ? `(${user.institution})` : ''} ${
+          user.country ? `(${user.country})` : ''
+        }`
+    : 'None';


### PR DESCRIPTION
## Description
This PR introduces feature that adds country detail in proposal information view tab.

## Motivation and Context
The change is required to provide more detailed information about the Principal Investigator and Co-Proposers in the proposal information view tab, specifically their country of residence. This will facilitate better understanding of the proposal's context and aid in decision-making processes.

## Changes
1. `getFullUserNameWithEmail` function has been replaced with `getFullUserNameWithBasicDetails` in `ProposalQuestionaryReview.tsx`. This allows for the inclusion of user's country in the Principal Investigator and Co-Proposers fields.
2. A new function `getFullUserNameWithBasicDetails` has been added to `user.ts` utility. This function returns a string containing user's full name, email, institution, and country.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue
https://github.com/UserOfficeProject/issue-tracker/issues/1428

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated