### PR TITLE
refactor:  return template id for question template relationship object

### DIFF
--- a/apps/backend/src/datasources/mockups/QuestionaryDataSource.ts
+++ b/apps/backend/src/datasources/mockups/QuestionaryDataSource.ts
@@ -1,3 +1,4 @@
+import { DeepPartial } from './ProposalDataSource';
 import {
   DependenciesLogicOperator,
   EvaluatorOperator,
@@ -29,7 +30,6 @@ import {
   TextInputConfig,
 } from '../../resolvers/types/FieldConfig';
 import { QuestionaryDataSource } from '../QuestionaryDataSource';
-import { DeepPartial } from './ProposalDataSource';
 
 export let dummyQuestionarySteps: QuestionaryStep[];
 export let dummyQuestionary: Questionary;
@@ -74,6 +74,7 @@ export const dummyQuestionTemplateRelationFactory = (
     dummyQuestionFactory(values?.question),
     values?.sortOrder || Math.round(Math.random() * 100),
     values?.topicId || Math.round(Math.random() * 10),
+    values?.templateId || Math.round(Math.random() * 100),
     values?.config || { ...new BooleanConfig(), readPermissions: [] },
     values?.dependencies as FieldDependency[],
     values?.dependenciesOperator as DependenciesLogicOperator

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -931,6 +931,7 @@ export const createQuestionTemplateRelationObject = async <T extends DataType>(
     ),
     record.topic_id,
     record.sort_order,
+    record.template_id,
     createConfig<any>(record.data_type as DataType, transformedConfig),
     dependencies,
     record.dependencies_operator

--- a/apps/backend/src/models/Questionary.ts
+++ b/apps/backend/src/models/Questionary.ts
@@ -20,6 +20,7 @@ export class Answer extends QuestionTemplateRelation {
       questionTemplateRelation.question,
       questionTemplateRelation.topicId,
       questionTemplateRelation.sortOrder,
+      questionTemplateRelation.templateId,
       questionTemplateRelation.config,
       questionTemplateRelation.dependencies,
       questionTemplateRelation.dependenciesOperator

--- a/apps/backend/src/models/Template.ts
+++ b/apps/backend/src/models/Template.ts
@@ -80,6 +80,7 @@ export class QuestionTemplateRelation {
     public question: Question,
     public topicId: number,
     public sortOrder: number,
+    public templateId: number,
     public config: typeof FieldConfigType,
     public dependencies: FieldDependency[],
     public dependenciesOperator?: DependenciesLogicOperator

--- a/apps/backend/src/resolvers/types/QuestionTemplateRelation.ts
+++ b/apps/backend/src/resolvers/types/QuestionTemplateRelation.ts
@@ -17,6 +17,9 @@ export class QuestionTemplateRelation
   public sortOrder: number;
 
   @Field(() => Int)
+  public templateId: number;
+
+  @Field(() => Int)
   public topicId: number;
 
   @Field(() => FieldConfigType)

--- a/apps/frontend/src/components/common/proposalFilters/QuestionaryFilter.tsx
+++ b/apps/frontend/src/components/common/proposalFilters/QuestionaryFilter.tsx
@@ -63,11 +63,7 @@ const extractSearchableQuestions = (
     ); // only searchable questions
 };
 
-function QuestionaryFilter({
-  onSubmit,
-  callId,
-  templateId,
-}: QuestionaryFilterProps) {
+function QuestionaryFilter({ onSubmit, callId }: QuestionaryFilterProps) {
   const { loading: isLoadingQuestionarySteps, questionarySteps } =
     useBlankQuestionaryStepsDataByCallId(callId);
 
@@ -163,7 +159,7 @@ function QuestionaryFilter({
               }}
               questionTemplateRelation={selectedQuestion}
               callId={callId}
-              templateId={templateId}
+              templateId={selectedQuestion.templateId}
             />
           )}
         </Collapse>

--- a/apps/frontend/src/graphql/questionary/fragment.answer.graphql
+++ b/apps/frontend/src/graphql/questionary/fragment.answer.graphql
@@ -4,6 +4,7 @@ fragment answer on Answer {
     ...question
   }
   sortOrder
+  templateId
   topicId
   config {
     ...fieldConfig

--- a/apps/frontend/src/graphql/template/fragment.questionRel.graphql
+++ b/apps/frontend/src/graphql/template/fragment.questionRel.graphql
@@ -3,6 +3,7 @@ fragment questionTemplateRelation on QuestionTemplateRelation {
     ...question
   }
   sortOrder
+  templateId
   topicId
   config {
     ...fieldConfig


### PR DESCRIPTION
## Description
This PR introduces a refactor to return the template ID for question template relationship object.

## Motivation and Context
This PR addresses comment raised here where the template id was missing
https://github.com/UserOfficeProject/user-office-core/pull/1582#discussion_r3420601361
Template ID is an essential field for the question-template relationship object therefore it should be included in the return fields. This PR adds the field and utilizes in the apps/frontend/src/components/common/proposalFilters/QuestionaryFilter.tsx

## Changes
1. 'templateId' field was added to several classes related to question template relations, including 'QuestionTemplateRelation', 'Answer' and 'createQuestionTemplateRelationObject'.
2. Adjustments were made to 'QuestionaryFilter' component to use the new 'templateId' field.
3. The GraphQL fragments 'answer' and 'questionTemplateRelation' were updated to include 'templateId'.

## How Has This Been Tested?

Manually and checking if the performance is not degrated

