### PR TITLE
feat: implement stfc dynamic roles

### DIFF
--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.spec.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.spec.ts
@@ -1,5 +1,6 @@
 import { Role, Roles } from '../../models/Role';
 import { dummyUser } from '../mockups/UserDataSource';
+import PostgresUserDataSource from '../postgres/UserDataSource';
 import { StfcUserDataSource } from './StfcUserDataSource';
 
 jest.mock('../postgres/UserDataSource.ts');
@@ -157,6 +158,12 @@ describe('Role tests', () => {
       ])
     );
 
+    const mockGetUserRoles = jest.spyOn(
+      PostgresUserDataSource.prototype,
+      'getUserRoles'
+    );
+    mockGetUserRoles.mockImplementation(() => Promise.resolve([]));
+
     const mockEnsureDummyUserExists = jest.spyOn(
       StfcUserDataSource.prototype,
       'ensureDummyUserExists'
@@ -181,7 +188,7 @@ describe('Role tests', () => {
     );
   });
 
-  test('When getting roles for a user, STFC roles are translated into ESS roles', async () => {
+  test('When getting roles for a user, STFC roles are translated into UO system roles', async () => {
     const userdataSource = new StfcUserDataSource();
 
     return expect(

--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -38,7 +38,6 @@ const stfcRolesToSystemRoleDefinitions: StfcRolesToEssRole = {
   'FAP Secretary': [Roles.FAP_SECRETARY],
   'FAP Chair': [Roles.FAP_CHAIR],
   'Internal Reviewer': [Roles.INTERNAL_REVIEWER],
-  'Proposal Reader': [Roles.PROPOSAL_READER],
 };
 
 export type stfcRole = {
@@ -397,27 +396,32 @@ export class StfcUserDataSource implements UserDataSource {
 
   async setUserRoles(id: number, roles: number[]): Promise<void> {
     try {
-      const allSystemRoles = await this.getRoles();
-      const rolesMap = new Map(allSystemRoles.map((role) => [role.id, role]));
-
-      const rootRoles = roles
-        .map((roleId) => rolesMap.get(roleId))
-        .filter((role): role is Role => role !== undefined && role.isRootRole);
-
-      if (rootRoles.length > 0) {
-        const rootRoleNames = rootRoles.map((role) => role.title).join(', ');
-        logger.logError('Cannot assign root roles to users', {
-          rootRoleNames,
-          userId: id,
-        });
-        throw new Error(
-          `Cannot assign root roles to users ${JSON.stringify(rootRoleNames)}.`
-        );
+      const roleDefinitions = await this.getRoles();
+      if (!roleDefinitions) {
+        throw new Error('Role definitions not set up in the system');
       }
-      const uniqueRoles = Array.from(new Set(roles));
-      await postgresUserDataSource.setUserRoles(id, uniqueRoles);
-      this.stfcRolesCache.remove(String(id));
-      this.uopRolesCache.remove(String(id));
+      const userRole: Role | undefined = roleDefinitions.find(
+        (role) => role.shortCode == Roles.USER
+      );
+      const stfcRoles = await this.getRolesForUser(id);
+
+      const assignedRoleIds = new Set(
+        this.mapStfcRolesToSystemRoleDefinitions(
+          stfcRoles,
+          roleDefinitions
+        ).map((r) => r.id)
+      );
+      const newRolesToAssign = Array.from(new Set(roles)).filter(
+        (roleId) => !assignedRoleIds.has(roleId) && roleId !== userRole?.id
+      );
+
+      if (newRolesToAssign.length > 0) {
+        await postgresUserDataSource.setUserRoles(id, newRolesToAssign);
+        this.stfcRolesCache.remove(String(id));
+        this.uopRolesCache.remove(String(id));
+      }
+
+      return;
     } catch (error) {
       logger.logError('Error setting user roles in', {
         error,
@@ -446,47 +450,45 @@ export class StfcUserDataSource implements UserDataSource {
 
     return stfcRawRolesRequest!;
   }
-
   async getUserRoles(id: number): Promise<Role[]> {
     const cachedRoles = this.uopRolesCache.get(String(id));
     if (cachedRoles) {
       return cachedRoles;
     }
 
-    const systemRoleDefinitions = await this.getRoles();
+    const roleDefinitions = await this.getRoles();
+    if (!roleDefinitions) {
+      return [];
+    }
 
-    const userRole = systemRoleDefinitions.find(
+    const [assignedSystemUserRoles, stfcRoles] = await Promise.all([
+      postgresUserDataSource.getUserRoles(id),
+      this.getRolesForUser(id),
+    ]);
+
+    const userRole: Role | undefined = roleDefinitions.find(
       (role) => role.shortCode == Roles.USER
     );
     if (!userRole) {
       return [];
     }
 
-    const [assignedSystemUserRoles, UOWSRoles] = await Promise.all([
-      postgresUserDataSource.getUserRoles(id),
-      this.getRolesForUser(id),
-    ]);
-
-    if (!UOWSRoles || UOWSRoles.length === 0) {
-      const userRoles = [userRole, ...assignedSystemUserRoles];
-      this.uopRolesCache.put(String(id), Promise.resolve(userRoles));
-
-      return userRoles;
+    if (!stfcRoles || stfcRoles.length == 0) {
+      return [userRole];
     }
 
     const externalRoles = this.mapStfcRolesToSystemRoleDefinitions(
-      UOWSRoles,
-      systemRoleDefinitions
+      stfcRoles,
+      roleDefinitions
     );
 
-    const combinedUserRoles = [...assignedSystemUserRoles, ...externalRoles];
-    const uniqueUserRoles = new Map(
-      combinedUserRoles.map((role) => [role.id, role])
-    );
-    const sortedUserRoles = Array.from(uniqueUserRoles.values()).sort(
-      (a, b) => a.id - b.id
-    );
-    const userRoles = [userRole, ...sortedUserRoles];
+    const combinedUserRoles = [...externalRoles, ...assignedSystemUserRoles];
+
+    const uniqueRoles: Role[] = [...new Set(combinedUserRoles)];
+
+    uniqueRoles.sort((a, b) => a.id - b.id);
+
+    const userRoles = [userRole, ...uniqueRoles];
 
     this.uopRolesCache.put(String(id), Promise.resolve(userRoles));
 
@@ -495,37 +497,19 @@ export class StfcUserDataSource implements UserDataSource {
 
   private mapStfcRolesToSystemRoleDefinitions(
     stfcRoles: RoleDTO[] | undefined,
-    systemRoleDefinitions: Role[]
+    roleDefinitions: Role[]
   ): Role[] {
     if (!stfcRoles?.length) {
       return [];
     }
 
-    const rolesMap = new Map(
-      systemRoleDefinitions.map((r) => [r.shortCode, r])
-    );
-    const processedRoleIds = new Set<number>();
-    const mappedRoles: Role[] = [];
+    const userRolesAsEnum: Roles[] = stfcRoles
+      .flatMap((stfcRole) => stfcRolesToSystemRoleDefinitions[stfcRole.name!])
+      .filter((r) => r !== undefined) as Roles[];
 
-    for (const stfcRole of stfcRoles) {
-      const stfcRoleKey = stfcRole.name;
-      if (!stfcRoleKey) {
-        continue;
-      }
-
-      const systemRoles = stfcRolesToSystemRoleDefinitions[stfcRoleKey];
-      if (!systemRoles) {
-        continue;
-      }
-
-      for (const systemRoleEnum of systemRoles) {
-        const role = rolesMap.get(systemRoleEnum);
-        if (role && !processedRoleIds.has(role.id)) {
-          processedRoleIds.add(role.id);
-          mappedRoles.push(role);
-        }
-      }
-    }
+    const mappedRoles: Role[] = userRolesAsEnum
+      .map((r) => roleDefinitions.find((d) => d.shortCode === r))
+      .filter((r) => r !== undefined) as Role[];
 
     return mappedRoles;
   }

--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -25,7 +25,7 @@ type StfcRolesToEssRole = { [key: string]: Roles[] };
 /*
  * Must not contain user role, this is appended at the very last step.
  */
-const stfcRolesToEssRoleDefinitions: StfcRolesToEssRole = {
+const stfcRolesToSystemRoleDefinitions: StfcRolesToEssRole = {
   'User Officer': [Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST],
   'ISIS Instrument Scientist': [Roles.INSTRUMENT_SCIENTIST],
   'CLF Artemis FAP Secretary': [Roles.INSTRUMENT_SCIENTIST],
@@ -38,6 +38,7 @@ const stfcRolesToEssRoleDefinitions: StfcRolesToEssRole = {
   'FAP Secretary': [Roles.FAP_SECRETARY],
   'FAP Chair': [Roles.FAP_CHAIR],
   'Internal Reviewer': [Roles.INTERNAL_REVIEWER],
+  'Proposal Reader': [Roles.PROPOSAL_READER],
 };
 
 export type stfcRole = {
@@ -395,7 +396,35 @@ export class StfcUserDataSource implements UserDataSource {
   }
 
   async setUserRoles(id: number, roles: number[]): Promise<void> {
-    throw new Error('Method not implemented.');
+    try {
+      const allSystemRoles = await this.getRoles();
+      const rolesMap = new Map(allSystemRoles.map((role) => [role.id, role]));
+
+      const rootRoles = roles
+        .map((roleId) => rolesMap.get(roleId))
+        .filter((role): role is Role => role !== undefined && role.isRootRole);
+
+      if (rootRoles.length > 0) {
+        const rootRoleNames = rootRoles.map((role) => role.title).join(', ');
+        logger.logError('Cannot assign root roles to users', {
+          rootRoleNames,
+          userId: id,
+        });
+        throw new Error(
+          `Cannot assign root roles to users ${JSON.stringify(rootRoleNames)}.`
+        );
+      }
+      const uniqueRoles = Array.from(new Set(roles));
+      await postgresUserDataSource.setUserRoles(id, uniqueRoles);
+      this.stfcRolesCache.remove(String(id));
+      this.uopRolesCache.remove(String(id));
+    } catch (error) {
+      logger.logError('Error setting user roles in', {
+        error,
+        userId: id,
+      });
+      throw error;
+    }
   }
   async getRolesForUser(id: number): Promise<RoleDTO[]> {
     const cachedRoles = this.stfcRolesCache.get(String(id));
@@ -424,56 +453,81 @@ export class StfcUserDataSource implements UserDataSource {
       return cachedRoles;
     }
 
-    const stfcRawRolesRequest = this.getRolesForUser(id);
+    const systemRoleDefinitions = await this.getRoles();
 
-    const stfcRolesRequest = stfcRawRolesRequest.then((stfcRoles) => {
-      return this.getRoles().then((roleDefinitions) => {
-        const userRole: Role | undefined = roleDefinitions.find(
-          (role) => role.shortCode == Roles.USER
-        );
-        if (!userRole) {
-          return [];
+    const userRole = systemRoleDefinitions.find(
+      (role) => role.shortCode == Roles.USER
+    );
+    if (!userRole) {
+      return [];
+    }
+
+    const [assignedSystemUserRoles, UOWSRoles] = await Promise.all([
+      postgresUserDataSource.getUserRoles(id),
+      this.getRolesForUser(id),
+    ]);
+
+    if (!UOWSRoles || UOWSRoles.length === 0) {
+      const userRoles = [userRole, ...assignedSystemUserRoles];
+      this.uopRolesCache.put(String(id), Promise.resolve(userRoles));
+
+      return userRoles;
+    }
+
+    const externalRoles = this.mapStfcRolesToSystemRoleDefinitions(
+      UOWSRoles,
+      systemRoleDefinitions
+    );
+
+    const combinedUserRoles = [...assignedSystemUserRoles, ...externalRoles];
+    const uniqueUserRoles = new Map(
+      combinedUserRoles.map((role) => [role.id, role])
+    );
+    const sortedUserRoles = Array.from(uniqueUserRoles.values()).sort(
+      (a, b) => a.id - b.id
+    );
+    const userRoles = [userRole, ...sortedUserRoles];
+
+    this.uopRolesCache.put(String(id), Promise.resolve(userRoles));
+
+    return userRoles;
+  }
+
+  private mapStfcRolesToSystemRoleDefinitions(
+    stfcRoles: RoleDTO[] | undefined,
+    systemRoleDefinitions: Role[]
+  ): Role[] {
+    if (!stfcRoles?.length) {
+      return [];
+    }
+
+    const rolesMap = new Map(
+      systemRoleDefinitions.map((r) => [r.shortCode, r])
+    );
+    const processedRoleIds = new Set<number>();
+    const mappedRoles: Role[] = [];
+
+    for (const stfcRole of stfcRoles) {
+      const stfcRoleKey = stfcRole.name;
+      if (!stfcRoleKey) {
+        continue;
+      }
+
+      const systemRoles = stfcRolesToSystemRoleDefinitions[stfcRoleKey];
+      if (!systemRoles) {
+        continue;
+      }
+
+      for (const systemRoleEnum of systemRoles) {
+        const role = rolesMap.get(systemRoleEnum);
+        if (role && !processedRoleIds.has(role.id)) {
+          processedRoleIds.add(role.id);
+          mappedRoles.push(role);
         }
+      }
+    }
 
-        if (!stfcRoles || stfcRoles.length == 0) {
-          return [userRole];
-        }
-
-        /*
-         * Convert the STFC roles to the Roles enums which refers to roles
-         * by short code. We will use the short code to filter relevant
-         * roles.
-         */
-        const userRolesAsEnum: Roles[] = stfcRoles
-          .flatMap((stfcRole) => stfcRolesToEssRoleDefinitions[stfcRole.name!])
-          .filter((r) => r !== undefined) as Roles[];
-
-        /*
-         * Filter relevant roles by short code.
-         */
-        const userRolesAsRole: Role[] = userRolesAsEnum
-          .map((r) => roleDefinitions.find((d) => d.shortCode === r))
-          .filter((r) => r !== undefined) as Role[];
-
-        /*
-         * We can't return non-unique roles.
-         */
-        const uniqueRoles: Role[] = [...new Set(userRolesAsRole)];
-
-        uniqueRoles.sort((a, b) => a.id - b.id);
-
-        /*
-         * Prepend the user role as it must be first.
-         */
-        const userRoles = [userRole, ...uniqueRoles];
-
-        return userRoles;
-      });
-    });
-
-    this.uopRolesCache.put(String(id), stfcRolesRequest);
-
-    return stfcRolesRequest;
+    return mappedRoles;
   }
 
   async getRoles(): Promise<Role[]> {

--- a/apps/e2e/cypress/e2e/tag.cy.ts
+++ b/apps/e2e/cypress/e2e/tag.cy.ts
@@ -19,10 +19,7 @@ const instrument1 = {
 context('Tag tests', () => {
   beforeEach(function () {
     cy.getAndStoreFeaturesEnabled().then(() => {
-      if (
-        !featureFlags.getEnabledFeatures().get(FeatureId.TAGS) ||
-        !featureFlags.getEnabledFeatures().get(FeatureId.OAUTH) // TODO implement method setUserRoles in StfcUserDataSource and remove this condition
-      ) {
+      if (!featureFlags.getEnabledFeatures().get(FeatureId.TAGS)) {
         this.skip();
       }
     });

--- a/apps/e2e/cypress/e2e/tag.cy.ts
+++ b/apps/e2e/cypress/e2e/tag.cy.ts
@@ -201,6 +201,7 @@ context('Tag tests', () => {
 
       cy.login('officer');
       cy.visit('/admin/roles');
+      cy.finishedLoading();
       cy.get('[aria-label="Assign Tag"]').click();
 
       cy.get('[role="dialog"]').contains(tagName).click();

--- a/apps/e2e/cypress/e2e/tag.cy.ts
+++ b/apps/e2e/cypress/e2e/tag.cy.ts
@@ -6,7 +6,12 @@ import initialDBData from '../support/initialDBData';
 
 const tagName = faker.word.words(2);
 const tagShortCode = faker.word.words(1);
-
+const dynamicRoleDetails = {
+  id: 11,
+  title: 'Dynamic Proposal Reader',
+  description: 'Role that can only see calls and proposals with specific tags',
+  shortCode: 'proposal_reader',
+};
 const scientist1 = initialDBData.users.user1;
 
 const instrument1 = {
@@ -178,17 +183,17 @@ context('Tag tests', () => {
 
       cy.get('[data-cy="create-new-entry"]').click();
 
-      cy.get('[data-cy="role-title-input"]').type('Dynamic Proposal Reader');
+      cy.get('[data-cy="role-title-input"]').type(dynamicRoleDetails.title);
       cy.get('[data-cy="role-description-input"]').type(
-        'Role that can only see calls and proposals with specific tags'
+        dynamicRoleDetails.description
       );
       cy.get('[data-cy="role-shortcode-select"]').click();
-      cy.get('[role="listbox"]').contains('proposal_reader').click();
+      cy.get('[role="listbox"]').contains(dynamicRoleDetails.shortCode).click();
       cy.get('[data-cy="submit-role-button"]').click();
 
       cy.updateUserRoles({
         id: initialDBData.users.user1.id,
-        roles: [11], // newly created role
+        roles: [dynamicRoleDetails.id], // newly created role
       });
 
       cy.login('user1');
@@ -202,13 +207,20 @@ context('Tag tests', () => {
       cy.login('officer');
       cy.visit('/admin/roles');
       cy.finishedLoading();
-      cy.get('[aria-label="Assign Tag"]').click();
 
-      cy.get('[role="dialog"]').contains(tagName).click();
+      cy.contains('tr', dynamicRoleDetails.title)
+        .find('[aria-label="Assign Tags"]')
+        .click();
+
+      cy.get('[role="dialog"] input[placeholder="Select tags"]')
+        .should('be.visible')
+        .click()
+        .type(tagName);
+
+      cy.get('[role="option"]').contains(tagName).should('be.visible').click();
 
       cy.get('[role="dialog"] [data-cy="assign-selected-tags"]').click();
-
-      cy.login('user1');
+      cy.login('user1', dynamicRoleDetails.id);
       cy.visit('/Proposals');
 
       cy.contains(title).should('exist');


### PR DESCRIPTION
## Description
This PR implements dynamic roles for STFC users.

## Motivation and Context
This change is required to accurately reflect the roles of STFC users within the system, allowing the application to correctly assign permissions and access levels based on these roles.

## Changes
1. The `stfcRolesToEssRoleDefinitions` constant has been renamed to `stfcRolesToSystemRoleDefinitions` and a new role, 'Proposal Reader', has been added to the role definitions.
2. The `setUserRoles` function has been implemented to assign roles to users and handle any errors that may occur during this process.
3. The `getRolesForUser` function has been updated to get user roles from both the system and STFC, combine them, remove duplicates, sort them, and return them.
4. A new private function, `mapStfcRolesToSystemRoleDefinitions`, has been added to map STFC roles to system role definitions.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[1532](https://github.com/UserOfficeProject/issue-tracker/issues/1534)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated