### PR TITLE
fix: allow user numbers metics to be collected with needing apollo studio key

### DIFF
--- a/apps/backend/src/middlewares/graphql.ts
+++ b/apps/backend/src/middlewares/graphql.ts
@@ -192,6 +192,9 @@ const apolloServer = async (app: Express) => {
         },
       })
     );
+  }
+
+  if (process.env.INCLUDE_USER_NUMBER_IN_METRICS) {
     app.use((req, res, next) => {
       const clientName = req.headers['apollographql-client-name'];
       if (


### PR DESCRIPTION
Closes https://github.com/UserOfficeProject/issue-tracker/issues/1524

## Description

We would still like to to add the user number to requests so we can collect metrics on specific users but not provide a apollo studio key. I have just added a new env varible `INCLUDE_USER_NUMBER_IN_METRICS` to caputure this

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
