### PR TITLE
refactor: improve status action logging

### DIFF
--- a/apps/backend/src/eventHandlers/workflowEntities/proposal/statusActionEngine.ts
+++ b/apps/backend/src/eventHandlers/workflowEntities/proposal/statusActionEngine.ts
@@ -1,3 +1,4 @@
+import { logger } from '@user-office-software/duo-logger';
 import { container } from 'tsyringe';
 
 import { emailActionHandler } from './emailActionHandler';
@@ -32,6 +33,18 @@ export const proposalStatusActionEngine = async (
     groupResult.map(async (groupedProposals) => {
       // NOTE: We get the needed ids from the first proposal in the group.
       const [{ workflowStatusConnectionId }] = groupedProposals;
+      const callIds = [
+        ...new Set(groupedProposals.map(({ proposal }) => proposal.callId)),
+      ];
+      const proposalPks = groupedProposals.map(
+        ({ proposal }) => proposal.primaryKey
+      );
+      const groupLogContext = {
+        workflowStatusConnectionId,
+        callIds,
+        proposalPks,
+      };
+
       const currentConnection = await workflowDataSource.getWorkflowConnection(
         workflowStatusConnectionId
       );
@@ -52,11 +65,22 @@ export const proposalStatusActionEngine = async (
             return;
           }
 
+          const logContext = {
+            ...groupLogContext,
+            actionId: statusAction.type,
+          };
+
           switch (statusAction.type) {
             case StatusActionType.EMAIL:
               emailActionHandler(
                 statusAction,
                 groupedProposals.map((proposal) => proposal.proposal)
+              ).catch((error) =>
+                logger.logException(
+                  'Error executing email status actions',
+                  error,
+                  logContext
+                )
               );
               break;
 
@@ -64,6 +88,12 @@ export const proposalStatusActionEngine = async (
               rabbitMQActionHandler(
                 statusAction,
                 groupedProposals.map((proposal) => proposal.proposal)
+              ).catch((error) =>
+                logger.logException(
+                  'Error executing RabbitMQ status actions',
+                  error,
+                  logContext
+                )
               );
               break;
 
@@ -71,6 +101,12 @@ export const proposalStatusActionEngine = async (
               pdfDownloadActionHandler(
                 statusAction,
                 groupedProposals.map((proposal) => proposal.proposal)
+              ).catch((error) =>
+                logger.logException(
+                  'Error executing proposal download status actions',
+                  error,
+                  logContext
+                )
               );
               break;
 
@@ -80,5 +116,7 @@ export const proposalStatusActionEngine = async (
         })
       );
     })
-  );
+  ).catch((error) => {
+    logger.logException('Error executing proposal status action engine', error);
+  });
 };


### PR DESCRIPTION
## Description
Adds some logging around executing status actions where errors thrown inside the individual action handlers were previously uncaught. The lookups that run before the status actions are also caught and logged.

## Motivation and Context
Part of the investigation into https://github.com/UserOfficeProject/issue-tracker/issues/1648

The current logging system for status actions lacks specificity, making it difficult to debug and track errors. This change is required to provide clearer, context-specific logging for different status actions (email, RabbitMQ, proposal download), and thus facilitate easier error tracking and resolution.

## Changes
1. Added a dedicated logger from the '@user-office-software/duo-logger' package.
2. Enhanced logging context with specific details such as 'workflowStatusConnectionId', 'callIds', and 'proposalPks'.
3. Implemented error catching for each status action type (EMAIL, RABBITMQ, PROPOSALDOWNLOAD) to log specific exceptions, thus providing more precise information for debugging.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

Part of https://github.com/UserOfficeProject/issue-tracker/issues/1648

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated