### PR TITLE
hotfix: api token download for pdfs

### DIFF
--- a/apps/backend/src/factory/pdf/proposal.ts
+++ b/apps/backend/src/factory/pdf/proposal.ts
@@ -79,18 +79,13 @@ const getTechnicalReviewHumanReadableStatus = (
 };
 
 const getSampleQuestionarySteps = async (
-  questionaryId: number,
-  user: UserWithRole | null
+  questionaryId: number
 ): Promise<QuestionaryStep[]> => {
   const questionaryDataSource = container.resolve<QuestionaryDataSource>(
     Tokens.QuestionaryDataSource
   );
-  const questionarySteps = user
-    ? await baseContext.queries.questionary.getQuestionarySteps(
-        user,
-        questionaryId
-      )
-    : await questionaryDataSource.getQuestionarySteps(questionaryId);
+  const questionarySteps =
+    await questionaryDataSource.getQuestionarySteps(questionaryId);
   if (!questionarySteps) {
     throw new Error(
       `Questionary steps for Questionary ID '${questionaryId}' not found, or the user has insufficient rights`
@@ -581,7 +576,7 @@ export const collectProposalPDFDataTokenAccess = async (
           undefined,
           sample,
           await getQuestionary(sample.questionaryId),
-          await getSampleQuestionarySteps(sample.questionaryId, null)
+          await getSampleQuestionarySteps(sample.questionaryId)
         )
       )
     )
@@ -616,7 +611,7 @@ export const collectProposalPDFDataTokenAccess = async (
           undefined,
           genericTemplate,
           await getQuestionary(genericTemplate.questionaryId),
-          await getSampleQuestionarySteps(genericTemplate.questionaryId, null)
+          await getSampleQuestionarySteps(genericTemplate.questionaryId)
         )
       )
     )


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
This fix the issue were api tokens can not down load proposal pdfs 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Issue with pdf not able to de downloaded using api token
`{"name":"Error","message":"Questionary steps for Questionary ID '39668' not found, or the user has insufficient rights","stack":"Error: Questionary steps for Questionary ID '39668' not found, or the user has insufficient rights\n    at /home/node/app/build/src/factory/pdf/proposal.js:42:15\n `
## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
