### PR TITLE
chore: amends vscode debug config root paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "request": "launch",
             "type": "pwa-chrome",
             "url": "http://localhost:3000",
-            "webRoot": "${workspaceFolder}/apps/frontend",
+            "webRoot": "${workspaceFolder}/apps",
         },
         {
             "name": "Attach to Docker container",
@@ -17,7 +17,7 @@
             "request": "attach",
             "port": 9229,
             "protocol": "inspector",
-            "localRoot": "${workspaceFolder}/apps/backend",
+            "localRoot": "${workspaceFolder}/apps",
             "remoteRoot": "/app"
         }
     ]


### PR DESCRIPTION
## Description

Debugging using the configs specified in `.vscode/launch.json` is currently broken. This PR aims to fix them.

## Motivation and Context

After a recent change to the way the images are built, `localRoot` and `remoteRoot` no longer match, meaning breakpoints can't be bound, preventing debugging.

## How Has This Been Tested

I've ran the debugger and am able to hit breakpoints.

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] All relevant doc has been updated