### PR TITLE
fix: move frontend client names from metric labels to logs

### DIFF
--- a/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
+++ b/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
@@ -4,6 +4,7 @@ import {
   GraphQLRequestContext,
   GraphQLRequestContextWillSendResponse,
 } from '@apollo/server';
+import { logger } from '@user-office-software/duo-logger';
 import { GraphQLError, GraphQLFormattedError } from 'graphql';
 import { Counter, Histogram } from 'prom-client';
 
@@ -53,12 +54,19 @@ export const apolloServerMetricsPlugin = (): ApolloServerPlugin => ({
     const operationType = getOperationType(request.query);
     const clientName =
       request.http?.headers.get('apollographql-client-name') || 'unknown';
+    let apiClient = 'unknown';
+    if (clientName.startsWith('UOP frontend')) {
+      logger.logInfo('GraphQL request received', {
+        client: clientName,
+        operation: operationName,
+      });
+    } else apiClient = clientName;
 
     const labels: MetricLabels = {
       operation: operationName,
       operation_type: operationType,
       status: 'success',
-      client_name: clientName,
+      client_name: apiClient,
     };
 
     const end = graphqlRequestDuration.startTimer(labels);

--- a/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
+++ b/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
@@ -58,7 +58,9 @@ export const apolloServerMetricsPlugin = (): ApolloServerPlugin => ({
     if (clientName.startsWith('UOP frontend')) {
       logger.logInfo('GraphQL request received', {
         client: clientName,
+        client_type: 'frontend',
         operation: operationName,
+        operation_Type: operationType,
       });
     } else apiClient = clientName;
 

--- a/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
+++ b/apps/backend/src/middlewares/metrics/apolloServerMetricsPlugin.ts
@@ -54,21 +54,20 @@ export const apolloServerMetricsPlugin = (): ApolloServerPlugin => ({
     const operationType = getOperationType(request.query);
     const clientName =
       request.http?.headers.get('apollographql-client-name') || 'unknown';
-    let apiClient = 'unknown';
-    if (clientName.startsWith('UOP frontend')) {
+    const isFrontendClient = clientName.startsWith('UOP frontend');
+    if (isFrontendClient) {
       logger.logInfo('GraphQL request received', {
         client: clientName,
         client_type: 'frontend',
         operation: operationName,
         operation_Type: operationType,
       });
-    } else apiClient = clientName;
-
+    }
     const labels: MetricLabels = {
       operation: operationName,
       operation_type: operationType,
       status: 'success',
-      client_name: apiClient,
+      client_name: isFrontendClient ? 'frontend' : clientName,
     };
 
     const end = graphqlRequestDuration.startTimer(labels);


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
This PR aims to reduce metric cardinality by moving UOP frontend client names from Prometheus/Mimir metric labels to logs.


<!--- Describe your changes in detail -->

## Motivation and Context
Previously, all client names were added to the `client_name` metric label, which significantly increased time series cardinality due to the dynamic and high-volume nature of frontend clients. This contributed to slower Grafana dashboard loads and increased query execution time in Mimir.
Internal API clients are a fixed and controlled set of values, so retaining them in metric labels should not significantly increase cardinality.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
