### PR TITLE
fix: error occurs when searching for anything containing a full stop. #1463

### DIFF
--- a/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcProposalDataSource.ts
@@ -120,6 +120,7 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
       .orderBy('proposal_pk', 'desc')
       .modify((query) => {
         if (filter?.text) {
+          const jsonPath = `$[*].name ? (@.type() == "string" && @ like_regex "${filter.text}" flag "i")`;
           query.where(function () {
             this.where('title', 'ilike', `%${filter.text}%`)
               .orWhere('proposal_id', 'ilike', `%${filter.text}%`)
@@ -129,10 +130,7 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
               .orWhere('users.lastname', 'ilike', `%${filter.text}%`)
               .orWhere('principal_investigator', 'in', stfcUserIds)
               // NOTE: Using jsonpath we check the jsonb (instruments) field if it contains object with name equal to searchText case insensitive
-              .orWhereRaw(
-                'jsonb_path_exists(instruments, \'$[*].name \\? (@.type() == "string" && @ like_regex :searchText: flag "i")\')',
-                { searchText: filter.text }
-              );
+              .orWhereRaw('jsonb_path_exists(instruments, ?)', [jsonPath]);
           });
         }
         if (filter?.reviewer === ReviewerFilter.ME) {


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/1463 

## Description
This PR fix the error occurs when searching for anything containing a full stop (e.g. bam.de) while using the instrument scientist role. 

## Motivation and Context
Fix the error occurs when searching for anything containing a full stop (e.g. bam.de) while using the instrument scientist role. 

## Changes
Update the data source to fix the error occurs when searching for anything containing a full stop (e.g. bam.de) while using the instrument scientist role.  

## How Has This Been Tested?

Manually

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated