### PR TITLE
perf: add delay to search for people table

### DIFF
--- a/apps/frontend/src/components/user/PeopleTable.tsx
+++ b/apps/frontend/src/components/user/PeopleTable.tsx
@@ -455,6 +455,7 @@ const PeopleTable = ({
           }}
           options={{
             search: search,
+            searchDebounceDelay: 1500,
             searchText: persistUrlQueryParams
               ? searchParams.get('search') || undefined
               : undefined,

--- a/apps/frontend/src/components/user/PeopleTable.tsx
+++ b/apps/frontend/src/components/user/PeopleTable.tsx
@@ -455,7 +455,7 @@ const PeopleTable = ({
           }}
           options={{
             search: search,
-            searchDebounceDelay: 1500,
+            searchDebounceDelay: 1500, //1500ms delay on search
             searchText: persistUrlQueryParams
               ? searchParams.get('search') || undefined
               : undefined,

--- a/apps/frontend/src/components/user/PeopleTable.tsx
+++ b/apps/frontend/src/components/user/PeopleTable.tsx
@@ -455,11 +455,10 @@ const PeopleTable = ({
           }}
           options={{
             search: search,
-            searchDebounceDelay: 1500, //1500ms delay on search
             searchText: persistUrlQueryParams
               ? searchParams.get('search') || undefined
               : undefined,
-            debounceInterval: 400,
+            debounceInterval: 750,
             selection: selection,
             headerSelectionProps: {
               inputProps: { 'aria-label': 'Select All Rows' },


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
refs: https://github.com/UserOfficeProject/issue-tracker/issues/1546

The people table has some performance issues, we have a lot of users and on every character typed the search is executed. 

This PR adds a delay into the search bar so the user has time to type the full name they are searching for, reducing the number of calls to the database. 

<!--- Describe your changes in detail -->

## How Has This Been Tested
Tested manually 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Changes
Delay added to People table search 
<!--- What types of changes does your code introduce? In what place? -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
