### PR TITLE
fix: ilike in the sql query leads to search error in the instrument scientist proposal page

### DIFF
--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -631,9 +631,9 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
               .orWhereRaw('title ILIKE ?', `%${filter.text}%`)
               .orWhereRaw('proposal_id ILIKE ?', `%${filter.text}%`)
               .orWhereRaw('proposal_status_name ILIKE ?', `%${filter.text}%`)
-              .orWhereRaw('users.email ILIKE', `%${filter.text}%`)
-              .orWhereRaw('users.firstname ILIKE', `%${filter.text}%`)
-              .orWhereRaw('users.lastname ILIKE', `%${filter.text}%`)
+              .orWhereRaw('users.email ILIKE ?', `%${filter.text}%`)
+              .orWhereRaw('users.firstname ILIKE ?', `%${filter.text}%`)
+              .orWhereRaw('users.lastname ILIKE ?', `%${filter.text}%`)
               // NOTE: Using jsonpath we check the jsonb (instruments) field if it contains object with name equal to searchText case insensitive
               .orWhereRaw(
                 'jsonb_path_exists(instruments, \'$[*].name \\? (@.type() == "string" && @ like_regex :searchText: flag "i")\')',
@@ -653,7 +653,7 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
             ).orWhereRaw(
               // This query finds proposals where the current user is a scientist on an instrument that allows multiple technical reviews
               // eslint-disable-next-line prettier/prettier
-              'jsonb_path_exists(instruments, \'$[*] \\? (@.multipleTechReviewsEnabled == true && @.scientists[*].id == :userId:)\')',
+              "jsonb_path_exists(instruments, '$[*] \\? (@.multipleTechReviewsEnabled == true && @.scientists[*].id == :userId:)')",
               { userId: user.id }
             );
           });


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Missing ? in the ILIKE query leads to error while searching. This happens when Instrument Scientists searches in the Proposal table. 

## Motivation and Context

To fix the error in Instrument Scientist Proposal table, where searching is buggy.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manually

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->
Added ? alongside ILIKE in the raw query

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
