### PR TITLE
fix: instrument picker can be left blank when marked as required

### DIFF
--- a/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/InstrumentPicker/QuestionaryComponentInstrumentPicker.tsx
@@ -52,7 +52,7 @@ export function processInstrumentPickerValue(
     return instrumentExists ? answer.value : null;
   }
 
-  return undefined;
+  return null;
 }
 export function QuestionaryComponentInstrumentPicker(
   props: BasicComponentProps


### PR DESCRIPTION
The instrument picker can be submitted without a answer when it has been marked as required

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
