### PR TITLE
fix: add country name to UserListItem

### DIFF
--- a/apps/frontend/src/components/user/UserListItem.tsx
+++ b/apps/frontend/src/components/user/UserListItem.tsx
@@ -12,7 +12,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user }) => {
   return (
     <ListItemText
       primary={getFullUserNameWithEmail(user)}
-      secondary={user?.institution || ''}
+      secondary={`${user?.institution || ''} , ${user?.country || ''}`}
       primaryTypographyProps={{ variant: 'body2' }}
       secondaryTypographyProps={{ variant: 'caption' }}
     />


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
This PR adds country's name for principal investigator and co-investigators when viewing a proposal
<!--- Describe your changes in detail -->

## Motivation and Context
According to our user-officer, Emma Gozzard, both LSF and HPL are currently in the online review stage, and it is important for staff and reviewers to be able to see the applicant’s country. 
Therefore, this change adds the country's name for the PI and Co-Is in Proposal Questionary Review page.

<img width="1456" height="493" alt="image" src="https://github.com/user-attachments/assets/9ba1ab89-606f-4ab5-a34b-b40e830efc36" />

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
https://github.com/UserOfficeProject/issue-tracker/issues/1539
<!--- Does this fix a user story, if so add a reference here -->

## Changes
apps/frontend/src/components/user/UserListItem.tsx 
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
