### PR TITLE
refactor: remove paged script and index creation logic from default PDF template

### DIFF
--- a/apps/frontend/src/components/template/PdfTemplateDefaultData.tsx
+++ b/apps/frontend/src/components/template/PdfTemplateDefaultData.tsx
@@ -51,7 +51,6 @@ export const body = `<html lang="en">
       content: ' – ';
     }
   </style>
-  <script src="http://localhost:4500/static/js/paged.polyfill.min.js"></script>
 </head>
 
 <body>
@@ -307,79 +306,6 @@ export const body = `<html lang="en">
     </div>
   </div>
 </body>
-<script>
-  function createIndex(config) {
-    let indexElements = document.querySelectorAll("[data-book-index]");
-    let indices = [];
-    let num = 0;
-    for (let i = 0; i < indexElements.length; ++i) {
-      let indexElement = indexElements[i];
-
-      // create array with all data-book-index
-      let indexKey = indexElement.dataset.bookIndex;
-      let indexKeyFirst = indexKey.slice(0, 1);
-
-      let indexParent = indexElement.dataset.bookIndexParent;
-      indices.push({ indexKey, indexParent });
-
-      // create id for span whithout
-      num++;
-      if (indexElement.id == '') {
-        indexElement.id = 'book-index-' + num;
-      }
-    }
-
-    // create <ul> element for the index
-    let indexElementDiv = document.querySelector(config.indexElement);
-    let indexUl = document.createElement('ul');
-    indexUl.id = 'list-index-generated';
-    indexElementDiv.appendChild(indexUl);
-
-    // create <li> element for the index
-    indices.forEach((index) => {
-      // create <li> element for the index
-      let indexNewLi = document.createElement('li');
-      indexNewLi.classList.add('list-index-element');
-
-      const indexKey = index.indexKey;
-      const indexParent = index.indexParent;
-
-      indexNewLi.dataset.listIndex = indexKey;
-      if (indexParent) indexNewLi.dataset.listIndexParent = indexParent;
-      indexUl.appendChild(indexNewLi);
-    });
-
-    let indexLi = document
-      .getElementById('list-index-generated')
-      .getElementsByClassName('list-index-element');
-
-    for (var n = 0; n < indexLi.length; n++) {
-      // find data and add HTML of the list
-      let dataIndex = indexLi[n].dataset.listIndex;
-      let spanIndex = document.querySelectorAll(
-        "[data-book-index='" + dataIndex + "']"
-      );
-      indexLi[n].innerHTML =
-        '<span class="index-value">' +
-        dataIndex +
-        '</span><span class="links-pages"></span>';
-
-      // add span for link page
-      spanIndex.forEach(function (elem) {
-        spanIndexId = elem.id;
-        let spanPage = document.createElement('span');
-        spanPage.classList.add('link-page');
-        spanPage.innerHTML = '<a href="#' + spanIndexId + '"></a>';
-        indexLi[n]
-          .getElementsByClassName('links-pages')[0]
-          .appendChild(spanPage);
-      });
-    }
-  }
-  createIndex({
-    indexElement: '#bookIndex',
-  });
-</script>
 </html>
 `;
 


### PR DESCRIPTION
It removes the locally embedded Paged.js script and inline createIndex function/call from the custom default PDF template.
In user-office-factory, the same script/function/invocation are already injected automatically into the generated HTML, so keeping them here caused redundant execution and duplication.

https://github.com/UserOfficeProject/user-office-factory/blob/4fabbe3fd1750ff9a9b5777ca4f6e5058abdbf86/src/util/pdfHtmlScript.ts#L5