### PR TITLE
fix: add the button to download proposals for FAP Reviewers

### DIFF
--- a/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
+++ b/apps/frontend/src/components/fap/Proposals/FapProposalsAndAssignmentsTable.tsx
@@ -603,13 +603,12 @@ const FapProposalsAndAssignmentsTable = ({
       onClick: handleAssignMembersToFapProposals,
       position: 'toolbarOnSelect',
     });
-  hasRightToAssignReviewers &&
-    tableActions.push({
-      icon: () => <GetAppIcon data-cy="download-fap-proposals" />,
-      tooltip: 'Download proposals',
-      onClick: handleBulkDownloadClick,
-      position: 'toolbarOnSelect',
-    });
+  tableActions.push({
+    icon: () => <GetAppIcon data-cy="download-fap-proposals" />,
+    tooltip: 'Download proposals',
+    onClick: handleBulkDownloadClick,
+    position: 'toolbarOnSelect',
+  });
   hasRightToRemoveAssignedProposal &&
     tableActions.push({
       icon: () => <DeleteOutline data-cy="remove-assigned-fap-proposal" />,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->
Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1425
## Motivation and Context
Previously, FAP Reviewers could not download proposals in the `Proposals and Assignments` view. This PR allows them to do so.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually
## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->
Updated `FapProposalsAndAssignmentsTable.tsx` by removing the `hasRightToAssignReviewers` check on `Download proposals` so FAP Reviewers can download proposals
## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
