### PR TITLE
fix: add role guard to user officer proposals table

### DIFF
--- a/apps/frontend/src/components/AppRoutes.tsx
+++ b/apps/frontend/src/components/AppRoutes.tsx
@@ -238,10 +238,16 @@ const AppRoutes = () => {
           }
         />
 
-        <Route
-          path="/Proposals"
-          element={<TitledRoute title="Proposals" element={<ProposalPage />} />}
-        />
+        {isUserOfficer || isProposalReader ? (
+          <Route
+            path="/Proposals"
+            element={
+              <TitledRoute title="Proposals" element={<ProposalPage />} />
+            }
+          />
+        ) : (
+          <Route path="/Proposals" element={<Navigate to="/" replace />} />
+        )}
         {isTechniqueProposalsEnabled &&
           (isInstrumentScientist || isUserOfficer) && (
             <Route


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->
Closes UserOfficeProject/issue-tracker/issues/990
## Description

Currently, unauthorized roles could access the `ProposalTableOfficer` component by navigating to the `/Proposals` route manually. This change makes it such only the `User Officer` and `Proposal Reader` roles are allowed to access it. Any unauthorized roles attempting to access the `/Proposals` route directly will be redirected back to the main dashboard (`/`)
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes
Frontend AppRoutes.tsx: 
- Added conditional guards based on user roles (`isUserOfficer` || `isProposalReader`)
- Added a fallback route for `/Proposals` that redirects unauthorized roles back to `/`
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
