### PR TITLE
fix: remove excess throw from unhandled diamond events

### DIFF
--- a/apps/backend/src/eventHandlers/email/DLS/DLSEmailHandler.ts
+++ b/apps/backend/src/eventHandlers/email/DLS/DLSEmailHandler.ts
@@ -16,9 +16,9 @@ export async function DLSEmailHandler(event: ApplicationEvent) {
 
   const handler = handlers[event.type];
 
-  if (!handler) {
-    throw new Error(`No handler for event type ${event.type}`);
+  if (handler) {
+    return await handler(event);
   }
 
-  return await handler(event);
+  return;
 }


### PR DESCRIPTION
removes too many errors from diamond logs when event not handled.
Tested diamond emails to confirm still works and logs are cleaner