### PR TITLE
fix: handle error if the auth returns with key error

### DIFF
--- a/apps/frontend/src/components/user/ExternalAuth.tsx
+++ b/apps/frontend/src/components/user/ExternalAuth.tsx
@@ -35,6 +35,7 @@ function ExternalAuth() {
   const code = searchParams.get('code');
   const token = searchParams.get('token');
   const errorDescription = searchParams.get('error_description');
+  const error = searchParams.get('error');
 
   const unauthorizedApi = useUnauthorizedApi();
   const navigate = useNavigate();
@@ -163,6 +164,8 @@ function ExternalAuth() {
 
     if (errorDescription) {
       handleError(errorDescription);
+    } else if (error) {
+      handleError(error);
     } else if (authorizationCode) {
       handleAuthorizationCode(authorizationCode);
     } else {
@@ -170,6 +173,7 @@ function ExternalAuth() {
     }
   }, [
     code,
+    error,
     errorDescription,
     handleLogin,
     navigate,

--- a/apps/frontend/src/components/user/ExternalAuth.tsx
+++ b/apps/frontend/src/components/user/ExternalAuth.tsx
@@ -35,7 +35,8 @@ function ExternalAuth() {
   const sessionid = searchParams.get('sessionid');
   const code = searchParams.get('code');
   const token = searchParams.get('token');
-  const errorDescription = searchParams.get('error_description') ?? searchParams.get('error');
+  const errorDescription =
+    searchParams.get('error_description') ?? searchParams.get('error');
 
   const unauthorizedApi = useUnauthorizedApi();
   const navigate = useNavigate();
@@ -161,7 +162,7 @@ function ExternalAuth() {
     setView(<LoadingMessage />);
 
     const authorizationCode = sessionid ?? code ?? token;
-    
+
     if (errorDescription) {
       handleError(errorDescription);
     } else if (authorizationCode) {

--- a/apps/frontend/src/components/user/ExternalAuth.tsx
+++ b/apps/frontend/src/components/user/ExternalAuth.tsx
@@ -171,7 +171,6 @@ function ExternalAuth() {
     }
   }, [
     code,
-    error,
     errorDescription,
     handleLogin,
     navigate,

--- a/apps/frontend/src/components/user/ExternalAuth.tsx
+++ b/apps/frontend/src/components/user/ExternalAuth.tsx
@@ -21,6 +21,7 @@ export const getCurrentUrlValues = () => {
   queryParams.delete('code');
   queryParams.delete('token');
   queryParams.delete('error_description');
+  queryParams.delete('error');
 
   return {
     currentUrlWithoutParams,
@@ -34,8 +35,7 @@ function ExternalAuth() {
   const sessionid = searchParams.get('sessionid');
   const code = searchParams.get('code');
   const token = searchParams.get('token');
-  const errorDescription = searchParams.get('error_description');
-  const error = searchParams.get('error');
+  const errorDescription = searchParams.get('error_description') ?? searchParams.get('error');
 
   const unauthorizedApi = useUnauthorizedApi();
   const navigate = useNavigate();
@@ -161,11 +161,9 @@ function ExternalAuth() {
     setView(<LoadingMessage />);
 
     const authorizationCode = sessionid ?? code ?? token;
-
+    
     if (errorDescription) {
       handleError(errorDescription);
-    } else if (error) {
-      handleError(error);
     } else if (authorizationCode) {
       handleAuthorizationCode(authorizationCode);
     } else {


### PR DESCRIPTION
## Description

This pull request makes a small update to the `ExternalAuth` component to improve error handling for authentication. Now, the component checks for an `error` parameter in addition to `error_description` in the URL query parameters, ensuring that all possible OAuth errors are properly handled.

<!--- Describe your changes in detail -->

## Motivation and Context

To Fix infinite loop of the app caused by the new error parameter `error`
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

* Enhanced error handling by checking for an `error` parameter in the query string and passing it to the `handleError` function if present. [[1]](diffhunk://#diff-6f39957ce26077cdbaf231dca87d67b685dd590febffd2c3e9b02eeb3074d3c9R38) [[2]](diffhunk://#diff-6f39957ce26077cdbaf231dca87d67b685dd590febffd2c3e9b02eeb3074d3c9R167-R176)<!--- You can leave blank or remove sections which aren't necessary for the PR. -->
* 
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
