### PR TITLE
fix: the sorting of users on /people page

### DIFF
--- a/apps/backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/backend/src/datasources/postgres/UserDataSource.ts
@@ -260,7 +260,7 @@ export default class PostgresUserDataSource implements UserDataSource {
       })
       .first()
       .then((user: UserRecord & InstitutionRecord & CountryRecord) =>
-        !!user ? createBasicUserObject(user) : null
+        user ? createBasicUserObject(user) : null
       );
   }
 

--- a/apps/backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/backend/src/datasources/postgres/UserDataSource.ts
@@ -36,6 +36,8 @@ const fieldMap: { [key: string]: string } = {
   preferredname: 'preferredname',
   lastname: 'lastname',
   institution: 'i.institution',
+  email: 'email',
+  oidcSub: 'oidc_sub'
 };
 
 export default class PostgresUserDataSource implements UserDataSource {
@@ -258,7 +260,7 @@ export default class PostgresUserDataSource implements UserDataSource {
       })
       .first()
       .then((user: UserRecord & InstitutionRecord & CountryRecord) =>
-        user ? createBasicUserObject(user) : null
+        !!user ? createBasicUserObject(user) : null
       );
   }
 
@@ -433,7 +435,10 @@ export default class PostgresUserDataSource implements UserDataSource {
             throw new GraphQLError(`Bad sort field given: ${sortField}`);
           }
           sortField = fieldMap[sortField];
-          query.orderBy(sortField, sortDirection);
+          query.orderByRaw(
+            `LOWER(??) ${sortDirection}, ?? ${sortDirection}`,
+            [sortField, sortField]
+          );
         }
       })
       .then(

--- a/apps/backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/backend/src/datasources/postgres/UserDataSource.ts
@@ -37,7 +37,7 @@ const fieldMap: { [key: string]: string } = {
   lastname: 'lastname',
   institution: 'i.institution',
   email: 'email',
-  oidcSub: 'oidc_sub'
+  oidcSub: 'oidc_sub',
 };
 
 export default class PostgresUserDataSource implements UserDataSource {
@@ -435,10 +435,7 @@ export default class PostgresUserDataSource implements UserDataSource {
             throw new GraphQLError(`Bad sort field given: ${sortField}`);
           }
           sortField = fieldMap[sortField];
-          query.orderByRaw(
-            `LOWER(??) ${sortDirection}, ?? ${sortDirection}`,
-            [sortField, sortField]
-          );
+          query.orderByRaw(`LOWER(??) ${sortDirection}`, [sortField]);
         }
       })
       .then(


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

fixes the existing bug that occours when you try to sort the people by "User Name" and "Email" on the /people page. It also makes the sorting case insensitive. Without this fix it orders by askii values so "A" and "a" are separated.

## Motivation and Context

Fixes the bug on sorting in /people

## How Has This Been Tested

Tested with the frontend pressing the ordering button.

BEFORE:
<img width="3379" height="1253" alt="image" src="https://github.com/user-attachments/assets/b10804c8-b6a6-47df-b7c0-d1c95864b8ff" />

AFTER:
<img width="3366" height="1244" alt="image" src="https://github.com/user-attachments/assets/fd504d12-659e-4bf9-bd0a-40ce99bd0cce" />

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated