### PR TITLE
fix: stfc remove roles bug

### DIFF
--- a/apps/backend/src/datasources/UserDataSource.ts
+++ b/apps/backend/src/datasources/UserDataSource.ts
@@ -75,6 +75,7 @@ export interface UserDataSource {
   ): Promise<number>;
   update(user: UpdateUserByIdArgs): Promise<User>;
   setUserRoles(id: number, roles: number[]): Promise<void>;
+  removeUserRoles(id: number, roles: number[]): Promise<void>;
   setUserNotPlaceholder(id: number): Promise<User | null>;
   checkScientistToProposal(
     userId: number,

--- a/apps/backend/src/datasources/mockups/UserDataSource.ts
+++ b/apps/backend/src/datasources/mockups/UserDataSource.ts
@@ -475,6 +475,9 @@ export class UserDataSourceMock implements UserDataSource {
   async setUserRoles(id: number, roles: number[]): Promise<void> {
     // Do something here or remove the function.
   }
+  async removeUserRoles(id: number): Promise<void> {
+    return;
+  }
   async getUserRoles(id: number): Promise<Role[]> {
     if (id == dummyUserOfficer.id) {
       return [

--- a/apps/backend/src/datasources/postgres/UserDataSource.ts
+++ b/apps/backend/src/datasources/postgres/UserDataSource.ts
@@ -151,6 +151,12 @@ export default class PostgresUserDataSource implements UserDataSource {
     });
   }
 
+  async removeUserRoles(id: number): Promise<void> {
+    return database.transaction(async (trx) => {
+      await trx<RoleUserRecord>('role_user').where('user_id', id).del();
+    });
+  }
+
   async me(id: number): Promise<User | null> {
     return database
       .select()

--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -416,7 +416,7 @@ export class StfcUserDataSource implements UserDataSource {
       );
 
       if (newRolesToAssign.length == 0) {
-        postgresUserDataSource.removeUserRoles(id);
+        this.removeUserRoles(id);
         this.stfcRolesCache.remove(String(id));
         this.uopRolesCache.remove(String(id));
       } else if (newRolesToAssign.length > 0) {
@@ -527,7 +527,9 @@ export class StfcUserDataSource implements UserDataSource {
   }
 
   async removeUserRoles(id: number): Promise<void> {
-    throw new Error('Method not implemented.');
+    await postgresUserDataSource.removeUserRoles(id);
+
+    return;
   }
 
   async me(id: number) {

--- a/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
+++ b/apps/backend/src/datasources/stfc/StfcUserDataSource.ts
@@ -415,7 +415,11 @@ export class StfcUserDataSource implements UserDataSource {
         (roleId) => !assignedRoleIds.has(roleId) && roleId !== userRole?.id
       );
 
-      if (newRolesToAssign.length > 0) {
+      if (newRolesToAssign.length == 0) {
+        postgresUserDataSource.removeUserRoles(id);
+        this.stfcRolesCache.remove(String(id));
+        this.uopRolesCache.remove(String(id));
+      } else if (newRolesToAssign.length > 0) {
         await postgresUserDataSource.setUserRoles(id, newRolesToAssign);
         this.stfcRolesCache.remove(String(id));
         this.uopRolesCache.remove(String(id));
@@ -519,6 +523,10 @@ export class StfcUserDataSource implements UserDataSource {
   }
 
   async update(user: UpdateUserByIdArgs): Promise<User> {
+    throw new Error('Method not implemented.');
+  }
+
+  async removeUserRoles(id: number): Promise<void> {
     throw new Error('Method not implemented.');
   }
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->
refs: #https://github.com/UserOfficeProject/issue-tracker/issues/1610

Fixes bug that stopped the removal of the all UOS given roles.

Now when removing a role if it is the last role given in UOS and not from STFC UOWS then all UOS roles are removed from the role_user table for that user and only roles from UOWS are left.

## Motivation and Context
When wanting to remove all roles given in the UI and not from UOWS there was a bug where the role would not be deleted as it was the last roles associated with that user in the role_user table, however an STFC user will always have roles given by UOWS  and therefore can have all UOS given roles removed without error. 

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
