### PR TITLE
feat: add getVisitMessageData function to handle visit registration payload

### DIFF
--- a/apps/backend/src/eventHandlers/messageBroker.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.ts
@@ -31,7 +31,10 @@ import { Institution } from '../models/Institution';
 import { Proposal } from '../models/Proposal';
 import { Sample } from '../models/Sample';
 import { Visit } from '../models/Visit';
-import { VisitRegistrationStatus } from '../models/VisitRegistration';
+import {
+  VisitRegistration,
+  VisitRegistrationStatus,
+} from '../models/VisitRegistration';
 import { WorkflowEngine } from '../workflowEngine';
 import proposalWorkflowEntity from './workflowEntities/proposal';
 
@@ -295,6 +298,29 @@ export const getExperimentMessageData = async (experiment: Experiment) => {
   return JSON.stringify(messageData);
 };
 
+export const getVisitMessageData = async (
+  visitRegistration: VisitRegistration
+) => {
+  const proposalDataSource = container.resolve<ProposalDataSource>(
+    Tokens.ProposalDataSource
+  );
+
+  const proposal = await proposalDataSource.getProposalByVisitId(
+    visitRegistration.visitId
+  );
+  const proposalPayload = await getProposalMessageData(proposal);
+
+  const visitJsonMessage = JSON.stringify({
+    id: visitRegistration.id,
+    startAt: visitRegistration.startsAt,
+    endAt: visitRegistration.endsAt,
+    visitorId: visitRegistration.userId.toString(),
+    proposal: JSON.parse(proposalPayload),
+  });
+
+  return visitJsonMessage;
+};
+
 export async function createPostToRabbitMQHandler() {
   const rabbitMQ = await getRabbitMQMessageBroker();
 
@@ -495,7 +521,6 @@ export async function createPostToRabbitMQHandler() {
           break;
         }
 
-        const jsonMessage = await getExperimentMessageData(experiment);
         let rabbitMQVisitEventType = RABBITMQ_VISIT_EVENT_TYPE.VISIT_UPDATED;
         if (event.type === Event.VISIT_REGISTRATION_APPROVED) {
           rabbitMQVisitEventType = RABBITMQ_VISIT_EVENT_TYPE.VISIT_CREATED;
@@ -503,17 +528,21 @@ export async function createPostToRabbitMQHandler() {
           rabbitMQVisitEventType = RABBITMQ_VISIT_EVENT_TYPE.VISIT_DELETED;
         }
 
+        const visitJsonMessage = await getVisitMessageData(visitRegistration);
         await rabbitMQ.sendMessageToExchange(
           EXCHANGE_NAME,
           rabbitMQVisitEventType,
-          jsonMessage
+          visitJsonMessage
         );
 
+        const experimentJsonMessage =
+          await getExperimentMessageData(experiment);
         await rabbitMQ.sendMessageToExchange(
           EXCHANGE_NAME,
           Event.EXPERIMENT_UPDATED,
-          jsonMessage
+          experimentJsonMessage
         );
+
         break;
       }
       case Event.DATA_ACCESS_USERS_UPDATED: {


### PR DESCRIPTION
## Description
This PR introduces a new function `getVisitMessageData` to handle visit registration payload.

## Motivation and Context
Previously, the visit registration payload was not being handled correctly, which resulted in incorrect data being sent. This new function will ensure the correct visit registration payload data is fetched and sent.

## Changes
1. A new function `getVisitMessageData` has been added which fetches the visit registration data and returns it in a correct format.
2. The function `getVisitMessageData` is used to get the visit registration payload in the `createPostToRabbitMQHandler` function.
3. The `createPostToRabbitMQHandler` function has been refactored to use the new `getVisitMessageData` function for handling visit registration payload.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/](https://jira.ess.eu//browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated