### PR TITLE
fix: pdf omits answers dependent on instrument picker questions

### DIFF
--- a/apps/backend/src/datasources/mockups/QuestionaryDataSource.ts
+++ b/apps/backend/src/datasources/mockups/QuestionaryDataSource.ts
@@ -26,6 +26,7 @@ import {
   EmbellishmentConfig,
   FieldConfigType,
   FileUploadConfig,
+  InstrumentPickerConfig,
   SelectionFromOptionsConfig,
   TextInputConfig,
 } from '../../resolvers/types/FieldConfig';
@@ -365,6 +366,52 @@ const create1Topic3FieldWithDependenciesQuestionarySteps = () => {
             ],
           }),
           ['A', 'B']
+        ),
+
+        // Instrument picker questions
+        new Answer(
+          12,
+          dummyQuestionTemplateRelationFactory({
+            question: dummyQuestionFactory({
+              id: 'instrument_picker',
+              naturalKey: 'instrument_picker',
+              dataType: DataType.INSTRUMENT_PICKER,
+              config: createConfig<InstrumentPickerConfig>(
+                DataType.INSTRUMENT_PICKER,
+                {
+                  instruments: [{ id: 49, name: 'INST1' }],
+                  isMultipleSelect: false,
+                  requestTime: false,
+                  variant: 'dropdown',
+                }
+              ),
+            }),
+          }),
+          { instrumentId: '49', timeRequested: '0' }
+        ),
+
+        new Answer(
+          13,
+          dummyQuestionTemplateRelationFactory({
+            question: dummyQuestionFactory({
+              id: 'instrument_picker_depender',
+              naturalKey: 'instrument_picker_depender',
+              dataType: DataType.TEXT_INPUT,
+              config: createConfig<TextInputConfig>(DataType.TEXT_INPUT, {
+                multiline: false,
+                required: true,
+              }),
+            }),
+            dependencies: [
+              new FieldDependency(
+                'instrument_picker_depender',
+                'instrument_picker',
+                'instrument_picker',
+                new FieldCondition(EvaluatorOperator.eq, 49)
+              ),
+            ],
+          }),
+          'INST1-only answer'
         ),
       ]
     ),

--- a/apps/backend/src/models/ConditionEvaluator.ts
+++ b/apps/backend/src/models/ConditionEvaluator.ts
@@ -1,4 +1,5 @@
 import { Answer } from './Questionary';
+import { DataType } from './Template';
 
 export enum EvaluatorOperator {
   eq = 'eq',
@@ -10,8 +11,28 @@ export enum DependenciesLogicOperator {
   OR = 'OR',
 }
 
+const equalityForInstrumentPicker = (
+  answer: Answer,
+  params: Record<string, unknown>
+): boolean => {
+  if (Array.isArray(answer.value)) {
+    const ids = answer.value.map(
+      (v: { instrumentId: string }) => v?.instrumentId
+    );
+
+    return ids.includes(new String(params).valueOf());
+  } else {
+    const v: { instrumentId: string } | undefined = answer.value;
+
+    return v?.instrumentId === new String(params).valueOf();
+  }
+};
+
 export class EqualityValidator implements FieldConditionEvaluator {
   isSatisfied(answer: Answer, params: Record<string, unknown>): boolean {
+    if (answer.question.dataType === DataType.INSTRUMENT_PICKER) {
+      return equalityForInstrumentPicker(answer, params);
+    }
     if (Array.isArray(answer.value)) {
       return answer.value.some((v: unknown) => v === params);
     } else {
@@ -24,6 +45,10 @@ export class EqualityValidator implements FieldConditionEvaluator {
 
 export class InequalityValidator implements FieldConditionEvaluator {
   isSatisfied(answer: Answer, params: Record<string, unknown>): boolean {
+    if (answer.question.dataType === DataType.INSTRUMENT_PICKER) {
+      return !equalityForInstrumentPicker(answer, params);
+    }
+
     return answer.value !== params;
   }
 }

--- a/apps/backend/src/models/ProposalModelFunctions.spec.ts
+++ b/apps/backend/src/models/ProposalModelFunctions.spec.ts
@@ -166,3 +166,27 @@ it('AND dependency requires all satisfied', async () => {
     false
   );
 });
+
+it('Instrument picker dependencies should be satisfied if the selected instrument matches', async () => {
+  const questionarySteps = await dataSource.getQuestionarySteps(1);
+  const dependee = getFieldById(
+    questionarySteps,
+    'instrument_picker'
+  ) as Answer;
+  const depender = getFieldById(
+    questionarySteps,
+    'instrument_picker_depender'
+  ) as Answer;
+
+  dependee.value = { instrumentId: '49', timeRequested: '0' };
+
+  expect(areDependenciesSatisfied(questionarySteps, depender.question.id)).toBe(
+    true
+  );
+
+  dependee.value = { instrumentId: '50', timeRequested: '0' };
+
+  expect(areDependenciesSatisfied(questionarySteps, depender.question.id)).toBe(
+    false
+  );
+});


### PR DESCRIPTION
## Description
This PR fixes an issue where answers dependent on instrument picker questions were being omitted in the generated PDF.

## Motivation and Context
The issue arose because the current condition evaluator did not properly handle the `INSTRUMENT_PICKER` datatype, causing dependent answers to be erroneously omitted. This fix is crucial to ensure that all relevant data is accurately represented in the generated PDFs.

## Changes
1. Modified `QuestionaryDataSource.ts` to include instrument picker questions and their dependent answers.
2. Updated `ConditionEvaluator.ts` to add an equality check for the `INSTRUMENT_PICKER` datatype.
3. Added a test case in `ProposalModelFunctions.spec.ts` to verify that instrument picker dependencies are correctly satisfied.

## How Has This Been Tested?

- Unit test added
- Manually tested that the question and answer shows up in PDFs, with both default and custom template.

## Fixes Jira Issue

https://github.com/UserOfficeProject/issue-tracker/issues/1645

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated