### PR TITLE
fix: invite chips overflow out of invites-chips box

### DIFF
--- a/apps/frontend/src/components/common/UserManagementTable.tsx
+++ b/apps/frontend/src/components/common/UserManagementTable.tsx
@@ -157,10 +157,9 @@ const UserManagementTable = ({
             <Box
               sx={{
                 display: 'flex',
-                flexDirection: 'row',
                 marginTop: 1,
                 gap: 1,
-                alignItems: 'center',
+                alignItems: 'flex-start',
               }}
               data-cy="invites-chips"
             >
@@ -170,21 +169,25 @@ const UserManagementTable = ({
                   color: 'grey',
                   paddingRight: '10px',
                   display: 'inline-block',
+                  whiteSpace: 'nowrap',
+                  mt: '4px',
                 }}
               >
                 Invited:
               </Typography>
-              {invites.map((invite) => (
-                <Chip
-                  sx={{ gap: '2px', padding: '6px' }}
-                  color="secondary"
-                  icon={invite.isEmailSent ? <SendIcon /> : <ScheduleSend />}
-                  size="small"
-                  label={invite.email}
-                  key={invite.email}
-                  onDelete={() => handleDeleteInvite(invite)}
-                />
-              ))}
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, flex: 1 }}>
+                {invites.map((invite) => (
+                  <Chip
+                    sx={{ gap: '2px', padding: '6px' }}
+                    color="secondary"
+                    icon={invite.isEmailSent ? <SendIcon /> : <ScheduleSend />}
+                    size="small"
+                    label={invite.email}
+                    key={invite.email}
+                    onDelete={() => handleDeleteInvite(invite)}
+                  />
+                ))}
+              </Box>
             </Box>
           )}
           <ActionButtonContainer


### PR DESCRIPTION
## Description
This PR fixes an issue where the invite chips were overflowing out of the invites-chips box.

## Motivation and Context
The change is required to improve the UI and enhance the user experience by ensuring that the invite chips are properly contained within the invites-chips box. This resolves the problem of UI elements overflowing, which could lead to a confusing and visually unappealing user interface.

## Changes
- Changed the alignment of the invite chips box from center to flex-start to ensure that the chips are aligned to the start of the box.
- Added a wrapping functionality to the invite chips box to ensure that the chips wrap within the box if there are too many.
- Added a nowrap property to the "Invited:" label to prevent it from breaking into multiple lines.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/SWAP-5414](https://jira.ess.eu//browse/SWAP-5414)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated