### PR TITLE
refactor: template editor component

### DIFF
--- a/apps/frontend/src/components/template/TemplateEditor.tsx
+++ b/apps/frontend/src/components/template/TemplateEditor.tsx
@@ -1,103 +1,40 @@
-import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
-import Preview from '@mui/icons-material/Preview';
 import Button from '@mui/material/Button';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormGroup from '@mui/material/FormGroup';
-import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
-import { useTheme } from '@mui/material/styles';
-import Switch from '@mui/material/Switch';
-import Tooltip from '@mui/material/Tooltip';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import React, { useState } from 'react';
 
-import {
-  Question,
-  QuestionaryStep,
-  QuestionTemplateRelation,
-  Template,
-} from 'generated/sdk';
 import { usePersistQuestionaryEditorModel } from 'hooks/questionary/usePersistQuestionaryEditorModel';
+import { useTemplateEditorSelection } from 'hooks/questionary/useTemplateEditorSelection';
 import QuestionaryEditorModel, {
-  Event,
   EventType,
 } from 'models/questionary/QuestionaryEditorModel';
-import {
-  getFieldById,
-  getQuestionaryStepByTopicId,
-} from 'models/questionary/QuestionaryFunctions';
+import { handleTemplateDragEnd } from 'models/questionary/templateEditorDragHandlers';
 import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
 import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
-import { MiddlewareInputParams } from 'utils/useReducerWithMiddleWares';
-import { FunctionType } from 'utils/utilTypes';
 
 import PreviewTemplateModal from './PreviewTemplateModal';
 import QuestionEditor from './QuestionEditor';
-import { QuestionPicker } from './QuestionPicker';
 import QuestionTemplateRelationEditor from './QuestionTemplateRelationEditor';
+import { TemplateEditorToolbar } from './TemplateEditorToolbar';
 import { TemplateMetadataEditor } from './TemplateMetadataEditor';
-import QuestionaryEditorTopic from './TemplateTopicEditor';
+import { TemplateTopicList } from './TemplateTopicList';
 
 export default function TemplateEditor() {
   const { api } = useDataApiWithFeedback();
-  const [
+
+  const {
     selectedQuestionTemplateRelation,
     setSelectedQuestionTemplateRelation,
-  ] = useState<QuestionTemplateRelation | null>(null);
-  const [selectedQuestion, setSelectedQuestion] = useState<Question | null>(
-    null
-  );
+    selectedQuestion,
+    setSelectedQuestion,
+    hoveredDependency,
+    openedPreviewTemplateId,
+    setOpenedPreviewTemplateId,
+    questionPickerTopicId,
+    setQuestionPickerTopicId,
+    handleEvents,
+  } = useTemplateEditorSelection();
 
-  const [hoveredDependency, setHoveredDependency] = useState<string>('');
-  const [openedPreviewTemplateId, setOpenedPreviewTemplateId] = useState<
-    number | null
-  >(null);
-
-  const [questionPickerTopicId, setQuestionPickerTopicId] = useState<
-    number | null
-  >(null);
-  const handleEvents = ({
-    getState,
-  }: MiddlewareInputParams<Template, Event>) => {
-    return (next: FunctionType) => (action: Event) => {
-      next(action);
-      switch (action.type) {
-        case EventType.QUESTION_CREATED:
-          setSelectedQuestion(action.payload);
-          break;
-
-        case EventType.PICK_QUESTION_REQUESTED:
-          setQuestionPickerTopicId(action.payload.topic.id);
-          break;
-
-        case EventType.OPEN_QUESTION_EDITOR:
-          setSelectedQuestion(action.payload);
-          break;
-
-        case EventType.OPEN_QUESTIONREL_EDITOR:
-          const templateRelation = getFieldById(
-            getState().steps,
-            action.payload.questionId
-          );
-          if (!templateRelation) {
-            return;
-          }
-
-          setSelectedQuestionTemplateRelation(
-            templateRelation as QuestionTemplateRelation
-          );
-          break;
-
-        case EventType.QUESTION_PICKER_NEW_QUESTION_CLICKED:
-          setQuestionPickerTopicId(action.payload.topic.id);
-          break;
-        case EventType.DEPENDENCY_HOVER:
-          setHoveredDependency(action.payload.dependency);
-          break;
-      }
-    };
-  };
   const { persistModel, isLoading } = usePersistQuestionaryEditorModel();
   const { state, dispatch } = QuestionaryEditorModel([
     persistModel,
@@ -106,167 +43,14 @@ export default function TemplateEditor() {
 
   const [isTopicReorderMode, setIsTopicReorderMode] = useState(false);
 
-  const theme = useTheme();
-  const isExtraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
-
-  const getTopicListStyle = (isDraggingOver: boolean) => ({
-    background: isDraggingOver
-      ? theme.palette.primary.light
-      : theme.palette.grey[100],
-    transition: 'all 500ms cubic-bezier(0.190, 1.000, 0.220, 1.000)',
-    display: 'flex',
-    overflow: 'auto',
-    maxHeight: isExtraLargeScreen ? '1400px' : '700px',
-  });
-
-  const onDragEnd = (result: DropResult): void => {
-    const dragSource = result.source;
-    const dragDestination = result.destination;
-
-    if (
-      !dragDestination ||
-      (dragDestination.droppableId === dragSource.droppableId &&
-        dragDestination.index === dragSource.index)
-    ) {
-      return;
-    }
-
-    const isDraggingQuestion = result.type === 'field';
-    const isDraggingTopic = result.type === 'topic';
-
-    if (isDraggingQuestion) {
-      const isDraggingFromQuestionDrawerToTopic =
-        dragSource.droppableId === 'questionPicker' &&
-        dragDestination.droppableId !== 'questionPicker';
-      const isDraggingFromTopicToQuestionDrawer =
-        dragDestination.droppableId === 'questionPicker' &&
-        dragSource.droppableId !== 'questionPicker';
-      const isReorderingInsideTopics =
-        dragDestination.droppableId !== 'questionPicker' &&
-        dragSource.droppableId !== 'questionPicker';
-
-      if (isDraggingFromQuestionDrawerToTopic) {
-        const questionId = result.draggableId;
-        const topicId = dragDestination.droppableId
-          ? +dragDestination.droppableId
-          : undefined;
-
-        const sortOrder = dragDestination.index;
-
-        if (topicId && questionId) {
-          dispatch({
-            type: EventType.CREATE_QUESTION_REL_REQUESTED,
-            payload: {
-              topicId,
-              questionId,
-              sortOrder,
-              templateId: state.templateId,
-            },
-          });
-        }
-      } else if (isDraggingFromTopicToQuestionDrawer) {
-        const topicId = parseInt(dragSource.droppableId);
-        const step = getQuestionaryStepByTopicId(
-          state.steps,
-          topicId
-        ) as QuestionaryStep;
-        const question = step.fields[dragSource.index].question;
-        api()
-          .deleteQuestionTemplateRelation({
-            templateId: state.templateId,
-            questionId: question.id,
-          })
-          .then((data) => {
-            if (data.deleteQuestionTemplateRelation) {
-              dispatch({
-                type: EventType.QUESTION_REL_UPDATED,
-                payload: data.deleteQuestionTemplateRelation,
-              });
-            }
-          });
-      } else if (isReorderingInsideTopics) {
-        dispatch({
-          type: EventType.REORDER_QUESTION_REL_REQUESTED,
-          payload: {
-            source: dragSource,
-            destination: dragDestination,
-          },
-        });
-      }
-    }
-    if (isDraggingTopic) {
-      dispatch({
-        type: EventType.REORDER_TOPIC_REQUESTED,
-        payload: { source: dragSource, destination: dragDestination },
-      });
-    }
-  };
-
-  const getContainerStyle = (): React.CSSProperties => {
-    return isLoading || state.templateId === 0
+  const getContainerStyle = (): React.CSSProperties =>
+    isLoading || state.templateId === 0
       ? {
           pointerEvents: 'none',
           userSelect: 'none',
           opacity: 0.5,
         }
       : {};
-  };
-
-  const progressJsx = isLoading ? <LinearProgress /> : null;
-  const newTopicFallbackButton =
-    state.steps.length === 0 ? (
-      <Button
-        variant="outlined"
-        sx={{ display: 'flex', margin: '10px auto' }}
-        onClick={(): void =>
-          dispatch({
-            type: EventType.CREATE_TOPIC_REQUESTED,
-            payload: { isFirstTopic: true },
-          })
-        }
-      >
-        <PlaylistAddIcon />
-        &nbsp; Add topic
-      </Button>
-    ) : null;
-
-  const topControlBarElements = [];
-
-  if (state.steps.length > 1) {
-    topControlBarElements.push(
-      <FormControlLabel
-        control={
-          <Switch
-            checked={isTopicReorderMode}
-            onChange={(): void => setIsTopicReorderMode(!isTopicReorderMode)}
-          />
-        }
-        label="Reorder topics mode"
-      />
-    );
-  }
-
-  topControlBarElements.push(
-    <Tooltip title="Preview questionary">
-      <IconButton
-        onClick={() => setOpenedPreviewTemplateId(state.templateId)}
-        data-cy="preview-questionary-template"
-      >
-        <Preview />
-      </IconButton>
-    </Tooltip>
-  );
-
-  const topControlBar = topControlBarElements.length ? (
-    <FormGroup
-      row
-      style={{ justifyContent: 'flex-end', paddingBottom: '25px' }}
-    >
-      {topControlBarElements.map((element, index) => (
-        <div key={index}>{element}</div>
-      ))}
-    </FormGroup>
-  ) : null;
 
   return (
     <StyledContainer maxWidth={false}>
@@ -279,50 +63,39 @@ export default function TemplateEditor() {
       )}
       <TemplateMetadataEditor dispatch={dispatch} template={state} />
       <StyledPaper style={getContainerStyle()}>
-        {progressJsx}
-        {topControlBar}
-        <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable droppableId="topics" direction="horizontal" type="topic">
-            {(provided, snapshot) => (
-              <div
-                {...provided.droppableProps}
-                ref={provided.innerRef}
-                style={getTopicListStyle(snapshot.isDraggingOver)}
-                className="tinyScroll"
-              >
-                {state.steps.map((step, index) => {
-                  const questionPicker =
-                    step.topic.id === questionPickerTopicId ? (
-                      <QuestionPicker
-                        topic={step.topic}
-                        dispatch={dispatch}
-                        template={state}
-                        closeMe={() => {
-                          setQuestionPickerTopicId(null);
-                        }}
-                        id="questionPicker"
-                      />
-                    ) : null;
-
-                  return (
-                    <React.Fragment key={step.topic.id}>
-                      <QuestionaryEditorTopic
-                        data={step}
-                        dispatch={dispatch}
-                        index={index}
-                        dragMode={isTopicReorderMode}
-                        hoveredDependency={hoveredDependency}
-                      />
-                      {questionPicker}
-                    </React.Fragment>
-                  );
-                })}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        </DragDropContext>
-        {newTopicFallbackButton}
+        {isLoading && <LinearProgress />}
+        <TemplateEditorToolbar
+          stepCount={state.steps.length}
+          isTopicReorderMode={isTopicReorderMode}
+          onToggleReorderMode={() => setIsTopicReorderMode((prev) => !prev)}
+          onPreview={() => setOpenedPreviewTemplateId(state.templateId)}
+        />
+        <TemplateTopicList
+          template={state}
+          dispatch={dispatch}
+          questionPickerTopicId={questionPickerTopicId}
+          closeQuestionPicker={() => setQuestionPickerTopicId(null)}
+          isTopicReorderMode={isTopicReorderMode}
+          hoveredDependency={hoveredDependency}
+          onDragEnd={(result) =>
+            handleTemplateDragEnd(result, { state, dispatch, api })
+          }
+        />
+        {state.steps.length === 0 && (
+          <Button
+            variant="outlined"
+            sx={{ display: 'flex', margin: '10px auto' }}
+            onClick={(): void =>
+              dispatch({
+                type: EventType.CREATE_TOPIC_REQUESTED,
+                payload: { isFirstTopic: true },
+              })
+            }
+          >
+            <PlaylistAddIcon />
+            &nbsp; Add topic
+          </Button>
+        )}
       </StyledPaper>
 
       <QuestionTemplateRelationEditor

--- a/apps/frontend/src/components/template/TemplateEditor.tsx
+++ b/apps/frontend/src/components/template/TemplateEditor.tsx
@@ -15,9 +15,9 @@ import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
 import PreviewTemplateModal from './PreviewTemplateModal';
 import QuestionEditor from './QuestionEditor';
 import QuestionTemplateRelationEditor from './QuestionTemplateRelationEditor';
+import { TemplateEditorContent } from './TemplateEditorContent';
 import { TemplateEditorToolbar } from './TemplateEditorToolbar';
 import { TemplateMetadataEditor } from './TemplateMetadataEditor';
-import { TemplateTopicList } from './TemplateTopicList';
 
 export default function TemplateEditor() {
   const { api } = useDataApiWithFeedback();
@@ -70,7 +70,7 @@ export default function TemplateEditor() {
           onToggleReorderMode={() => setIsTopicReorderMode((prev) => !prev)}
           onPreview={() => setOpenedPreviewTemplateId(state.templateId)}
         />
-        <TemplateTopicList
+        <TemplateEditorContent
           template={state}
           dispatch={dispatch}
           questionPickerTopicId={questionPickerTopicId}

--- a/apps/frontend/src/components/template/TemplateEditorContent.tsx
+++ b/apps/frontend/src/components/template/TemplateEditorContent.tsx
@@ -9,7 +9,7 @@ import { Event } from 'models/questionary/QuestionaryEditorModel';
 import { QuestionPicker } from './QuestionPicker';
 import QuestionaryEditorTopic from './TemplateTopicEditor';
 
-interface TemplateTopicListProps {
+interface TemplateEditorContentProps {
   template: Template;
   dispatch: React.Dispatch<Event>;
   questionPickerTopicId: number | null;
@@ -19,7 +19,7 @@ interface TemplateTopicListProps {
   onDragEnd: (result: DropResult) => void;
 }
 
-export function TemplateTopicList({
+export function TemplateEditorContent({
   template,
   dispatch,
   questionPickerTopicId,
@@ -27,7 +27,7 @@ export function TemplateTopicList({
   isTopicReorderMode,
   hoveredDependency,
   onDragEnd,
-}: TemplateTopicListProps) {
+}: TemplateEditorContentProps) {
   const theme = useTheme();
   const isExtraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
 

--- a/apps/frontend/src/components/template/TemplateEditorToolbar.tsx
+++ b/apps/frontend/src/components/template/TemplateEditorToolbar.tsx
@@ -1,0 +1,45 @@
+import Preview from '@mui/icons-material/Preview';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import IconButton from '@mui/material/IconButton';
+import Switch from '@mui/material/Switch';
+import Tooltip from '@mui/material/Tooltip';
+import React from 'react';
+
+interface TemplateEditorToolbarProps {
+  stepCount: number;
+  isTopicReorderMode: boolean;
+  onToggleReorderMode: () => void;
+  onPreview: () => void;
+}
+
+export function TemplateEditorToolbar({
+  stepCount,
+  isTopicReorderMode,
+  onToggleReorderMode,
+  onPreview,
+}: TemplateEditorToolbarProps) {
+  return (
+    <FormGroup
+      row
+      style={{ justifyContent: 'flex-end', paddingBottom: '25px' }}
+    >
+      {stepCount > 1 && (
+        <FormControlLabel
+          control={
+            <Switch
+              checked={isTopicReorderMode}
+              onChange={onToggleReorderMode}
+            />
+          }
+          label="Reorder topics mode"
+        />
+      )}
+      <Tooltip title="Preview questionary">
+        <IconButton onClick={onPreview} data-cy="preview-questionary-template">
+          <Preview />
+        </IconButton>
+      </Tooltip>
+    </FormGroup>
+  );
+}

--- a/apps/frontend/src/components/template/TemplateTopicList.tsx
+++ b/apps/frontend/src/components/template/TemplateTopicList.tsx
@@ -1,0 +1,85 @@
+import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import React from 'react';
+
+import { Template } from 'generated/sdk';
+import { Event } from 'models/questionary/QuestionaryEditorModel';
+
+import { QuestionPicker } from './QuestionPicker';
+import QuestionaryEditorTopic from './TemplateTopicEditor';
+
+interface TemplateTopicListProps {
+  template: Template;
+  dispatch: React.Dispatch<Event>;
+  questionPickerTopicId: number | null;
+  closeQuestionPicker: () => void;
+  isTopicReorderMode: boolean;
+  hoveredDependency: string;
+  onDragEnd: (result: DropResult) => void;
+}
+
+export function TemplateTopicList({
+  template,
+  dispatch,
+  questionPickerTopicId,
+  closeQuestionPicker,
+  isTopicReorderMode,
+  hoveredDependency,
+  onDragEnd,
+}: TemplateTopicListProps) {
+  const theme = useTheme();
+  const isExtraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+
+  const getTopicListStyle = (isDraggingOver: boolean) => ({
+    background: isDraggingOver
+      ? theme.palette.primary.light
+      : theme.palette.grey[100],
+    transition: 'all 500ms cubic-bezier(0.190, 1.000, 0.220, 1.000)',
+    display: 'flex',
+    overflow: 'auto',
+    maxHeight: isExtraLargeScreen ? '1400px' : '700px',
+  });
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Droppable droppableId="topics" direction="horizontal" type="topic">
+        {(provided, snapshot) => (
+          <div
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+            style={getTopicListStyle(snapshot.isDraggingOver)}
+            className="tinyScroll"
+          >
+            {template.steps.map((step, index) => {
+              const questionPicker =
+                step.topic.id === questionPickerTopicId ? (
+                  <QuestionPicker
+                    topic={step.topic}
+                    dispatch={dispatch}
+                    template={template}
+                    closeMe={closeQuestionPicker}
+                    id="questionPicker"
+                  />
+                ) : null;
+
+              return (
+                <React.Fragment key={step.topic.id}>
+                  <QuestionaryEditorTopic
+                    data={step}
+                    dispatch={dispatch}
+                    index={index}
+                    dragMode={isTopicReorderMode}
+                    hoveredDependency={hoveredDependency}
+                  />
+                  {questionPicker}
+                </React.Fragment>
+              );
+            })}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+}

--- a/apps/frontend/src/hooks/questionary/useTemplateEditorSelection.ts
+++ b/apps/frontend/src/hooks/questionary/useTemplateEditorSelection.ts
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+
+import { Question, QuestionTemplateRelation, Template } from 'generated/sdk';
+import { Event, EventType } from 'models/questionary/QuestionaryEditorModel';
+import { getFieldById } from 'models/questionary/QuestionaryFunctions';
+import {
+  MiddlewareInputParams,
+  ReducerMiddleware,
+} from 'utils/useReducerWithMiddleWares';
+import { FunctionType } from 'utils/utilTypes';
+
+/**
+ * Owns the TemplateEditor's transient UI selection state (which question /
+ * relation / picker / preview is currently open) together with the reducer
+ * middleware that drives it. The middleware reacts to editor events and opens
+ * the matching drawer/picker, keeping that wiring next to the state it mutates.
+ */
+export function useTemplateEditorSelection() {
+  const [
+    selectedQuestionTemplateRelation,
+    setSelectedQuestionTemplateRelation,
+  ] = useState<QuestionTemplateRelation | null>(null);
+  const [selectedQuestion, setSelectedQuestion] = useState<Question | null>(
+    null
+  );
+  const [hoveredDependency, setHoveredDependency] = useState<string>('');
+  const [openedPreviewTemplateId, setOpenedPreviewTemplateId] = useState<
+    number | null
+  >(null);
+  const [questionPickerTopicId, setQuestionPickerTopicId] = useState<
+    number | null
+  >(null);
+
+  const handleEvents: ReducerMiddleware<Template, Event> = ({
+    getState,
+  }: MiddlewareInputParams<Template, Event>) => {
+    return (next: FunctionType) => (action: Event) => {
+      next(action);
+      switch (action.type) {
+        case EventType.QUESTION_CREATED:
+          setSelectedQuestion(action.payload);
+          break;
+
+        case EventType.PICK_QUESTION_REQUESTED:
+          setQuestionPickerTopicId(action.payload.topic.id);
+          break;
+
+        case EventType.OPEN_QUESTION_EDITOR:
+          setSelectedQuestion(action.payload);
+          break;
+
+        case EventType.OPEN_QUESTIONREL_EDITOR: {
+          const templateRelation = getFieldById(
+            getState().steps,
+            action.payload.questionId
+          );
+          if (!templateRelation) {
+            return;
+          }
+
+          setSelectedQuestionTemplateRelation(
+            templateRelation as QuestionTemplateRelation
+          );
+          break;
+        }
+
+        case EventType.QUESTION_PICKER_NEW_QUESTION_CLICKED:
+          setQuestionPickerTopicId(action.payload.topic.id);
+          break;
+
+        case EventType.DEPENDENCY_HOVER:
+          setHoveredDependency(action.payload.dependency);
+          break;
+      }
+    };
+  };
+
+  return {
+    selectedQuestionTemplateRelation,
+    setSelectedQuestionTemplateRelation,
+    selectedQuestion,
+    setSelectedQuestion,
+    hoveredDependency,
+    openedPreviewTemplateId,
+    setOpenedPreviewTemplateId,
+    questionPickerTopicId,
+    setQuestionPickerTopicId,
+    handleEvents,
+  };
+}

--- a/apps/frontend/src/models/questionary/templateEditorDragHandlers.ts
+++ b/apps/frontend/src/models/questionary/templateEditorDragHandlers.ts
@@ -1,0 +1,134 @@
+import { DraggableLocation, DropResult } from '@hello-pangea/dnd';
+import React from 'react';
+
+import { QuestionaryStep, Template } from 'generated/sdk';
+import { Event, EventType } from 'models/questionary/QuestionaryEditorModel';
+import { getQuestionaryStepByTopicId } from 'models/questionary/QuestionaryFunctions';
+import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
+
+const QUESTION_PICKER_DROPPABLE_ID = 'questionPicker';
+
+type DataApi = ReturnType<typeof useDataApiWithFeedback>['api'];
+
+export interface TemplateDragHandlerDeps {
+  state: Template;
+  dispatch: React.Dispatch<Event>;
+  api: DataApi;
+}
+
+const isSamePosition = (
+  source: DraggableLocation,
+  destination: DraggableLocation
+): boolean =>
+  destination.droppableId === source.droppableId &&
+  destination.index === source.index;
+
+const isPicker = (location: DraggableLocation): boolean =>
+  location.droppableId === QUESTION_PICKER_DROPPABLE_ID;
+
+const addQuestionToTopic = (
+  result: DropResult,
+  destination: DraggableLocation,
+  { state, dispatch }: TemplateDragHandlerDeps
+): void => {
+  const questionId = result.draggableId;
+  const topicId = destination.droppableId
+    ? +destination.droppableId
+    : undefined;
+  const sortOrder = destination.index;
+
+  if (topicId && questionId) {
+    dispatch({
+      type: EventType.CREATE_QUESTION_REL_REQUESTED,
+      payload: {
+        topicId,
+        questionId,
+        sortOrder,
+        templateId: state.templateId,
+      },
+    });
+  }
+};
+
+const removeQuestionFromTopic = (
+  source: DraggableLocation,
+  { state, dispatch, api }: TemplateDragHandlerDeps
+): void => {
+  const topicId = parseInt(source.droppableId);
+  const step = getQuestionaryStepByTopicId(
+    state.steps,
+    topicId
+  ) as QuestionaryStep;
+  const question = step.fields[source.index].question;
+
+  api()
+    .deleteQuestionTemplateRelation({
+      templateId: state.templateId,
+      questionId: question.id,
+    })
+    .then((data) => {
+      if (data.deleteQuestionTemplateRelation) {
+        dispatch({
+          type: EventType.QUESTION_REL_UPDATED,
+          payload: data.deleteQuestionTemplateRelation,
+        });
+      }
+    });
+};
+
+const reorderQuestionWithinTopics = (
+  source: DraggableLocation,
+  destination: DraggableLocation,
+  { dispatch }: TemplateDragHandlerDeps
+): void => {
+  dispatch({
+    type: EventType.REORDER_QUESTION_REL_REQUESTED,
+    payload: { source, destination },
+  });
+};
+
+const reorderTopic = (
+  source: DraggableLocation,
+  destination: DraggableLocation,
+  { dispatch }: TemplateDragHandlerDeps
+): void => {
+  dispatch({
+    type: EventType.REORDER_TOPIC_REQUESTED,
+    payload: { source, destination },
+  });
+};
+
+/**
+ * Entry point for the template editor's drag-and-drop interactions. Routes a
+ * drop to the matching handler based on whether a question or a topic was
+ * dragged, and where it came from / went to (the question picker drawer vs. a
+ * topic column).
+ */
+export const handleTemplateDragEnd = (
+  result: DropResult,
+  deps: TemplateDragHandlerDeps
+): void => {
+  const { source, destination } = result;
+
+  if (!destination || isSamePosition(source, destination)) {
+    return;
+  }
+
+  if (result.type === 'topic') {
+    reorderTopic(source, destination, deps);
+
+    return;
+  }
+
+  if (result.type !== 'field') {
+    return;
+  }
+
+  if (isPicker(source) && !isPicker(destination)) {
+    addQuestionToTopic(result, destination, deps);
+  } else if (isPicker(destination) && !isPicker(source)) {
+    removeQuestionFromTopic(source, deps);
+  } else if (!isPicker(source) && !isPicker(destination)) {
+    reorderQuestionWithinTopics(source, destination, deps);
+  }
+};


### PR DESCRIPTION
## Description

Refactor the clunky, monolithic `TemplateEditor` component so it reads clearly and is broken down into small, single-responsibility files. No behaviour changes — the component is purely reorganized.

## Motivation and Context

The original `TemplateEditor.tsx` had grown into a single ~340-line file mixing selection state, drag-and-drop logic, toolbar UI, and the topic/question list rendering. This made the component hard to read and maintain, and overly reliant on AI assistance just to navigate. Splitting it into focused modules improves readability and lowers the maintenance burden.

## Changes

1. `TemplateEditor.tsx` was slimmed down from ~340 lines to ~115, now acting as a thin orchestrator that composes the extracted pieces.
2. Extracted the topic/question list and drag-drop rendering into a new `TemplateEditorContent.tsx` component (renamed from the original `TemplateTopicList` concept).
3. Extracted the top control bar (reorder-topics switch and preview button) into a new `TemplateEditorToolbar.tsx` component.
4. Moved all selection and editor-open state, plus the `handleEvents` middleware, into a new `useTemplateEditorSelection.ts` hook.
5. Moved the `onDragEnd` drag-and-drop logic into a new `templateEditorDragHandlers.ts` model module (`handleTemplateDragEnd`).

## How Has This Been Tested?

Functionality remains the same — only the code is reordered and extracted. The existing template editor behaviour (creating topics/questions, drag-and-drop reordering, question picker, preview) was exercised to confirm parity.

## Fixes Jira Issue

<!--- No associated Jira issue. -->

## Depends On

This PR targets `SWAP-5643-templatepreview` as its base branch.

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
