### PR TITLE
fix: creating derived roles from certain base roles

### DIFF
--- a/apps/backend/src/datasources/postgres/RoleDataSource.ts
+++ b/apps/backend/src/datasources/postgres/RoleDataSource.ts
@@ -23,7 +23,7 @@ function defaultConfig(shortCode: string): unknown {
         hasAdminAccess: false,
       };
     default:
-      return {};
+      return { note: '' };
   }
 }
 

--- a/apps/frontend/src/components/admin/RoleModal.tsx
+++ b/apps/frontend/src/components/admin/RoleModal.tsx
@@ -127,7 +127,7 @@ const RoleModal: React.FC<RoleModalProps> = ({
           config: { proposalReader: config as ProposalReaderRoleConfig },
         };
       default:
-        return { config: {} };
+        return { config: { user: { note: '' } } };
     }
   };
 

--- a/apps/frontend/src/components/settings/workflow/WorkflowEditorModel.tsx
+++ b/apps/frontend/src/components/settings/workflow/WorkflowEditorModel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { produce } from 'immer';
 import { Reducer, useCallback, useEffect } from 'react';
 import { useParams } from 'react-router-dom';


### PR DESCRIPTION
## Description

Deriving a role from any role that's not `user` or `proposal_reader` throws the following error:
<img width="873" height="52" alt="image" src="https://github.com/user-attachments/assets/84e7e21d-3b8e-43db-a250-74c36c165390" />

## Motivation and Context

A change was introduced that requires derived roles to have configs. For derived roles that are not `user` or `proposal_reader`, they are given an empty config, which is not allowed by GraphQL mutation specification. This causes a GraphQL error when creating derived roles.

## How Has This Been Tested

Tested manually. We should add tests to cover role management.

## Changes

The default role config was changed from an empty object to one with a note property with an empty string value.