### PR TITLE
fix: temp fix for fap reviewers seeing other reviews stfc only

### DIFF
--- a/apps/backend/src/auth/StfcUserAuthorization.ts
+++ b/apps/backend/src/auth/StfcUserAuthorization.ts
@@ -364,7 +364,8 @@ export class StfcUserAuthorization extends UserAuthorization {
   ): Promise<boolean> {
     return (
       this.isUserOfficer(agent) ||
-      (await this.isChairOrSecretaryOfFap(agent, fapId))
+      (await this.isChairOrSecretaryOfFap(agent, fapId)) ||
+      !!this.isApiToken(agent)
     );
   }
 }

--- a/apps/backend/src/auth/StfcUserAuthorization.ts
+++ b/apps/backend/src/auth/StfcUserAuthorization.ts
@@ -356,4 +356,15 @@ export class StfcUserAuthorization extends UserAuthorization {
   }): Promise<Institution | null> {
     throw new Error('Method not implemented.');
   }
+
+  // Temp fix for https://github.com/UserOfficeProject/issue-tracker/issues/1522
+  async canSeeAllCurrentFapReviews(
+    agent: UserWithRole | null,
+    fapId: number
+  ): Promise<boolean> {
+    return (
+      this.isUserOfficer(agent) ||
+      (await this.isChairOrSecretaryOfFap(agent, fapId))
+    );
+  }
 }

--- a/apps/backend/src/auth/UserAuthorization.ts
+++ b/apps/backend/src/auth/UserAuthorization.ts
@@ -219,4 +219,11 @@ export abstract class UserAuthorization {
 
     return isFapReviewer;
   }
+
+  async canSeeAllCurrentFapReviews(
+    agent: UserWithRole | null,
+    fapId: number
+  ): Promise<boolean> {
+    return Promise.resolve(true);
+  }
 }

--- a/apps/backend/src/queries/FapQueries.ts
+++ b/apps/backend/src/queries/FapQueries.ts
@@ -187,7 +187,8 @@ export default class FapQueries {
       agent &&
       !this.userAuth.isUserOfficer(agent) &&
       !(await this.userAuth.isChairOrSecretaryOfFap(agent, fapId)) &&
-      !proposalEvents?.proposal_all_fap_reviews_submitted
+      !proposalEvents?.proposal_all_fap_reviews_submitted &&
+      (await this.userAuth.canSeeAllCurrentFapReviews(agent, fapId))
     ) {
       reviewerId = agent.id;
     }

--- a/apps/backend/src/queries/FapQueries.ts
+++ b/apps/backend/src/queries/FapQueries.ts
@@ -188,7 +188,7 @@ export default class FapQueries {
       !this.userAuth.isUserOfficer(agent) &&
       !(await this.userAuth.isChairOrSecretaryOfFap(agent, fapId)) &&
       !proposalEvents?.proposal_all_fap_reviews_submitted &&
-      (await this.userAuth.canSeeAllCurrentFapReviews(agent, fapId))
+      !(await this.userAuth.canSeeAllCurrentFapReviews(agent, fapId))
     ) {
       reviewerId = agent.id;
     }


### PR DESCRIPTION
Temp fix for https://github.com/UserOfficeProject/issue-tracker/issues/1522

## Description

At STFC we dont want reviewers to see other reviews until after the round has ended. We didnt notices this behaviour until now (whoops). This change only affects stfc as we need a solution for next week and this was the quickest thing I could see to do. 

I have opened https://github.com/UserOfficeProject/issue-tracker/issues/1522 to make it more configurable.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
