### PR TITLE
fix: update dependabot configuration for weekly PR scheduling and limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'sunday'
-    # Limit PRs open from dependabot to avoid reaching job runners limt
-    open-pull-requests-limit: 2
+      day: 'saturday'
+      time: '08:00'
+    # Only 1 PR at a time so e2e tests pass and automerge completes before the next PR opens
+    open-pull-requests-limit: 1
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen because docker hub doesn't want slashes
       # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
@@ -21,8 +22,9 @@ updates:
     directory: '/apps/backend'
     schedule:
       interval: 'weekly'
-      day: 'sunday'
-    open-pull-requests-limit: 2
+      day: 'saturday'
+      time: '10:00'
+    open-pull-requests-limit: 1
     pull-request-branch-name:
       separator: '-'
     versioning-strategy: increase-if-necessary
@@ -33,8 +35,9 @@ updates:
     directory: '/apps/frontend'
     schedule:
       interval: 'weekly'
-      day: 'sunday'
-    open-pull-requests-limit: 2
+      day: 'saturday'
+      time: '12:00'
+    open-pull-requests-limit: 1
     pull-request-branch-name:
       separator: '-'
     versioning-strategy: increase-if-necessary
@@ -46,7 +49,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'sunday'
-    open-pull-requests-limit: 2
+      time: '08:00'
+    open-pull-requests-limit: 1
     pull-request-branch-name:
       separator: '-'
     versioning-strategy: increase-if-necessary
@@ -58,7 +62,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'sunday'
-    open-pull-requests-limit: 2
+      time: '10:00'
+    open-pull-requests-limit: 1
     pull-request-branch-name:
       separator: '-'
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
## Description
This PR updates the scheduling and limits of Dependabot configuration to reduce manual work of clicking "Update branch"

## Motivation and Context
The change ensures that all e2e tests pass and auto-merging completes before the next PR opens

## Changes
- Updated the scheduling of Dependabot to weekly on Saturday and Sunday at specific times.
- Limited the open pull requests by Dependabot to 1 at a time to ensure e2e tests pass and auto-merge completes before the next PR opens.

