### PR TITLE
fix: stfc user lookup failing for large amount of userids

### DIFF
--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -175,6 +175,8 @@ export class StfcUserDataSource implements UserDataSource {
     userNumbers: string[],
     searchableOnly?: boolean
   ): Promise<StfcBasicPersonDetails[]> {
+    const distinctUserNumbers = Array.from(new Set(userNumbers));
+
     const cache = searchableOnly
       ? this.uowsSearchableBasicUserDetailsCache
       : this.uowsBasicUserDetailsCache;
@@ -182,7 +184,7 @@ export class StfcUserDataSource implements UserDataSource {
     const stfcUserRequests: Promise<StfcBasicPersonDetails | undefined>[] = [];
     const cacheMisses: string[] = [];
 
-    for (const userNumber of userNumbers) {
+    for (const userNumber of distinctUserNumbers) {
       const cachedUser = cache.get(userNumber);
       if (cachedUser) {
         stfcUserRequests.push(cachedUser);
@@ -266,7 +268,7 @@ export class StfcUserDataSource implements UserDataSource {
       users.filter((user): user is StfcBasicPersonDetails => user !== undefined)
     );
     // Uncache any failed lookups
-    userNumbers
+    distinctUserNumbers
       .filter(
         (un) => stfcUsers.find((user) => user.userNumber === un) === undefined
       )


### PR DESCRIPTION
fix stfc user lookup dummy user creation check. Multiple user id could be passed the ensureDummyUserExists function https://github.com/UserOfficeProject/user-office-core/blob/f00cd657708c0f2982e2c30c969c8f2aaf71e55a/apps/backend/src/datasources/postgres/UserDataSource.ts#L368 causing a equality error at the end of the function. 