### PR TITLE
fix: on xpress management page only load calls filter when there are instrument(s) in the technique(s)

### DIFF
--- a/apps/frontend/src/components/techniqueProposal/TechniqueProposalTable.tsx
+++ b/apps/frontend/src/components/techniqueProposal/TechniqueProposalTable.tsx
@@ -100,7 +100,7 @@ const TechniqueProposalTable = ({ confirm }: { confirm: WithConfirmType }) => {
     },
     CallsDataQuantity.MINIMAL,
     currentRole !== UserRole.USER_OFFICER
-      ? !techniques || techniques.length <= 0
+      ? !instrumentIds || instrumentIds.length <= 0
       : false
   );
 


### PR DESCRIPTION
## Description
This PR fixes an issue where call filters were being loaded on the Xpress management page even when no instruments were associated with the techniques.

## Motivation and Context
We only want to show calls when the is an associated instruments

## Changes
- The condition for loading calls has been updated to check for the existence of instruments associated with techniques. Now, calls will only load when there is at least one instrument in the technique(s). This change is reflected in the file `apps/frontend/src/components/techniqueProposal/TechniqueProposalTable.tsx`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

Closes: https://github.com/UserOfficeProject/issue-tracker/issues/1536

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated