### PR TITLE
test: remove .only from invites e2e tests

### DIFF
--- a/apps/e2e/cypress/e2e/invites.cy.ts
+++ b/apps/e2e/cypress/e2e/invites.cy.ts
@@ -185,7 +185,7 @@ context('Invites tests', () => {
         .should('not.exist');
     });
 
-    it.only('Should not be able to invite the email of the current user', function () {
+    it('Should not be able to invite the email of the current user', function () {
       if (!featureFlags.getEnabledFeatures().get(FeatureId.EMAIL_INVITE)) {
         this.skip();
       }


### PR DESCRIPTION
## Description
This PR removes the `.only` method from the 'Should not be able to invite the email of the current user' test in the invites e2e tests.

## Motivation and Context
The `.only` method was inadvertently left in the test suite, limiting the execution of the entire test suite to this single test. This change is required to ensure that all tests in the suite are executed.

## Changes
- Removed the `.only` method from the 'Should not be able to invite the email of the current user' test in the invites e2e tests file (invites.cy.ts) to ensure all tests in the suite are run.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue


## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated