### PR TITLE
feat: add new events to the message broker

### DIFF
--- a/apps/backend/src/eventHandlers/messageBroker.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.ts
@@ -121,7 +121,7 @@ export function createListenToQueueHandler() {
   );
 }
 
-export const getProposalMessageData = async (proposal: Proposal) => {
+const buildProposalMessageData = async (proposal: Proposal) => {
   const userDataSource = container.resolve<UserDataSource>(
     Tokens.UserDataSource
   );
@@ -231,7 +231,21 @@ export const getProposalMessageData = async (proposal: Proposal) => {
     );
   }
 
+  return messageData;
+};
+
+export const getProposalMessageData = async (proposal: Proposal) => {
+  const messageData = await buildProposalMessageData(proposal);
+
   return JSON.stringify(messageData);
+};
+
+export const getProposalsMessageData = async (proposals: Proposal[]) => {
+  const proposalsMessageData = await Promise.all(
+    proposals.map(getProposalMessageData)
+  );
+
+  return JSON.stringify(proposalsMessageData);
 };
 
 export const getExperimentMessageData = async (experiment: Experiment) => {
@@ -328,7 +342,9 @@ export async function createPostToRabbitMQHandler() {
 
     switch (event.type) {
       case Event.PROPOSAL_STATUS_CHANGED_BY_USER: {
-        const jsonMessage = JSON.stringify(event.proposals);
+        const jsonMessage = await getProposalsMessageData(
+          event.proposals.proposals
+        );
         await rabbitMQ.sendMessageToExchange(
           event.exchange || EXCHANGE_NAME,
           event.type,

--- a/apps/backend/src/eventHandlers/messageBroker.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.ts
@@ -242,7 +242,7 @@ export const getProposalMessageData = async (proposal: Proposal) => {
 
 export const getProposalsMessageData = async (proposals: Proposal[]) => {
   const proposalsMessageData = await Promise.all(
-    proposals.map(getProposalMessageData)
+    proposals.map(buildProposalMessageData)
   );
 
   return JSON.stringify(proposalsMessageData);

--- a/apps/backend/src/eventHandlers/messageBroker.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.ts
@@ -327,6 +327,17 @@ export async function createPostToRabbitMQHandler() {
     }
 
     switch (event.type) {
+      case Event.PROPOSAL_STATUS_CHANGED_BY_USER: {
+        const jsonMessage = JSON.stringify(event.proposals);
+        await rabbitMQ.sendMessageToExchange(
+          event.exchange || EXCHANGE_NAME,
+          event.type,
+          jsonMessage
+        );
+        break;
+      }
+      case Event.PROPOSAL_MANAGEMENT_DECISION_UPDATED:
+      case Event.PROPOSAL_MANAGEMENT_DECISION_SUBMITTED:
       case Event.PROPOSAL_CREATED:
       case Event.PROPOSAL_UPDATED:
       case Event.PROPOSAL_SUBMITTED:


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Add new events to the message broker. 

## Motivation and Context

At ELI we need these proposal update events. 

## How Has This Been Tested

Local tests. 

## Fixes

N/A

## Changes

messageBroker.ts

## Depends on

N/A

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
