### PR TITLE
fix: remove extra row in questionaries in inital db setup

### DIFF
--- a/apps/backend/db_patches/0212_removeQuestionariesEntryFromSeed.sql
+++ b/apps/backend/db_patches/0212_removeQuestionariesEntryFromSeed.sql
@@ -1,0 +1,14 @@
+DO
+$$
+BEGIN
+	IF register_patch('RemoveQuestionariesEntryFromSeed.sql', 'Zachary Hankin', 'Removes entry in questionaries that is left over from initialising db', '2026-06-01') THEN
+	BEGIN
+        DELETE FROM questionaries
+        WHERE questionary_id = 1
+        AND template_id = 2
+        AND creator_id = 0;
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

When you start the database from scratch and apply all of the seeds and patches you are left with one row in the questionaries table. This row contains a FK reference to user 0, which is the service account. We want to delete this account when starting a new instance of UOP, and we get an error. The questionaries table row can't be easily? deleted in the gui. So this just makes initial startup easier. 

Error that is shown when you try to delete the service user in the gui after startup.
<img width="1555" height="954" alt="screenshot-1" src="https://github.com/user-attachments/assets/dde03a36-a3f6-4123-9019-1d4b7ec3cd5f" />

This row is added here:
[this](https://github.com/UserOfficeProject/user-office-core/pull/691) pull request, apps/backend/db_patches/0158_AddFAPReviewTemplate.sql line 45.

picture of DB just after starting up
<img width="1296" height="301" alt="image" src="https://github.com/user-attachments/assets/5aa164e9-6462-4b26-b2f7-8f3bffe4f47f" />


## How Has This Been Tested

Locally ran though starting the database and tested deleting the service account with my user in it. 
<img width="1973" height="184" alt="image" src="https://github.com/user-attachments/assets/bf24e041-7c36-4ee3-ab38-a2ead0a58d95" />


## Changes

Adds a patch to delete one row from questionaries.

