### PR TITLE
fix: getProposal api error

### DIFF
--- a/apps/backend/src/resolvers/types/Questionary.ts
+++ b/apps/backend/src/resolvers/types/Questionary.ts
@@ -38,7 +38,7 @@ export class QuestionaryResolver {
     );
   }
 
-  @FieldResolver(() => Boolean)
+  @FieldResolver(() => Boolean, { nullable: true })
   async isCompleted(
     @Root() questionary: Questionary,
     @Ctx() context: ResolverContext

--- a/apps/backend/src/resolvers/types/QuestionaryStep.ts
+++ b/apps/backend/src/resolvers/types/QuestionaryStep.ts
@@ -10,7 +10,7 @@ export class QuestionaryStep implements Partial<QuestionaryStepOrigin> {
   public topic: Topic;
 
   @Field()
-  public isCompleted: boolean;
+  public isCompleted?: boolean;
 
   @Field(() => [Answer])
   public fields: Answer[];


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
refs: https://github.com/UserOfficeProject/issue-tracker/issues/1620
There has been an error when calling the getProposal api call that the isComplete cannot be null. 
This can be resolved by allowing it to be null. 
<!--- Describe your changes in detail -->
### **This includes schema changes that need to be approved**


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
