### PR TITLE
fix: add sort by enum to GQL endpoint

### DIFF
--- a/apps/backend/src/datasources/postgres/ExperimentDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ExperimentDataSource.ts
@@ -90,18 +90,17 @@ type SortableExperimentTableColumnName =
   | 'starts_at'
   | 'ends_at';
 
-// Which fields we are allowed to sort on
+// Maps a sortable column from the API to its database column.
+// Instrument and experiment safety status are intentionally omitted
+// (not sortable at the DB layer; create a view later if needed).
 const fieldMap: Record<
   ExperimentTableSortField,
   SortableExperimentTableColumnName
 > = {
-  experimentId: 'experiment_id',
-  'proposal.proposalId': 'proposal_id',
-  startsAt: 'starts_at',
-  endsAt: 'ends_at',
-  // We don't sort on the fields below, create a view later if sorting needed
-  // 'instrument.name': 'instrument_id',
-  // 'experimentSafety.status.name': '',
+  [ExperimentTableSortField.experimentId]: 'experiment_id',
+  [ExperimentTableSortField.proposalId]: 'proposal_id',
+  [ExperimentTableSortField.startsAt]: 'starts_at',
+  [ExperimentTableSortField.endsAt]: 'ends_at',
 };
 
 @injectable()

--- a/apps/backend/src/resolvers/queries/ExperimentsQuery.ts
+++ b/apps/backend/src/resolvers/queries/ExperimentsQuery.ts
@@ -8,6 +8,7 @@ import {
   Int,
   InputType,
   ObjectType,
+  registerEnumType,
 } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
@@ -24,11 +25,17 @@ class TimeSpan {
   to?: Date;
 }
 
-export type ExperimentTableSortField =
-  | 'experimentId'
-  | 'proposal.proposalId'
-  | 'startsAt'
-  | 'endsAt';
+export enum ExperimentTableSortField {
+  experimentId = 'experimentId',
+  proposalId = 'proposalId',
+  startsAt = 'startsAt',
+  endsAt = 'endsAt',
+}
+
+registerEnumType(ExperimentTableSortField, {
+  name: 'ExperimentTableSortField',
+  description: 'Experiment table columns that support sorting',
+});
 
 @InputType()
 export class ExperimentsFilter {
@@ -65,7 +72,7 @@ export class ExperimentsArgs {
   @Field(() => Int, { nullable: true })
   public offset?: number;
 
-  @Field({ nullable: true })
+  @Field(() => ExperimentTableSortField, { nullable: true })
   public sortField?: ExperimentTableSortField;
 
   @Field(() => PaginationSortDirection, { nullable: true })

--- a/apps/frontend/src/components/experiment/ExperimentsTable.tsx
+++ b/apps/frontend/src/components/experiment/ExperimentsTable.tsx
@@ -8,7 +8,12 @@ import { IconButton, Tooltip, Typography } from '@mui/material';
 import React, { useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { Experiment, PaginationSortDirection, SettingsId } from 'generated/sdk';
+import {
+  Experiment,
+  ExperimentTableSortField,
+  PaginationSortDirection,
+  SettingsId,
+} from 'generated/sdk';
 import { useFormattedDateTime } from 'hooks/admin/useFormattedDateTime';
 import { setSortDirectionOnSortField } from 'utils/helperFunctions';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
@@ -22,6 +27,14 @@ import { ExperimentsFilter } from './ExperimentsPage';
 type ExperimentsTableProps = {
   experimentsFilter: ExperimentsFilter;
   setExperimentsFilter?: (filter: ExperimentsFilter) => void;
+};
+
+// Maps a material-table column `field` to the GraphQL sort enum.
+const COLUMN_FIELD_TO_SORT_FIELD: Record<string, ExperimentTableSortField> = {
+  experimentId: ExperimentTableSortField.EXPERIMENTID,
+  'proposal.proposalId': ExperimentTableSortField.PROPOSALID,
+  startsAt: ExperimentTableSortField.STARTSAT,
+  endsAt: ExperimentTableSortField.ENDSAT,
 };
 
 const RowActionButtons = (rowData: Experiment) => {
@@ -111,7 +124,9 @@ export default function ExperimentsTable({
               ...(experimentStartDate ? { experimentStartDate } : {}),
               ...(experimentEndDate ? { experimentEndDate } : {}),
             },
-            sortField: orderBy?.orderByField,
+            sortField: orderBy
+              ? COLUMN_FIELD_TO_SORT_FIELD[orderBy.orderByField]
+              : undefined,
             sortDirection:
               orderBy?.orderDirection == PaginationSortDirection.ASC
                 ? PaginationSortDirection.ASC

--- a/apps/frontend/src/graphql/experiment/getAllExperiments.graphql
+++ b/apps/frontend/src/graphql/experiment/getAllExperiments.graphql
@@ -2,7 +2,7 @@ query getExperiments(
   $filter: ExperimentsFilter
   $first: Int
   $offset: Int
-  $sortField: String
+  $sortField: ExperimentTableSortField
   $sortDirection: PaginationSortDirection
   $searchText: String
 ) {


### PR DESCRIPTION
## Description
This PR introduces an improvement to the GraphQL sorting functionality by adding an enum for sortable fields.

## Motivation and Context
The change was needed to ensure type safety and allow for more precise sorting in the GraphQL endpoint.

## Changes
- Replaced the type of sortable fields from string to enum, which provides type safety.
- Registered the enum type in the ExperimentTableSortField.
- Updated the frontend to map the column field to the correct enum value.
- Updated the GraphQL query to accept the enum type for the sort field.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/SWAP-5630](https://jira.ess.eu//browse/SWAP-5630)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated