### PR TITLE
fix: proposal technical review in proposal Excel export

### DIFF
--- a/apps/backend/src/factory/xlsx/proposal.ts
+++ b/apps/backend/src/factory/xlsx/proposal.ts
@@ -2,6 +2,7 @@ import {
   getTranslation,
   ResourceId,
 } from '@user-office-software/duo-localisation';
+import { stripHtml } from 'string-strip-html';
 
 import baseContext from '../../buildContext';
 import { ProposalEndStatus } from '../../models/Proposal';
@@ -86,7 +87,11 @@ export const collectProposalXLSXData = async (
           .join(', ')
       : '<missing>',
     technicalReviews
-      ?.map((technicalReview) => technicalReview?.publicComment || '<missing>')
+      ?.map(
+        (technicalReview) =>
+          stripHtml(technicalReview.publicComment ?? '').result.trim() ||
+          '<missing>'
+      )
       .join(', ') || '<missing>',
     technicalReviews
       ?.map((technicalReview) => technicalReview?.timeAllocation ?? '<missing>')


### PR DESCRIPTION
## Description
This fixes some proposals failing to export via Excel, because their technical review exceeds Excel's maximum column length. This can happen when a user uploads images using the tech review HTML editor and it gets converted and stored as a very long Base64 string.

## Motivation and Context
STFC had one proposal that was failing to export with `"Text length must not exceed 32767 characters"` error.

## Changes
- Imported the 'string-strip-html' function to strip HTML tags from strings.
- Applied the 'string-strip-html' function to the 'publicComment' field of the proposal technical review data before it is exported to Excel.
- Trimmed the resulting string to remove any leading or trailing white space.

## How Has This Been Tested?

Manual testing the Excel export before and after applying the fix.

## Fixes Jira Issue

https://github.com/UserOfficeProject/issue-tracker/issues/1538

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated