### PR TITLE
fix: correct webRoot path in launch configuration for frontend debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "request": "launch",
             "type": "pwa-chrome",
             "url": "http://localhost:3000",
-            "webRoot": "${workspaceFolder}"
+            "webRoot": "${workspaceFolder}/apps/frontend",
         },
         {
             "name": "Attach to Docker container",


### PR DESCRIPTION
## Description
This PR corrects the `webRoot` path in the launch configuration to fix ability for frontend debugging.

## Motivation and Context
The path in the `webRoot` seems to be misconfigured, which results that when attaching debugger to the frontend no breakpoints are hit.

If the existing configuration works for you please let me know, so that fixing this for one environment does not break it for another.

## Changes
- The `webRoot` path in the `launch.json` configuration file has been updated from `"${workspaceFolder}"` to `"${workspaceFolder}/apps/frontend"`, aligning it with the actual frontend application directory.

How to test:
1. Launch the backend and frontend services and make sure localhost:3000 renders properly.

2. Click the "Debug on <browser>"
<img width="770" height="312" alt="image" src="https://github.com/user-attachments/assets/0ceb64cb-da17-45f9-8dd6-94b189b8fc2d" />


