### PR TITLE
feat: trace context propagation for factory calls

### DIFF
--- a/apps/backend/src/middlewares/tracing/tracing.ts
+++ b/apps/backend/src/middlewares/tracing/tracing.ts
@@ -71,3 +71,7 @@ export default async function startTracing() {
     otelSDK.start();
   }
 }
+
+export function isTracingEnabled(): boolean {
+  return !!process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+}


### PR DESCRIPTION
## Description
This PR introduces trace context propagation for factory calls in our backend service.

## Motivation and Context
The change is required to improve the observability of our application by tracing the factory service calls. This will help in identifying any issues, bottlenecks, or errors that may occur during the execution of these service calls and aid in debugging and optimization.

## Changes
1. Added OpenTelemetry API for context propagation and tracing.
2. Refactored the fetch call to the factory service to be within a tracer span.
3. Added error handling within the tracer span to record exceptions and set the status of the span appropriately.

## How Has This Been Tested?

Through Grafana traces and service graph

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue
https://github.com/UserOfficeProject/issue-tracker/issues/1433

## Depends On

https://github.com/UserOfficeProject/user-office-factory/pull/637
<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated