### PR TITLE
chore: adding proposal information to the coproposer invite email

### DIFF
--- a/apps/backend/src/eventHandlers/email/essEmailHandler.spec.ts
+++ b/apps/backend/src/eventHandlers/email/essEmailHandler.spec.ts
@@ -317,6 +317,106 @@ describe('essEmailHandler co-proposer invites', () => {
     expect(sendMailsSpy).toHaveBeenCalled();
   });
 
+  describe('handling PROPOSAL_CO_PROPOSER_INVITES_UPDATED event', () => {
+    it('should send invite email with proposal title and ID when proposal is found', async () => {
+      const inviteEmail = faker.internet.email();
+      const inviterId = 1;
+      const inviteId = 123;
+      const redeemCode = faker.string.alphanumeric(10);
+
+      const userDataSourceMock = container.resolve<UserDataSourceMock>(
+        Tokens.UserDataSource
+      );
+      const proposalMock = container.resolve<ProposalDataSourceMock>(
+        Tokens.ProposalDataSource
+      );
+
+      jest.spyOn(userDataSourceMock, 'getBasicUserInfo').mockResolvedValue({
+        id: inviterId,
+        firstname: 'Inviter',
+        lastname: 'User',
+        institution: 'TestOrg',
+        email: 'inviter@email.com',
+      } as any);
+
+      jest.spyOn(proposalMock, 'get').mockResolvedValue(dummyProposal);
+
+      const mockEvent = {
+        type: Event.PROPOSAL_CO_PROPOSER_INVITES_UPDATED,
+        proposalPKey: 1,
+        array: [
+          {
+            id: inviteId,
+            email: inviteEmail,
+            code: redeemCode,
+            createdByUserId: inviterId,
+            isEmailSent: false,
+          },
+        ],
+        isRejection: false,
+      } as ApplicationEvent;
+
+      await essEmailHandler(mockEvent);
+
+      expect(mockMailService.sendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: {
+            template_id:
+              EmailTemplateId.USER_OFFICE_REGISTRATION_INVITATION_CO_PROPOSER,
+          },
+          substitution_data: expect.objectContaining({
+            email: inviteEmail,
+            inviterName: 'Inviter',
+            inviterLastname: 'User',
+            inviterOrg: 'TestOrg',
+            redeemCode: redeemCode,
+            proposalTitle: dummyProposal.title,
+            proposalId: dummyProposal.proposalId,
+          }),
+          recipients: [{ address: inviteEmail }],
+        })
+      );
+    });
+
+    it('should log error when proposal is not found in PROPOSAL_CO_PROPOSER_INVITES_UPDATED', async () => {
+      const proposalMock = container.resolve<ProposalDataSourceMock>(
+        Tokens.ProposalDataSource
+      );
+
+      jest.spyOn(proposalMock, 'get').mockResolvedValue(null);
+
+      const mockEvent = {
+        type: Event.PROPOSAL_CO_PROPOSER_INVITES_UPDATED,
+        proposalPKey: 999,
+        array: [
+          {
+            id: 123,
+            email: faker.internet.email(),
+            code: faker.string.alphanumeric(10),
+            createdByUserId: 1,
+            isEmailSent: false,
+          },
+        ],
+        isRejection: false,
+      } as ApplicationEvent;
+
+      const sendMailsSpy = jest.spyOn(mockMailService, 'sendMail');
+
+      await essEmailHandler(mockEvent);
+
+      expect(sendMailsSpy).not.toHaveBeenCalled();
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        'No proposal found when trying to send email',
+        expect.objectContaining({
+          proposalPKey: 999,
+          event: expect.objectContaining({
+            type: Event.PROPOSAL_CO_PROPOSER_INVITES_UPDATED,
+          }),
+        })
+      );
+    });
+  });
+
   describe('handling PROPOSAL_SUBMITTED event', () => {
     it('Should have PI and CoProposals in the payload', async () => {
       const event: ApplicationEvent = {

--- a/apps/backend/src/eventHandlers/email/essEmailHandler.ts
+++ b/apps/backend/src/eventHandlers/email/essEmailHandler.ts
@@ -291,7 +291,6 @@ export async function essEmailHandler(event: ApplicationEvent) {
 
     case Event.PROPOSAL_VISIT_REGISTRATION_INVITES_UPDATED: {
       const invites = event.array;
-
       for (const invite of invites) {
         if (invite.isEmailSent) {
           continue;
@@ -328,6 +327,15 @@ export async function essEmailHandler(event: ApplicationEvent) {
     case Event.PROPOSAL_CO_PROPOSER_INVITES_UPDATED: {
       const invites = event.array;
 
+      const proposal = await proposalDataSource.get(event.proposalPKey);
+      if (!proposal) {
+        logger.logError('No proposal found when trying to send email', {
+          proposalPKey: event.proposalPKey,
+          event,
+        });
+
+        return;
+      }
       for (const invite of invites) {
         if (invite.isEmailSent) {
           continue;
@@ -348,7 +356,8 @@ export async function essEmailHandler(event: ApplicationEvent) {
         await sendInviteEmail(
           invite,
           inviter,
-          EmailTemplateId.USER_OFFICE_REGISTRATION_INVITATION_CO_PROPOSER
+          EmailTemplateId.USER_OFFICE_REGISTRATION_INVITATION_CO_PROPOSER,
+          { proposalTitle: proposal.title, proposalId: proposal.proposalId }
         ).then(async () => {
           await eventBus.publish({
             ...event,
@@ -514,7 +523,8 @@ export async function essEmailHandler(event: ApplicationEvent) {
 async function sendInviteEmail(
   invite: Invite,
   inviter: BasicUserDetails,
-  templateId: EmailTemplateId
+  templateId: EmailTemplateId,
+  additionalSubstitutionData?: Record<string, unknown>
 ) {
   const mailService = container.resolve<MailService>(Tokens.MailService);
   const inviteDataSource = container.resolve<InviteDataSource>(
@@ -532,6 +542,7 @@ async function sendInviteEmail(
         inviterLastname: inviter.lastname,
         inviterOrg: inviter.institution,
         redeemCode: invite.code,
+        ...additionalSubstitutionData,
       },
       recipients: [{ address: invite.email }],
     })


### PR DESCRIPTION
## Description
This pull request adds support for sending customized invite emails to co-proposers when proposal invites are updated, and improves error handling for missing proposals. The main changes include new logic in the `essEmailHandler` to fetch proposal details and pass them to the invite email, as well as corresponding tests to ensure correct behavior.

## Motivation and Context
To add the Proposal information to the Proposal Invite Email template
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Added Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

Improves clarity on the Invitation Email
<!--- Does this fix a user story, if so add a reference here -->

## Changes

Added the parameters for Proposal Title and Proposal ID to the Invite Email template. 
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
