### PR TITLE
fix: remove unused SampleDataSource import

### DIFF
--- a/apps/backend/src/auth/QuestionaryAuthorization.ts
+++ b/apps/backend/src/auth/QuestionaryAuthorization.ts
@@ -2,7 +2,6 @@ import { container, inject, injectable } from 'tsyringe';
 
 import { Tokens } from '../config/Tokens';
 import { QuestionaryDataSource } from '../datasources/QuestionaryDataSource';
-import { SampleDataSource } from '../datasources/SampleDataSource';
 import { TemplateDataSource } from '../datasources/TemplateDataSource';
 import { TemplateGroupId } from '../models/Template';
 import { UserJWT } from '../models/User';
@@ -34,8 +33,7 @@ export class QuestionaryAuthorization {
     @inject(Tokens.QuestionaryDataSource)
     private questionaryDataSource: QuestionaryDataSource,
     @inject(Tokens.TemplateDataSource)
-    private templateDataSource: TemplateDataSource,
-    @inject(Tokens.SampleDataSource) private sampleDataSource: SampleDataSource
+    private templateDataSource: TemplateDataSource
   ) {
     this.authorizers.set(
       TemplateGroupId.PROPOSAL,


### PR DESCRIPTION
## Description
This PR removes an unused import, SampleDataSource, from QuestionaryAuthorization.ts.

## Motivation and Context
The SampleDataSource import was not being utilized, which led to unnecessary code clutter and potential confusion. Removing this unused import improves code readability and maintains a clean code environment.

## Changes
- Removed the unused SampleDataSource import from QuestionaryAuthorization.ts.
- Removed the SampleDataSource injection from the QuestionaryAuthorization constructor.

These changes streamline the QuestionaryAuthorization file and adhere to best coding practices by eliminating unnecessary code.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated