### PR TITLE
fix: instrument requested time for multi-instrument of FAP page

### DIFF
--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -340,20 +340,32 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     proposalPk: number,
     instrumentId: number
   ): Promise<number> {
-    //Non-nullable, time is either requested for the instrument or it is zero.
-    const result = await database.raw(
-      `select sum(timeRequestedOne) as total_time_requested from (
-	select (instrumenrequest->>'timeRequested')::numeric as timeRequestedOne, p.proposal_pk as proposalPk, x.instrumenrequest->> 'instrumentId' as inslist from proposals p
-	inner join answers a on a.questionary_id  = p.questionary_id 
-	cross join lateral (
-	select  jsonb_array_elements(a.answer -> 'value') as instrumenrequest) x
-	where jsonb_typeof(a.answer->'value') = 'array'
-	union ALL
-	select (a.answer->'value'->>'timeRequested')::numeric as timeRequestedOne,  p.proposal_pk as proposalPk, a.answer->'value'->>'instrumentId' as inslist  from proposals p
-	inner join answers a on a.questionary_id  = p.questionary_id where jsonb_typeof(a.answer -> 'value') = 'object' 
-) as combinedResults
-where inslist = '${instrumentId}' and proposalpk =${proposalPk};`
-    );
+    const result = await database.raw(`
+      select sum(timeRequestedOne) as total_time_requested from (
+        --First query is for handling multiInstrument picker when answers.answer.value is an array.
+        select 
+          (instrumentrequest->>'timeRequested')::numeric as timeRequestedOne,
+          p.proposal_pk as proposalPk,
+          x.instrumentrequest->> 'instrumentId' as instrumentId
+        from proposals p
+	      inner join answers a on a.questionary_id = p.questionary_id 
+	      cross join lateral (
+	        select 
+            jsonb_array_elements(a.answer -> 'value') as instrumentrequest) x
+	        where jsonb_typeof(a.answer->'value') = 'array'
+
+	      union ALL
+	
+        --Second query is for handling single instrument picker when answers.answer.value is an object.
+        select 
+          (a.answer->'value'->>'timeRequested')::numeric as timeRequestedOne,
+          p.proposal_pk as proposalPk, 
+          a.answer->'value'->>'instrumentId' as instrumentId 
+        from proposals p
+        inner join answers a on a.questionary_id = p.questionary_id 
+        where jsonb_typeof(a.answer -> 'value') = 'object' 
+      ) as combinedResults
+      where instrumentId = '${instrumentId}' and proposalpk =${proposalPk};`);
 
     return result?.rows?.[0]?.total_time_requested
       ? Number(result?.rows?.[0]?.total_time_requested)

--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -341,31 +341,31 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     instrumentId: number
   ): Promise<number> {
     const result = await database.raw(`
-      select sum(timeRequestedOne) as total_time_requested from (
+      SELECT sum(timeRequestedOne) AS total_time_requested FROM (
         --First query is for handling multiInstrument picker when answers.answer.value is an array.
-        select 
-          (instrumentrequest->>'timeRequested')::numeric as timeRequestedOne,
-          p.proposal_pk as proposalPk,
-          x.instrumentrequest->> 'instrumentId' as instrumentId
-        from proposals p
-	      inner join answers a on a.questionary_id = p.questionary_id 
-	      cross join lateral (
-	        select 
-            jsonb_array_elements(a.answer -> 'value') as instrumentrequest) x
-	        where jsonb_typeof(a.answer->'value') = 'array'
+        SELECT 
+          (instrumentrequest->>'timeRequested')::numeric AS timeRequestedOne,
+          p.proposal_pk AS proposalPk,
+          x.instrumentrequest->> 'instrumentId' AS instrumentId
+        FROM proposals p
+	      INNER JOIN answers a ON a.questionary_id = p.questionary_id 
+	      CROSS JOIN LATERAL (
+	        SELECT 
+            jsonb_array_elements(a.answer -> 'value') AS instrumentrequest) x
+	        WHERE jsonb_typeof(a.answer->'value') = 'array'
 
-	      union ALL
+	      UNION ALL
 	
         --Second query is for handling single instrument picker when answers.answer.value is an object.
-        select 
-          (a.answer->'value'->>'timeRequested')::numeric as timeRequestedOne,
-          p.proposal_pk as proposalPk, 
-          a.answer->'value'->>'instrumentId' as instrumentId 
-        from proposals p
-        inner join answers a on a.questionary_id = p.questionary_id 
-        where jsonb_typeof(a.answer -> 'value') = 'object' 
-      ) as combinedResults
-      where instrumentId = '${instrumentId}' and proposalpk =${proposalPk};`);
+        SELECT 
+          (a.answer->'value'->>'timeRequested')::numeric AS timeRequestedOne,
+          p.proposal_pk AS proposalPk, 
+          a.answer->'value'->>'instrumentId' AS instrumentId 
+        FROM proposals p
+        INNER JOIN answers a ON a.questionary_id = p.questionary_id 
+        WHERE jsonb_typeof(a.answer -> 'value') = 'object' 
+      ) AS combinedResults
+      WHERE instrumentId = '${instrumentId}' AND proposalpk = ${proposalPk};`);
 
     return result?.rows?.[0]?.total_time_requested
       ? Number(result?.rows?.[0]?.total_time_requested)

--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -345,7 +345,7 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
       SELECT sum(timeRequestedOne) AS total_time_requested FROM (
         --First query is for handling multiInstrument picker when answers.answer.value is an array.
         SELECT 
-          (instrumentrequest->>'timeRequested')::numeric AS timeRequestedOne,
+          COALESCE((instrumentrequest->>'timeRequested')::numeric, 0) AS timeRequestedOne,
           p.proposal_pk AS proposalPk,
           x.instrumentrequest->> 'instrumentId' AS instrumentId
         FROM proposals p
@@ -359,7 +359,7 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
 	
         --Second query is for handling single instrument picker when answers.answer.value is an object.
         SELECT 
-          (a.answer->'value'->>'timeRequested')::numeric AS timeRequestedOne,
+          COALESCE((a.answer->'value'->>'timeRequested')::numeric, 0) AS timeRequestedOne,
           p.proposal_pk AS proposalPk, 
           a.answer->'value'->>'instrumentId' AS instrumentId 
         FROM proposals p

--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -341,24 +341,22 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     instrumentId: number
   ): Promise<number> {
     //Non-nullable, time is either requested for the instrument or it is zero.
-    const result = await database('proposals as p')
-      .sum({
-        total_time_requested: database.raw(
-          "(a.answer->'value'->>'timeRequested')::numeric"
-        ),
-      })
-      .innerJoin('questionaries as q2', 'q2.questionary_id', 'p.questionary_id')
-      .innerJoin('answers as a', 'a.questionary_id', 'q2.questionary_id')
-      .innerJoin('questions as q', 'q.question_id', 'a.question_id')
-      .where('p.proposal_pk', proposalPk)
-      .where('q.data_type', 'INSTRUMENT_PICKER')
-      .whereRaw("a.answer->'value'->>'instrumentId' = ?", [
-        instrumentId.toString(),
-      ])
-      .first();
+    const result = await database.raw(
+      `select sum(timeRequestedOne) as total_time_requested from (
+	select (instrumenrequest->>'timeRequested')::numeric as timeRequestedOne, p.proposal_pk as proposalPk, x.instrumenrequest->> 'instrumentId' as inslist from proposals p
+	inner join answers a on a.questionary_id  = p.questionary_id 
+	cross join lateral (
+	select  jsonb_array_elements(a.answer -> 'value') as instrumenrequest) x
+	where jsonb_typeof(a.answer->'value') = 'array'
+	union ALL
+	select (a.answer->'value'->>'timeRequested')::numeric as timeRequestedOne,  p.proposal_pk as proposalPk, a.answer->'value'->>'instrumentId' as inslist  from proposals p
+	inner join answers a on a.questionary_id  = p.questionary_id where jsonb_typeof(a.answer -> 'value') = 'object' 
+) as combinedResults
+where inslist = '${instrumentId}' and proposalpk =${proposalPk};`
+    );
 
-    return result?.total_time_requested
-      ? Number(result.total_time_requested)
+    return result?.rows?.[0]?.total_time_requested
+      ? Number(result?.rows?.[0]?.total_time_requested)
       : 0;
   }
 

--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -340,7 +340,8 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     proposalPk: number,
     instrumentId: number
   ): Promise<number> {
-    const result = await database.raw(`
+    const result = await database.raw(
+      `
       SELECT sum(timeRequestedOne) AS total_time_requested FROM (
         --First query is for handling multiInstrument picker when answers.answer.value is an array.
         SELECT 
@@ -365,7 +366,9 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
         INNER JOIN answers a ON a.questionary_id = p.questionary_id 
         WHERE jsonb_typeof(a.answer -> 'value') = 'object' 
       ) AS combinedResults
-      WHERE instrumentId = '${instrumentId}' AND proposalpk = ${proposalPk};`);
+      WHERE instrumentId = '?' AND proposalpk = ?;`,
+      [instrumentId, proposalPk]
+    );
 
     return result?.rows?.[0]?.total_time_requested
       ? Number(result?.rows?.[0]?.total_time_requested)

--- a/apps/backend/src/datasources/postgres/ProposalDataSource.ts
+++ b/apps/backend/src/datasources/postgres/ProposalDataSource.ts
@@ -366,7 +366,7 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
         INNER JOIN answers a ON a.questionary_id = p.questionary_id 
         WHERE jsonb_typeof(a.answer -> 'value') = 'object' 
       ) AS combinedResults
-      WHERE instrumentId = '?' AND proposalpk = ?;`,
+      WHERE instrumentId = ? AND proposalpk = ?;`,
       [instrumentId, proposalPk]
     );
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR fixes a bug where the instrument requested time would show as zero when it was a multi instrument type. The problem was that the answer could be stored as an object or a list so it now can handle both cases. 

I decided to use database.raw because I think it is easier to read than using the database syntax.

Note was written by me, not an AI. (Though an AI might have done a better job)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manual testing

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
