### PR TITLE
fix: standardize naming oidcSub

### DIFF
--- a/apps/backend/src/auth/OAuthAuthorization.ts
+++ b/apps/backend/src/auth/OAuthAuthorization.ts
@@ -149,7 +149,7 @@ export class OAuthAuthorization extends UserAuthorization {
         oidcSub: userId,
         institutionId: institution?.id ?? user.institutionId,
         preferredname: userInfo.preferred_username,
-        user_title: userInfo.title as string,
+        userTitle: userInfo.title as string,
       });
 
       return updatedUser;

--- a/apps/backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/backend/src/datasources/postgres/UserDataSource.ts
@@ -81,7 +81,7 @@ export default class PostgresUserDataSource implements UserDataSource {
   async update(user: UpdateUserByIdArgs): Promise<User> {
     const {
       firstname,
-      user_title,
+      userTitle,
       lastname,
       preferredname,
       institutionId,
@@ -94,7 +94,7 @@ export default class PostgresUserDataSource implements UserDataSource {
     const [userRecord]: UserRecord[] = await database
       .update({
         firstname,
-        user_title,
+        user_title: userTitle,
         lastname,
         preferredname,
         institution_id: institutionId,

--- a/apps/backend/src/models/User.ts
+++ b/apps/backend/src/models/User.ts
@@ -83,7 +83,7 @@ export class BasicUserDetails {
     public email: string,
     public country: string,
     public user_title: string,
-    public oidc_sub: string | null
+    public oidcSub: string | null
   ) {}
 }
 

--- a/apps/backend/src/models/User.ts
+++ b/apps/backend/src/models/User.ts
@@ -24,7 +24,7 @@ export type PasswordResetJwtPayload = SpecialActionJwtPayload & {
 export class User {
   constructor(
     public id: number,
-    public user_title: string,
+    public userTitle: string,
     public firstname: string,
     public lastname: string,
     public preferredname: string | undefined,
@@ -82,7 +82,7 @@ export class BasicUserDetails {
     public created: Date,
     public email: string,
     public country: string,
-    public user_title: string,
+    public userTitle: string,
     public oidcSub: string | null
   ) {}
 }

--- a/apps/backend/src/mutations/UserMutations.ts
+++ b/apps/backend/src/mutations/UserMutations.ts
@@ -404,7 +404,7 @@ export default class UserMutations {
         oidcSub: oidcSub,
         institutionId: institution.id,
         preferredname: preferredName ?? undefined,
-        user_title: userTitle ?? undefined,
+        userTitle: userTitle ?? undefined,
       });
 
       return updatedUser;

--- a/apps/backend/src/queries/UserQueries.ts
+++ b/apps/backend/src/queries/UserQueries.ts
@@ -72,7 +72,7 @@ export default class UserQueries {
         user.created,
         user.email,
         user.country,
-        user.user_title,
+        user.userTitle,
         user.oidcSub
       );
     } else {
@@ -105,7 +105,7 @@ export default class UserQueries {
       user.created,
       user.email,
       user.country,
-      user.user_title,
+      user.userTitle,
       user.oidcSub
     );
   }

--- a/apps/backend/src/queries/UserQueries.ts
+++ b/apps/backend/src/queries/UserQueries.ts
@@ -73,7 +73,7 @@ export default class UserQueries {
         user.email,
         user.country,
         user.user_title,
-        user.oidc_sub
+        user.oidcSub
       );
     } else {
       return null;
@@ -106,7 +106,7 @@ export default class UserQueries {
       user.email,
       user.country,
       user.user_title,
-      user.oidc_sub
+      user.oidcSub
     );
   }
 

--- a/apps/backend/src/resolvers/mutations/UpdateUserMutation.ts
+++ b/apps/backend/src/resolvers/mutations/UpdateUserMutation.ts
@@ -15,7 +15,7 @@ import { User } from '../types/User';
 @ArgsType()
 class UpdateUserArgs {
   @Field(() => String, { nullable: true })
-  public user_title?: string;
+  public userTitle?: string;
 
   @Field(() => String, { nullable: true })
   public firstname?: string;

--- a/apps/backend/src/resolvers/types/BasicUserDetails.ts
+++ b/apps/backend/src/resolvers/types/BasicUserDetails.ts
@@ -40,7 +40,7 @@ export class BasicUserDetails implements Partial<BasicUserDetailsOrigin> {
   public country: string;
 
   @Field(() => String, { nullable: true })
-  public oidc_sub?: string | null;
+  public oidcSub?: string | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/backend/src/resolvers/types/User.ts
+++ b/apps/backend/src/resolvers/types/User.ts
@@ -51,7 +51,7 @@ export class User implements Partial<UserOrigin> {
   public id: number;
 
   @Field(() => String)
-  public user_title: string;
+  public userTitle: string;
 
   @Field()
   public firstname: string;

--- a/apps/e2e/cypress/e2e/eventLogs.cy.ts
+++ b/apps/e2e/cypress/e2e/eventLogs.cy.ts
@@ -66,7 +66,7 @@ context('Event log tests', () => {
       cy.updateUserDetails({
         id: user.id,
         firstname: newFirstName,
-        user_title: 'Dr.',
+        userTitle: 'Dr.',
         lastname: 'Doe',
         institutionId: 1,
         email: faker.internet.email(),

--- a/apps/e2e/cypress/e2e/userAdministration.cy.ts
+++ b/apps/e2e/cypress/e2e/userAdministration.cy.ts
@@ -70,7 +70,7 @@ context('User administration tests', () => {
     if (featureFlags.getEnabledFeatures().get(FeatureId.USER_MANAGEMENT)) {
       cy.updateUserDetails({
         id: 4,
-        user_title: 'Mr.',
+        userTitle: 'Mr.',
         firstname: 'Benjamin',
         lastname: 'Beckley',
         preferredname: 'Ben',
@@ -114,7 +114,7 @@ context('User administration tests', () => {
     if (featureFlags.getEnabledFeatures().get(FeatureId.USER_MANAGEMENT)) {
       cy.updateUserDetails({
         id: 6,
-        user_title: 'Mr.',
+        userTitle: 'Mr.',
         firstname: 'David',
         lastname: 'Dawson',
         preferredname: '',

--- a/apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
+++ b/apps/frontend/src/components/instrument/AssignedScientistsTable.tsx
@@ -9,6 +9,7 @@ import { Instrument, BasicUserDetails, UserRole } from 'generated/sdk';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
 import { tableIcons } from 'utils/materialIcons';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
+import { StrictColumn } from 'utils/utilTypes';
 
 type AssignedScientistsTableProps = {
   instrument: Pick<Instrument, 'id' | 'scientists' | 'instrumentContact'>;
@@ -31,7 +32,8 @@ const assignmentColumns = [
     title: 'Institution',
     field: 'institution',
   },
-];
+] satisfies StrictColumn<BasicUserDetails>[];
+
 const instrumentContactColumns = [
   {
     title: 'Name',
@@ -49,7 +51,8 @@ const instrumentContactColumns = [
     title: 'Institution',
     field: 'institution',
   },
-];
+] satisfies StrictColumn<BasicUserDetails>[];
+
 const AssignedScientistsTable = ({
   instrument,
   removeAssignedScientistFromInstrument,

--- a/apps/frontend/src/components/technique/AssignedScientistsTable.tsx
+++ b/apps/frontend/src/components/technique/AssignedScientistsTable.tsx
@@ -8,6 +8,7 @@ import i18n from 'i18n';
 import { BasicUserDetails, TechniqueFragment, UserRole } from 'generated/sdk';
 import { useCheckAccess } from 'hooks/common/useCheckAccess';
 import { tableIcons } from 'utils/materialIcons';
+import { StrictColumn } from 'utils/utilTypes';
 type AssignedScientistsTableProps = {
   technique: TechniqueFragment;
   removeScientistFromTechnique: (
@@ -29,7 +30,7 @@ const assignmentScientistColumns = [
     title: 'Institution',
     field: 'institution',
   },
-];
+] satisfies StrictColumn<BasicUserDetails>[];
 
 const AssignedScientistsTable = ({
   technique,

--- a/apps/frontend/src/components/user/PeopleTable.tsx
+++ b/apps/frontend/src/components/user/PeopleTable.tsx
@@ -82,7 +82,7 @@ const localColumns = [
   { title: 'Preferred Name', field: 'preferredname' },
   { title: 'Institution', field: 'institution' },
   { title: 'Email', field: 'email' },
-  { title: 'User Name', field: 'oidc_sub' },
+  { title: 'User Name', field: 'oidcSub' },
 ];
 
 async function getUserByEmail(

--- a/apps/frontend/src/components/user/PeopleTable.tsx
+++ b/apps/frontend/src/components/user/PeopleTable.tsx
@@ -31,7 +31,7 @@ import {
 import { useDataApi } from 'hooks/common/useDataApi';
 import { setSortDirectionOnSortField } from 'utils/helperFunctions';
 import { tableIcons } from 'utils/materialIcons';
-import { FunctionType } from 'utils/utilTypes';
+import { FunctionType, StrictColumn } from 'utils/utilTypes';
 
 type InvitationButtonProps = {
   title: string;
@@ -83,7 +83,7 @@ const localColumns = [
   { title: 'Institution', field: 'institution' },
   { title: 'Email', field: 'email' },
   { title: 'User Name', field: 'oidcSub' },
-];
+] satisfies StrictColumn<BasicUserDetails>[];
 
 async function getUserByEmail(
   email: string,

--- a/apps/frontend/src/components/user/UpdateUserInformation.tsx
+++ b/apps/frontend/src/components/user/UpdateUserInformation.tsx
@@ -47,7 +47,7 @@ export default function UpdateUserInformation(
     institutionId: userData.institutionId,
     oldEmail: userData.email,
     email: userData.email,
-    user_title: userData.user_title,
+    userTitle: userData.userTitle,
     oidcSub: userData.oidcSub,
   };
 
@@ -105,10 +105,10 @@ export default function UpdateUserInformation(
             <Grid item xs={6}>
               <LocalizationProvider dateAdapter={DateAdapter}>
                 <Field
-                  name="user_title"
+                  name="userTitle"
                   options={userTitleOptions}
                   component={Select}
-                  inputLabel={{ htmlFor: 'user_title', required: true }}
+                  inputLabel={{ htmlFor: 'userTitle', required: true }}
                   label="Title"
                   data-cy="title"
                   required

--- a/apps/frontend/src/graphql/user/fragment.basicUserInformation.graphql
+++ b/apps/frontend/src/graphql/user/fragment.basicUserInformation.graphql
@@ -8,5 +8,5 @@ fragment basicUserDetails on BasicUserDetails {
   created
   email
   country
-  oidc_sub
+  oidcSub
 }

--- a/apps/frontend/src/graphql/user/getUser.graphql
+++ b/apps/frontend/src/graphql/user/getUser.graphql
@@ -1,6 +1,6 @@
 query getUser($userId: Int!) {
   user(userId: $userId) {
-    user_title
+    userTitle
     firstname
     lastname
     preferredname

--- a/apps/frontend/src/graphql/user/getUserMe.graphql
+++ b/apps/frontend/src/graphql/user/getUserMe.graphql
@@ -1,6 +1,6 @@
 query getUserMe {
   me {
-    user_title
+    userTitle
     firstname
     lastname
     preferredname

--- a/apps/frontend/src/graphql/user/updateUser.graphql
+++ b/apps/frontend/src/graphql/user/updateUser.graphql
@@ -1,6 +1,6 @@
 mutation updateUser(
   $id: Int!
-  $user_title: String
+  $userTitle: String
   $firstname: String
   $lastname: String
   $preferredname: String
@@ -9,7 +9,7 @@ mutation updateUser(
 ) {
   updateUser(
     id: $id
-    user_title: $user_title
+    userTitle: $userTitle
     firstname: $firstname
     lastname: $lastname
     preferredname: $preferredname

--- a/apps/frontend/src/hooks/visit/useBlankVisitRegistration.ts
+++ b/apps/frontend/src/hooks/visit/useBlankVisitRegistration.ts
@@ -32,7 +32,7 @@ function createRegistrationStub(
       institutionId: 1,
       email: '',
       country: '',
-      oidc_sub: '',
+      oidcSub: '',
     },
     questionary: {
       isCompleted: false,

--- a/apps/frontend/src/utils/utilTypes.ts
+++ b/apps/frontend/src/utils/utilTypes.ts
@@ -1,4 +1,5 @@
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { Column } from '@material-table/core';
 import { RequestDocument, Variables } from 'graphql-request';
 /**
  * This unpacks an array let you infer the type of a single elem
@@ -36,3 +37,10 @@ export interface Option {
 export type RequestQuery<T, V extends Variables> =
   | RequestDocument
   | TypedDocumentNode<T, V>;
+
+/**
+ * This type is used to make sure that the field in the column is actually a key of the object you are using in the table`
+ */
+export type StrictColumn<T extends object> = Omit<Column<T>, 'field'> & {
+  field: Extract<keyof T, string>;
+};

--- a/validation/src/User/index.ts
+++ b/validation/src/User/index.ts
@@ -47,7 +47,7 @@ export const updateUserValidationSchema = Yup.object().shape({
   firstname: Yup.string().min(2).max(50).required(),
   preferredname: Yup.string().notRequired().max(50),
   lastname: Yup.string().min(2).max(50).required(),
-  user_title: Yup.string().required(),
+  userTitle: Yup.string().required(),
   email: Yup.string().email().required(),
   institutionId: Yup.number().required(),
 });
@@ -57,7 +57,7 @@ export const updateUserValidationBackendSchema = Yup.object().shape({
   firstname: Yup.string().min(2).max(50).notRequired(),
   preferredname: Yup.string().notRequired().max(50),
   lastname: Yup.string().min(2).max(50).notRequired(),
-  user_title: Yup.string().notRequired(),
+  userTitle: Yup.string().notRequired(),
   email: Yup.string().email().notRequired(),
   institutionId: Yup.number().notRequired(),
 });


### PR DESCRIPTION
## Description
This PR standardizes the naming convention of 'oidc_sub' to 'oidcSub' across the codebase.

## Motivation and Context
The change is required to maintain a consistent naming convention in the codebase. This standardization will improve code readability and maintainability.

## Changes
- Renamed 'oidc_sub' to 'oidcSub' in User.ts, UserQueries.ts, BasicUserDetails.ts, basicUserInformation.graphql, and useBlankVisitRegistration.ts.
- This change does not introduce any new functionality or modify existing behavior, it is purely a refactoring of variable names for consistency.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/](https://jira.ess.eu//browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated