### PR TITLE
fix: api tokens cannot resolve Questionary.isCompleted

### DIFF
--- a/apps/backend/src/queries/QuestionaryQueries.ts
+++ b/apps/backend/src/queries/QuestionaryQueries.ts
@@ -108,7 +108,6 @@ export default class QuestionaryQueries {
     return this.dataSource.getCount(templateId);
   }
 
-  @Authorized()
   async isCompleted(agent: UserWithRole | null, questionaryId: number) {
     const hasRights =
       this.userAuth.isApiToken(agent) ||

--- a/apps/backend/src/queries/QuestionaryQueries.ts
+++ b/apps/backend/src/queries/QuestionaryQueries.ts
@@ -108,6 +108,8 @@ export default class QuestionaryQueries {
     return this.dataSource.getCount(templateId);
   }
 
+  // No @Authorized() - not grantable as an API key permission because it's
+  // only reachable via the already-authorised Questionary field resolver.
   async isCompleted(agent: UserWithRole | null, questionaryId: number) {
     const hasRights =
       this.userAuth.isApiToken(agent) ||


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Any API token selecting `isCompleted` on a `Questionary` failed with "Cannot return null for non-nullable field Questionary.isCompleted". It failed at the `@Authorized()` stage which checks if a specific API token permission exists for this query. But since we only make queries that begin with `get` grantable, it was never possible to grant it and so it always failed and returned null.

Rather than adding a new grantable permission for it, this removes the `@Authorized()` decorator instead because:

- `isCompleted` is only reachable via the `Questionary` field resolver, which is only reachable once already authorised to fetch the parent questionary
- The method already does its own authorisation inline checks.

## Motivation and Context

The error was noticed by another team consuming the UOP API.

## How Has This Been Tested

Manual testing

## Fixes

https://github.com/UserOfficeProject/issue-tracker/issues/1620

## Changes

Remove authorisation decorator

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
