### PR TITLE
refactor: improve logging on Factory download failure

### DIFF
--- a/apps/backend/src/factory/service.ts
+++ b/apps/backend/src/factory/service.ts
@@ -110,6 +110,7 @@ export default async function callFactoryService<TData, TMeta extends MetaBase>(
               });
               span.setStatus({ code: 2, message: String(err) });
             }
+            throw err;
           } finally {
             span.end();
           }

--- a/apps/backend/src/factory/service.ts
+++ b/apps/backend/src/factory/service.ts
@@ -38,6 +38,27 @@ export type XLSXMetaBase = MetaBase & { columns: string[] };
 
 const ENDPOINT = process.env.USER_OFFICE_FACTORY_ENDPOINT;
 
+async function throwFactoryError(
+  factoryResp: globalThis.Response,
+  downloadType: DownloadType,
+  type: PDFType | XLSXType | ZIPType
+) {
+  const body = await factoryResp.text();
+
+  let parsed: { message?: string } | undefined;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    parsed = undefined;
+  }
+
+  const detail = typeof parsed?.message === 'string' ? parsed.message : body;
+
+  throw new Error(
+    `Factory service failed to generate ${downloadType}/${type}: ${detail}`
+  );
+}
+
 export default async function callFactoryService<TData, TMeta extends MetaBase>(
   downloadType: DownloadType,
   type: PDFType | XLSXType | ZIPType,
@@ -90,7 +111,7 @@ export default async function callFactoryService<TData, TMeta extends MetaBase>(
             );
 
             if (!factoryResp.ok) {
-              throw new Error(await factoryResp.text());
+              await throwFactoryError(factoryResp, downloadType, type);
             }
 
             factoryRespBody = factoryResp.body;
@@ -125,7 +146,7 @@ export default async function callFactoryService<TData, TMeta extends MetaBase>(
       });
 
       if (!factoryResp.ok) {
-        throw new Error(await factoryResp.text());
+        await throwFactoryError(factoryResp, downloadType, type);
       }
 
       factoryRespBody = factoryResp.body;
@@ -142,7 +163,7 @@ export default async function callFactoryService<TData, TMeta extends MetaBase>(
 
     readableStream.on('error', (err) => {
       next({
-        error: err.toString(),
+        error: err,
         message: `Could not download generated ${downloadType}/${type}`,
       });
     });

--- a/apps/backend/src/middlewares/factory.ts
+++ b/apps/backend/src/middlewares/factory.ts
@@ -83,17 +83,26 @@ factoryDownloadRouter.use(
     next: NextFunction
   ) => {
     let message: string;
+    let underlyingError: Error | undefined;
 
     if (err instanceof Error) {
       message = err.message;
+      underlyingError = err;
     } else if (typeof err === 'string') {
       message = err;
+    } else if (err.error instanceof Error) {
+      message = err.error.message;
+      underlyingError = err.error;
     } else {
       message = err.message;
     }
 
-    err instanceof Error
-      ? logger.logException(err.message, err, getLogContextFromRequest(req))
+    underlyingError
+      ? logger.logException(
+          message,
+          underlyingError,
+          getLogContextFromRequest(req)
+        )
       : logger.logError(defaultErrorMessage, {
           err,
           ...getLogContextFromRequest(req),


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

- Fixes errors being swallowed when tracing was enabled. The catch block would never throw and so the code continued until it errored trying to read a non existent stream which caused the ambiguous `ERR_INVALID_ARG_TYPE` error.
- Improves the logging by including the error message from the factory.

Before:
> [2026-07-23T12:02:59.395+01:00] ERROR - Failed to generate the requested file(s) 
>  {"err":{"error":{"code":"ERR_INVALID_ARG_TYPE"},"message":"Could not download generated pdf/proposal"},"originalUrl":"/download/pdf/proposal/31754"


After: 
> [2026-07-28T17:19:27.448+01:00] ERROR - Factory service failed to generate pdf/proposal: Could not create readable stream
> error: large object 628393 does not exist undefined 
>  {"exception":{"name":"Error","message":"Factory service failed to generate pdf/proposal: Could not create readable stream \nerror: large object 628393 does not exist undefined",


<!--- Describe your changes in detail -->

## Motivation and Context

We see this vague error occasionally in logs at STFC and it is useful for diagnosing problems.

## How Has This Been Tested

Manual testing checking logs with tracing enabled and disabled.

## Fixes

https://github.com/UserOfficeProject/issue-tracker/issues/1636

## Changes

- A new function `throwFactoryError` is introduced to handle Factory download failures. It provides more detailed error messages, including the download type and the exact error message from the Factory service.
- The error handling in `callFactoryService` function has been updated to use the new `throwFactoryError` function.
- The error logging in the Factory middleware has been enhanced to log the underlying error along with its message, providing more context for debugging.

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated