### PR TITLE
fix: visit template question Preview crashes

### DIFF
--- a/apps/frontend/src/components/template/PreviewTemplateModal.tsx
+++ b/apps/frontend/src/components/template/PreviewTemplateModal.tsx
@@ -22,10 +22,12 @@ import TechnicalReviewQuestionary, {
   createTechnicalReviewStub,
 } from 'components/review/TechnicalReviewQuestionary';
 import ShipmentContainer from 'components/shipments/ShipmentContainer';
+import VisitRegistrationContainer from 'components/visit/VisitRegistrationContainer';
 import { UserContext } from 'context/UserContextProvider';
 import { BasicUserDetails, TemplateGroupId } from 'generated/sdk';
 import { useBlankQuestionaryStepsData } from 'hooks/questionary/useBlankQuestionaryStepsData';
 import { createShipmentStub } from 'hooks/shipment/useBlankShipment';
+import { createRegistrationStub } from 'hooks/visit/useBlankVisitRegistration';
 
 type PreviewTemplateModalProps = {
   templateId: number | null;
@@ -78,8 +80,19 @@ const PreviewTemplateModal = ({
             previewMode={true}
           />
         );
-      case TemplateGroupId.FEEDBACK:
       case TemplateGroupId.VISIT_REGISTRATION:
+        return (
+          <VisitRegistrationContainer
+            registration={createRegistrationStub(
+              user?.id ?? 0,
+              templateId,
+              questionarySteps,
+              0
+            )}
+            previewMode={true}
+          />
+        );
+      case TemplateGroupId.FEEDBACK:
       case TemplateGroupId.GENERIC_TEMPLATE:
         return (
           <GenericTemplateContainer

--- a/apps/frontend/src/components/template/TemplateEditor.tsx
+++ b/apps/frontend/src/components/template/TemplateEditor.tsx
@@ -1,103 +1,40 @@
-import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
-import Preview from '@mui/icons-material/Preview';
 import Button from '@mui/material/Button';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormGroup from '@mui/material/FormGroup';
-import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
-import { useTheme } from '@mui/material/styles';
-import Switch from '@mui/material/Switch';
-import Tooltip from '@mui/material/Tooltip';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import React, { useState } from 'react';
 
-import {
-  Question,
-  QuestionaryStep,
-  QuestionTemplateRelation,
-  Template,
-} from 'generated/sdk';
 import { usePersistQuestionaryEditorModel } from 'hooks/questionary/usePersistQuestionaryEditorModel';
+import { useTemplateEditorSelection } from 'hooks/questionary/useTemplateEditorSelection';
 import QuestionaryEditorModel, {
-  Event,
   EventType,
 } from 'models/questionary/QuestionaryEditorModel';
-import {
-  getFieldById,
-  getQuestionaryStepByTopicId,
-} from 'models/questionary/QuestionaryFunctions';
+import { handleTemplateDragEnd } from 'models/questionary/templateEditorDragHandlers';
 import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
-import { MiddlewareInputParams } from 'utils/useReducerWithMiddleWares';
-import { FunctionType } from 'utils/utilTypes';
 
 import PreviewTemplateModal from './PreviewTemplateModal';
 import QuestionEditor from './QuestionEditor';
-import { QuestionPicker } from './QuestionPicker';
 import QuestionTemplateRelationEditor from './QuestionTemplateRelationEditor';
+import { TemplateEditorContent } from './TemplateEditorContent';
+import { TemplateEditorToolbar } from './TemplateEditorToolbar';
 import { TemplateMetadataEditor } from './TemplateMetadataEditor';
-import QuestionaryEditorTopic from './TemplateTopicEditor';
 
 export default function TemplateEditor() {
   const { api } = useDataApiWithFeedback();
-  const [
+
+  const {
     selectedQuestionTemplateRelation,
     setSelectedQuestionTemplateRelation,
-  ] = useState<QuestionTemplateRelation | null>(null);
-  const [selectedQuestion, setSelectedQuestion] = useState<Question | null>(
-    null
-  );
+    selectedQuestion,
+    setSelectedQuestion,
+    hoveredDependency,
+    openedPreviewTemplateId,
+    setOpenedPreviewTemplateId,
+    questionPickerTopicId,
+    setQuestionPickerTopicId,
+    handleEvents,
+  } = useTemplateEditorSelection();
 
-  const [hoveredDependency, setHoveredDependency] = useState<string>('');
-  const [openedPreviewTemplateId, setOpenedPreviewTemplateId] = useState<
-    number | null
-  >(null);
-
-  const [questionPickerTopicId, setQuestionPickerTopicId] = useState<
-    number | null
-  >(null);
-  const handleEvents = ({
-    getState,
-  }: MiddlewareInputParams<Template, Event>) => {
-    return (next: FunctionType) => (action: Event) => {
-      next(action);
-      switch (action.type) {
-        case EventType.QUESTION_CREATED:
-          setSelectedQuestion(action.payload);
-          break;
-
-        case EventType.PICK_QUESTION_REQUESTED:
-          setQuestionPickerTopicId(action.payload.topic.id);
-          break;
-
-        case EventType.OPEN_QUESTION_EDITOR:
-          setSelectedQuestion(action.payload);
-          break;
-
-        case EventType.OPEN_QUESTIONREL_EDITOR:
-          const templateRelation = getFieldById(
-            getState().steps,
-            action.payload.questionId
-          );
-          if (!templateRelation) {
-            return;
-          }
-
-          setSelectedQuestionTemplateRelation(
-            templateRelation as QuestionTemplateRelation
-          );
-          break;
-
-        case EventType.QUESTION_PICKER_NEW_QUESTION_CLICKED:
-          setQuestionPickerTopicId(action.payload.topic.id);
-          break;
-        case EventType.DEPENDENCY_HOVER:
-          setHoveredDependency(action.payload.dependency);
-          break;
-      }
-    };
-  };
   const { persistModel, isLoading } = usePersistQuestionaryEditorModel();
   const { state, dispatch } = QuestionaryEditorModel([
     persistModel,
@@ -106,167 +43,14 @@ export default function TemplateEditor() {
 
   const [isTopicReorderMode, setIsTopicReorderMode] = useState(false);
 
-  const theme = useTheme();
-  const isExtraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
-
-  const getTopicListStyle = (isDraggingOver: boolean) => ({
-    background: isDraggingOver
-      ? theme.palette.primary.light
-      : theme.palette.grey[100],
-    transition: 'all 500ms cubic-bezier(0.190, 1.000, 0.220, 1.000)',
-    display: 'flex',
-    overflow: 'auto',
-    maxHeight: isExtraLargeScreen ? '1400px' : '700px',
-  });
-
-  const onDragEnd = (result: DropResult): void => {
-    const dragSource = result.source;
-    const dragDestination = result.destination;
-
-    if (
-      !dragDestination ||
-      (dragDestination.droppableId === dragSource.droppableId &&
-        dragDestination.index === dragSource.index)
-    ) {
-      return;
-    }
-
-    const isDraggingQuestion = result.type === 'field';
-    const isDraggingTopic = result.type === 'topic';
-
-    if (isDraggingQuestion) {
-      const isDraggingFromQuestionDrawerToTopic =
-        dragSource.droppableId === 'questionPicker' &&
-        dragDestination.droppableId !== 'questionPicker';
-      const isDraggingFromTopicToQuestionDrawer =
-        dragDestination.droppableId === 'questionPicker' &&
-        dragSource.droppableId !== 'questionPicker';
-      const isReorderingInsideTopics =
-        dragDestination.droppableId !== 'questionPicker' &&
-        dragSource.droppableId !== 'questionPicker';
-
-      if (isDraggingFromQuestionDrawerToTopic) {
-        const questionId = result.draggableId;
-        const topicId = dragDestination.droppableId
-          ? +dragDestination.droppableId
-          : undefined;
-
-        const sortOrder = dragDestination.index;
-
-        if (topicId && questionId) {
-          dispatch({
-            type: EventType.CREATE_QUESTION_REL_REQUESTED,
-            payload: {
-              topicId,
-              questionId,
-              sortOrder,
-              templateId: state.templateId,
-            },
-          });
-        }
-      } else if (isDraggingFromTopicToQuestionDrawer) {
-        const topicId = parseInt(dragSource.droppableId);
-        const step = getQuestionaryStepByTopicId(
-          state.steps,
-          topicId
-        ) as QuestionaryStep;
-        const question = step.fields[dragSource.index].question;
-        api()
-          .deleteQuestionTemplateRelation({
-            templateId: state.templateId,
-            questionId: question.id,
-          })
-          .then((data) => {
-            if (data.deleteQuestionTemplateRelation) {
-              dispatch({
-                type: EventType.QUESTION_REL_UPDATED,
-                payload: data.deleteQuestionTemplateRelation,
-              });
-            }
-          });
-      } else if (isReorderingInsideTopics) {
-        dispatch({
-          type: EventType.REORDER_QUESTION_REL_REQUESTED,
-          payload: {
-            source: dragSource,
-            destination: dragDestination,
-          },
-        });
-      }
-    }
-    if (isDraggingTopic) {
-      dispatch({
-        type: EventType.REORDER_TOPIC_REQUESTED,
-        payload: { source: dragSource, destination: dragDestination },
-      });
-    }
-  };
-
-  const getContainerStyle = (): React.CSSProperties => {
-    return isLoading || state.templateId === 0
+  const getContainerStyle = (): React.CSSProperties =>
+    isLoading || state.templateId === 0
       ? {
           pointerEvents: 'none',
           userSelect: 'none',
           opacity: 0.5,
         }
       : {};
-  };
-
-  const progressJsx = isLoading ? <LinearProgress /> : null;
-  const newTopicFallbackButton =
-    state.steps.length === 0 ? (
-      <Button
-        variant="outlined"
-        sx={{ display: 'flex', margin: '10px auto' }}
-        onClick={(): void =>
-          dispatch({
-            type: EventType.CREATE_TOPIC_REQUESTED,
-            payload: { isFirstTopic: true },
-          })
-        }
-      >
-        <PlaylistAddIcon />
-        &nbsp; Add topic
-      </Button>
-    ) : null;
-
-  const topControlBarElements = [];
-
-  if (state.steps.length > 1) {
-    topControlBarElements.push(
-      <FormControlLabel
-        control={
-          <Switch
-            checked={isTopicReorderMode}
-            onChange={(): void => setIsTopicReorderMode(!isTopicReorderMode)}
-          />
-        }
-        label="Reorder topics mode"
-      />
-    );
-  }
-
-  topControlBarElements.push(
-    <Tooltip title="Preview questionary">
-      <IconButton
-        onClick={() => setOpenedPreviewTemplateId(state.templateId)}
-        data-cy="preview-questionary-template"
-      >
-        <Preview />
-      </IconButton>
-    </Tooltip>
-  );
-
-  const topControlBar = topControlBarElements.length ? (
-    <FormGroup
-      row
-      style={{ justifyContent: 'flex-end', paddingBottom: '25px' }}
-    >
-      {topControlBarElements.map((element, index) => (
-        <div key={index}>{element}</div>
-      ))}
-    </FormGroup>
-  ) : null;
 
   return (
     <StyledContainer maxWidth={false}>
@@ -279,50 +63,39 @@ export default function TemplateEditor() {
       )}
       <TemplateMetadataEditor dispatch={dispatch} template={state} />
       <StyledPaper style={getContainerStyle()}>
-        {progressJsx}
-        {topControlBar}
-        <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable droppableId="topics" direction="horizontal" type="topic">
-            {(provided, snapshot) => (
-              <div
-                {...provided.droppableProps}
-                ref={provided.innerRef}
-                style={getTopicListStyle(snapshot.isDraggingOver)}
-                className="tinyScroll"
-              >
-                {state.steps.map((step, index) => {
-                  const questionPicker =
-                    step.topic.id === questionPickerTopicId ? (
-                      <QuestionPicker
-                        topic={step.topic}
-                        dispatch={dispatch}
-                        template={state}
-                        closeMe={() => {
-                          setQuestionPickerTopicId(null);
-                        }}
-                        id="questionPicker"
-                      />
-                    ) : null;
-
-                  return (
-                    <React.Fragment key={step.topic.id}>
-                      <QuestionaryEditorTopic
-                        data={step}
-                        dispatch={dispatch}
-                        index={index}
-                        dragMode={isTopicReorderMode}
-                        hoveredDependency={hoveredDependency}
-                      />
-                      {questionPicker}
-                    </React.Fragment>
-                  );
-                })}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        </DragDropContext>
-        {newTopicFallbackButton}
+        {isLoading && <LinearProgress />}
+        <TemplateEditorToolbar
+          stepCount={state.steps.length}
+          isTopicReorderMode={isTopicReorderMode}
+          onToggleReorderMode={() => setIsTopicReorderMode((prev) => !prev)}
+          onPreview={() => setOpenedPreviewTemplateId(state.templateId)}
+        />
+        <TemplateEditorContent
+          template={state}
+          dispatch={dispatch}
+          questionPickerTopicId={questionPickerTopicId}
+          closeQuestionPicker={() => setQuestionPickerTopicId(null)}
+          isTopicReorderMode={isTopicReorderMode}
+          hoveredDependency={hoveredDependency}
+          onDragEnd={(result) =>
+            handleTemplateDragEnd(result, { state, dispatch, api })
+          }
+        />
+        {state.steps.length === 0 && (
+          <Button
+            variant="outlined"
+            sx={{ display: 'flex', margin: '10px auto' }}
+            onClick={(): void =>
+              dispatch({
+                type: EventType.CREATE_TOPIC_REQUESTED,
+                payload: { isFirstTopic: true },
+              })
+            }
+          >
+            <PlaylistAddIcon />
+            &nbsp; Add topic
+          </Button>
+        )}
       </StyledPaper>
 
       <QuestionTemplateRelationEditor

--- a/apps/frontend/src/components/template/TemplateEditorContent.tsx
+++ b/apps/frontend/src/components/template/TemplateEditorContent.tsx
@@ -1,0 +1,85 @@
+import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import React from 'react';
+
+import { Template } from 'generated/sdk';
+import { Event } from 'models/questionary/QuestionaryEditorModel';
+
+import { QuestionPicker } from './QuestionPicker';
+import QuestionaryEditorTopic from './TemplateTopicEditor';
+
+interface TemplateEditorContentProps {
+  template: Template;
+  dispatch: React.Dispatch<Event>;
+  questionPickerTopicId: number | null;
+  closeQuestionPicker: () => void;
+  isTopicReorderMode: boolean;
+  hoveredDependency: string;
+  onDragEnd: (result: DropResult) => void;
+}
+
+export function TemplateEditorContent({
+  template,
+  dispatch,
+  questionPickerTopicId,
+  closeQuestionPicker,
+  isTopicReorderMode,
+  hoveredDependency,
+  onDragEnd,
+}: TemplateEditorContentProps) {
+  const theme = useTheme();
+  const isExtraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+
+  const getTopicListStyle = (isDraggingOver: boolean) => ({
+    background: isDraggingOver
+      ? theme.palette.primary.light
+      : theme.palette.grey[100],
+    transition: 'all 500ms cubic-bezier(0.190, 1.000, 0.220, 1.000)',
+    display: 'flex',
+    overflow: 'auto',
+    maxHeight: isExtraLargeScreen ? '1400px' : '700px',
+  });
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Droppable droppableId="topics" direction="horizontal" type="topic">
+        {(provided, snapshot) => (
+          <div
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+            style={getTopicListStyle(snapshot.isDraggingOver)}
+            className="tinyScroll"
+          >
+            {template.steps.map((step, index) => {
+              const questionPicker =
+                step.topic.id === questionPickerTopicId ? (
+                  <QuestionPicker
+                    topic={step.topic}
+                    dispatch={dispatch}
+                    template={template}
+                    closeMe={closeQuestionPicker}
+                    id="questionPicker"
+                  />
+                ) : null;
+
+              return (
+                <React.Fragment key={step.topic.id}>
+                  <QuestionaryEditorTopic
+                    data={step}
+                    dispatch={dispatch}
+                    index={index}
+                    dragMode={isTopicReorderMode}
+                    hoveredDependency={hoveredDependency}
+                  />
+                  {questionPicker}
+                </React.Fragment>
+              );
+            })}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+}

--- a/apps/frontend/src/components/template/TemplateEditorToolbar.tsx
+++ b/apps/frontend/src/components/template/TemplateEditorToolbar.tsx
@@ -1,0 +1,45 @@
+import Preview from '@mui/icons-material/Preview';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import IconButton from '@mui/material/IconButton';
+import Switch from '@mui/material/Switch';
+import Tooltip from '@mui/material/Tooltip';
+import React from 'react';
+
+interface TemplateEditorToolbarProps {
+  stepCount: number;
+  isTopicReorderMode: boolean;
+  onToggleReorderMode: () => void;
+  onPreview: () => void;
+}
+
+export function TemplateEditorToolbar({
+  stepCount,
+  isTopicReorderMode,
+  onToggleReorderMode,
+  onPreview,
+}: TemplateEditorToolbarProps) {
+  return (
+    <FormGroup
+      row
+      style={{ justifyContent: 'flex-end', paddingBottom: '25px' }}
+    >
+      {stepCount > 1 && (
+        <FormControlLabel
+          control={
+            <Switch
+              checked={isTopicReorderMode}
+              onChange={onToggleReorderMode}
+            />
+          }
+          label="Reorder topics mode"
+        />
+      )}
+      <Tooltip title="Preview questionary">
+        <IconButton onClick={onPreview} data-cy="preview-questionary-template">
+          <Preview />
+        </IconButton>
+      </Tooltip>
+    </FormGroup>
+  );
+}

--- a/apps/frontend/src/components/visit/VisitRegistrationContainer.tsx
+++ b/apps/frontend/src/components/visit/VisitRegistrationContainer.tsx
@@ -21,6 +21,7 @@ export interface VisitRegistrationContextType extends QuestionaryContextType {
 export interface VisitRegistrationContainerProps {
   registration: RegistrationWithQuestionary;
   onSubmitted?: (registration: RegistrationWithQuestionary) => void;
+  previewMode?: boolean;
 }
 export default function VisitRegistrationContainer(
   props: VisitRegistrationContainerProps
@@ -48,7 +49,10 @@ export default function VisitRegistrationContainer(
 
   return (
     <QuestionaryContext.Provider value={{ state, dispatch }}>
-      <Questionary title={'Visit the facility'} />
+      <Questionary
+        title={'Visit the facility'}
+        previewMode={props.previewMode}
+      />
     </QuestionaryContext.Provider>
   );
 }

--- a/apps/frontend/src/hooks/questionary/useTemplateEditorSelection.ts
+++ b/apps/frontend/src/hooks/questionary/useTemplateEditorSelection.ts
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+
+import { Question, QuestionTemplateRelation, Template } from 'generated/sdk';
+import { Event, EventType } from 'models/questionary/QuestionaryEditorModel';
+import { getFieldById } from 'models/questionary/QuestionaryFunctions';
+import {
+  MiddlewareInputParams,
+  ReducerMiddleware,
+} from 'utils/useReducerWithMiddleWares';
+import { FunctionType } from 'utils/utilTypes';
+
+/**
+ * Owns the TemplateEditor's transient UI selection state (which question /
+ * relation / picker / preview is currently open) together with the reducer
+ * middleware that drives it. The middleware reacts to editor events and opens
+ * the matching drawer/picker, keeping that wiring next to the state it mutates.
+ */
+export function useTemplateEditorSelection() {
+  const [
+    selectedQuestionTemplateRelation,
+    setSelectedQuestionTemplateRelation,
+  ] = useState<QuestionTemplateRelation | null>(null);
+  const [selectedQuestion, setSelectedQuestion] = useState<Question | null>(
+    null
+  );
+  const [hoveredDependency, setHoveredDependency] = useState<string>('');
+  const [openedPreviewTemplateId, setOpenedPreviewTemplateId] = useState<
+    number | null
+  >(null);
+  const [questionPickerTopicId, setQuestionPickerTopicId] = useState<
+    number | null
+  >(null);
+
+  const handleEvents: ReducerMiddleware<Template, Event> = ({
+    getState,
+  }: MiddlewareInputParams<Template, Event>) => {
+    return (next: FunctionType) => (action: Event) => {
+      next(action);
+      switch (action.type) {
+        case EventType.QUESTION_CREATED:
+          setSelectedQuestion(action.payload);
+          break;
+
+        case EventType.PICK_QUESTION_REQUESTED:
+          setQuestionPickerTopicId(action.payload.topic.id);
+          break;
+
+        case EventType.OPEN_QUESTION_EDITOR:
+          setSelectedQuestion(action.payload);
+          break;
+
+        case EventType.OPEN_QUESTIONREL_EDITOR: {
+          const templateRelation = getFieldById(
+            getState().steps,
+            action.payload.questionId
+          );
+          if (!templateRelation) {
+            return;
+          }
+
+          setSelectedQuestionTemplateRelation(
+            templateRelation as QuestionTemplateRelation
+          );
+          break;
+        }
+
+        case EventType.QUESTION_PICKER_NEW_QUESTION_CLICKED:
+          setQuestionPickerTopicId(action.payload.topic.id);
+          break;
+
+        case EventType.DEPENDENCY_HOVER:
+          setHoveredDependency(action.payload.dependency);
+          break;
+      }
+    };
+  };
+
+  return {
+    selectedQuestionTemplateRelation,
+    setSelectedQuestionTemplateRelation,
+    selectedQuestion,
+    setSelectedQuestion,
+    hoveredDependency,
+    openedPreviewTemplateId,
+    setOpenedPreviewTemplateId,
+    questionPickerTopicId,
+    setQuestionPickerTopicId,
+    handleEvents,
+  };
+}

--- a/apps/frontend/src/hooks/visit/useBlankVisitRegistration.ts
+++ b/apps/frontend/src/hooks/visit/useBlankVisitRegistration.ts
@@ -9,7 +9,7 @@ import {
 import { useDataApi } from 'hooks/common/useDataApi';
 import { RegistrationWithQuestionary } from 'models/questionary/visit/VisitRegistrationWithQuestionary';
 
-function createRegistrationStub(
+export function createRegistrationStub(
   userId: number,
   templateId: number,
   questionarySteps: QuestionaryStep[],

--- a/apps/frontend/src/models/questionary/templateEditorDragHandlers.ts
+++ b/apps/frontend/src/models/questionary/templateEditorDragHandlers.ts
@@ -1,0 +1,134 @@
+import { DraggableLocation, DropResult } from '@hello-pangea/dnd';
+import React from 'react';
+
+import { QuestionaryStep, Template } from 'generated/sdk';
+import { Event, EventType } from 'models/questionary/QuestionaryEditorModel';
+import { getQuestionaryStepByTopicId } from 'models/questionary/QuestionaryFunctions';
+import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
+
+const QUESTION_PICKER_DROPPABLE_ID = 'questionPicker';
+
+type DataApi = ReturnType<typeof useDataApiWithFeedback>['api'];
+
+export interface TemplateDragHandlerDeps {
+  state: Template;
+  dispatch: React.Dispatch<Event>;
+  api: DataApi;
+}
+
+const isSamePosition = (
+  source: DraggableLocation,
+  destination: DraggableLocation
+): boolean =>
+  destination.droppableId === source.droppableId &&
+  destination.index === source.index;
+
+const isPicker = (location: DraggableLocation): boolean =>
+  location.droppableId === QUESTION_PICKER_DROPPABLE_ID;
+
+const addQuestionToTopic = (
+  result: DropResult,
+  destination: DraggableLocation,
+  { state, dispatch }: TemplateDragHandlerDeps
+): void => {
+  const questionId = result.draggableId;
+  const topicId = destination.droppableId
+    ? +destination.droppableId
+    : undefined;
+  const sortOrder = destination.index;
+
+  if (topicId && questionId) {
+    dispatch({
+      type: EventType.CREATE_QUESTION_REL_REQUESTED,
+      payload: {
+        topicId,
+        questionId,
+        sortOrder,
+        templateId: state.templateId,
+      },
+    });
+  }
+};
+
+const removeQuestionFromTopic = (
+  source: DraggableLocation,
+  { state, dispatch, api }: TemplateDragHandlerDeps
+): void => {
+  const topicId = parseInt(source.droppableId);
+  const step = getQuestionaryStepByTopicId(
+    state.steps,
+    topicId
+  ) as QuestionaryStep;
+  const question = step.fields[source.index].question;
+
+  api()
+    .deleteQuestionTemplateRelation({
+      templateId: state.templateId,
+      questionId: question.id,
+    })
+    .then((data) => {
+      if (data.deleteQuestionTemplateRelation) {
+        dispatch({
+          type: EventType.QUESTION_REL_UPDATED,
+          payload: data.deleteQuestionTemplateRelation,
+        });
+      }
+    });
+};
+
+const reorderQuestionWithinTopics = (
+  source: DraggableLocation,
+  destination: DraggableLocation,
+  { dispatch }: TemplateDragHandlerDeps
+): void => {
+  dispatch({
+    type: EventType.REORDER_QUESTION_REL_REQUESTED,
+    payload: { source, destination },
+  });
+};
+
+const reorderTopic = (
+  source: DraggableLocation,
+  destination: DraggableLocation,
+  { dispatch }: TemplateDragHandlerDeps
+): void => {
+  dispatch({
+    type: EventType.REORDER_TOPIC_REQUESTED,
+    payload: { source, destination },
+  });
+};
+
+/**
+ * Entry point for the template editor's drag-and-drop interactions. Routes a
+ * drop to the matching handler based on whether a question or a topic was
+ * dragged, and where it came from / went to (the question picker drawer vs. a
+ * topic column).
+ */
+export const handleTemplateDragEnd = (
+  result: DropResult,
+  deps: TemplateDragHandlerDeps
+): void => {
+  const { source, destination } = result;
+
+  if (!destination || isSamePosition(source, destination)) {
+    return;
+  }
+
+  if (result.type === 'topic') {
+    reorderTopic(source, destination, deps);
+
+    return;
+  }
+
+  if (result.type !== 'field') {
+    return;
+  }
+
+  if (isPicker(source) && !isPicker(destination)) {
+    addQuestionToTopic(result, destination, deps);
+  } else if (isPicker(destination) && !isPicker(source)) {
+    removeQuestionFromTopic(source, deps);
+  } else if (!isPicker(source) && !isPicker(destination)) {
+    reorderQuestionWithinTopics(source, destination, deps);
+  }
+};


### PR DESCRIPTION
## Description
This PR fixes the crash occurring during the preview of the 'Visit Template' question in the User Office.

## Motivation and Context
The PR addresses the issue of the application crashing when a user attempts to preview the 'Visit Template' question. This was a significant problem as it hindered the user's ability to preview and validate the template before use.

## Changes
- Added a VisitRegistrationContainer to the PreviewTemplateModal component.
- Added a 'previewMode' prop to the VisitRegistrationContainer component to handle the preview state.
- Exposed the 'createRegistrationStub' function from useBlankVisitRegistration hook to create a stub for the registration in preview mode.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/SWAP-5643](https://jira.ess.eu//browse/SWAP-5643)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated