### PR TITLE
fix: instrument availability time can be null

### DIFF
--- a/apps/frontend/src/components/call/AssignedInstrumentsTable.tsx
+++ b/apps/frontend/src/components/call/AssignedInstrumentsTable.tsx
@@ -148,6 +148,13 @@ const AssignedInstrumentsTable = ({
           return { isValid: true };
         }
 
+        // NOTE: We sometimes don't know how much availability time is needed, so null is allowed
+        if (rowData.availabilityTime === null) {
+          return {
+            isValid: true,
+          };
+        }
+
         if (rowData.availabilityTime && +rowData.availabilityTime > 0) {
           // NOTE: Preventing inputs grater than 32-bit integer.
           if (+rowData.availabilityTime >= MAX_32_BIT_INTEGER) {


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1172

## Description
This PR allows instrument availability time to be null in the AssignedInstrumentsTable component.

## Motivation and Context
This change is required to handle cases where the instrument availability time is unknown or not provided as the call can be se up ahead of time.

## Changes
- Added a condition in the validation logic of the AssignedInstrumentsTable component to allow `null` for the `availabilityTime` property.

## Additional Context
The motivation behind this change comes from the need to handle real-life scenarios where sometimes the availability time of an instrument might not be known, hence allowing `null` values helps to maintain the integrity of the application.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.esss.lu.se/browse/](https://jira.esss.lu.se/browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated