### PR TITLE
feat: include visit registration questionary answers in visit messages

### DIFF
--- a/apps/backend/src/eventHandlers/messageBroker.spec.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.spec.ts
@@ -4,6 +4,7 @@ import { container } from 'tsyringe';
 import {
   getExperimentMessageData,
   getProposalMessageData,
+  getVisitMessageData,
 } from './messageBroker';
 import { Tokens } from '../config/Tokens';
 import { CallDataSourceMock } from '../datasources/mockups/CallDataSource';
@@ -22,14 +23,21 @@ import {
   dummyProposal,
   ProposalDataSourceMock,
 } from '../datasources/mockups/ProposalDataSource';
+import { QuestionaryDataSourceMock } from '../datasources/mockups/QuestionaryDataSource';
 import { SampleDataSourceMock } from '../datasources/mockups/SampleDataSource';
 import { StatusDataSourceMock } from '../datasources/mockups/StatusDataSource';
+import { TemplateDataSourceMock } from '../datasources/mockups/TemplateDataSource';
 import {
   dummyCountry,
   dummyInstitution,
   dummyUser,
   UserDataSourceMock,
 } from '../datasources/mockups/UserDataSource';
+import { Template, TemplateGroupId } from '../models/Template';
+import {
+  VisitRegistration,
+  VisitRegistrationStatus,
+} from '../models/VisitRegistration';
 
 describe('messageBroker', () => {
   describe('getProposalMessageData', () => {
@@ -215,6 +223,119 @@ describe('messageBroker', () => {
       expect(data.proposal.proposer).toBeDefined();
       expect(data.proposal.proposer.id).toBe(dummyUser.id.toString());
       expect(data.proposal.proposer.firstName).toBe(dummyUser.firstname);
+    });
+  });
+
+  describe('getVisitMessageData', () => {
+    let mockProposalDataSource: ProposalDataSourceMock;
+    let mockQuestionaryDataSource: QuestionaryDataSourceMock;
+    let mockSampleDataSource: SampleDataSourceMock;
+    let mockTemplateDataSource: TemplateDataSourceMock;
+
+    const visitRegistration = new VisitRegistration(
+      'visit-registration-id',
+      1,
+      dummyUser.id,
+      1,
+      new Date('2026-08-24T08:00:00.000Z'),
+      new Date('2026-08-24T16:00:00.000Z'),
+      VisitRegistrationStatus.APPROVED
+    );
+
+    beforeEach(() => {
+      mockProposalDataSource = container.resolve(Tokens.ProposalDataSource);
+      mockQuestionaryDataSource = container.resolve(
+        Tokens.QuestionaryDataSource
+      );
+      mockSampleDataSource = container.resolve(Tokens.SampleDataSource);
+      mockTemplateDataSource = container.resolve(Tokens.TemplateDataSource);
+
+      mockProposalDataSource.init();
+      mockQuestionaryDataSource.init();
+      mockSampleDataSource.init();
+      mockTemplateDataSource.init();
+
+      jest
+        .spyOn(mockTemplateDataSource, 'getTemplate')
+        .mockResolvedValue(
+          new Template(
+            1,
+            TemplateGroupId.VISIT_REGISTRATION,
+            'Visit registration',
+            'Visit registration template',
+            false
+          )
+        );
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should include stored and default visit answers by natural key', async () => {
+      jest
+        .spyOn(mockQuestionaryDataSource, 'getQuestionarySteps')
+        .mockResolvedValue([
+          {
+            fields: [
+              {
+                answerId: 10,
+                question: { naturalKey: 'arrival_transport' },
+                value: 'train',
+              },
+              {
+                answerId: null,
+                question: { naturalKey: 'unanswered_question' },
+                value: 'default value',
+              },
+            ],
+          },
+        ] as any);
+
+      const result = await getVisitMessageData(visitRegistration);
+      const data = JSON.parse(result);
+
+      expect(data).toMatchObject({
+        id: visitRegistration.id,
+        startAt: visitRegistration.startsAt!.toISOString(),
+        endAt: visitRegistration.endsAt!.toISOString(),
+        visitorId: visitRegistration.userId.toString(),
+        registrationAnswers: [
+          { questionNaturalKey: 'arrival_transport', value: 'train' },
+          {
+            questionNaturalKey: 'unanswered_question',
+            value: 'default value',
+          },
+        ],
+      });
+      expect(data.proposal.proposalPk).toBe(dummyProposal.primaryKey);
+      expect(
+        mockQuestionaryDataSource.getQuestionarySteps
+      ).toHaveBeenCalledWith(visitRegistration.registrationQuestionaryId);
+    });
+
+    it('should exclude answers from a non-visit template', async () => {
+      jest
+        .spyOn(mockTemplateDataSource, 'getTemplate')
+        .mockResolvedValue(
+          new Template(
+            1,
+            TemplateGroupId.PROPOSAL,
+            'Proposal',
+            'Proposal template',
+            false
+          )
+        );
+      const getQuestionarySteps = jest.spyOn(
+        mockQuestionaryDataSource,
+        'getQuestionarySteps'
+      );
+
+      const result = await getVisitMessageData(visitRegistration);
+      const data = JSON.parse(result);
+
+      expect(data.registrationAnswers).toEqual([]);
+      expect(getQuestionarySteps).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/eventHandlers/messageBroker.ts
+++ b/apps/backend/src/eventHandlers/messageBroker.ts
@@ -16,6 +16,7 @@ import {
 import { ExperimentDataSource } from '../datasources/ExperimentDataSource';
 import { InstrumentDataSource } from '../datasources/InstrumentDataSource';
 import { ProposalDataSource } from '../datasources/ProposalDataSource';
+import { QuestionaryDataSource } from '../datasources/QuestionaryDataSource';
 import { SampleDataSource } from '../datasources/SampleDataSource';
 import { StatusDataSource } from '../datasources/StatusDataSource';
 import { TemplateDataSource } from '../datasources/TemplateDataSource';
@@ -30,6 +31,7 @@ import { Experiment } from '../models/Experiment';
 import { Institution } from '../models/Institution';
 import { Proposal } from '../models/Proposal';
 import { Sample } from '../models/Sample';
+import { TemplateGroupId } from '../models/Template';
 import { Visit } from '../models/Visit';
 import {
   VisitRegistration,
@@ -87,6 +89,11 @@ type ExperimentMessageData = {
   proposal?: ProposalMessageData;
   samples?: Pick<Sample, 'id' | 'title'>[];
   instrument?: { id: number; name: string; shortCode: string };
+};
+
+type VisitRegistrationAnswerMessageData = {
+  questionNaturalKey: string;
+  value: unknown;
 };
 
 let rabbitMQCachedBroker: null | RabbitMQMessageBroker = null;
@@ -318,11 +325,42 @@ export const getVisitMessageData = async (
   const proposalDataSource = container.resolve<ProposalDataSource>(
     Tokens.ProposalDataSource
   );
+  const questionaryDataSource = container.resolve<QuestionaryDataSource>(
+    Tokens.QuestionaryDataSource
+  );
+  const templateDataSource = container.resolve<TemplateDataSource>(
+    Tokens.TemplateDataSource
+  );
 
   const proposal = await proposalDataSource.getProposalByVisitId(
     visitRegistration.visitId
   );
   const proposalPayload = await getProposalMessageData(proposal);
+
+  const registrationAnswers: VisitRegistrationAnswerMessageData[] = [];
+  if (visitRegistration.registrationQuestionaryId !== null) {
+    const questionary = await questionaryDataSource.getQuestionary(
+      visitRegistration.registrationQuestionaryId
+    );
+    const template = questionary
+      ? await templateDataSource.getTemplate(questionary.templateId)
+      : null;
+
+    if (template?.groupId === TemplateGroupId.VISIT_REGISTRATION) {
+      const questionarySteps = await questionaryDataSource.getQuestionarySteps(
+        visitRegistration.registrationQuestionaryId
+      );
+
+      registrationAnswers.push(
+        ...questionarySteps.flatMap((step) =>
+          step.fields.map((field) => ({
+            questionNaturalKey: field.question.naturalKey,
+            value: field.value,
+          }))
+        )
+      );
+    }
+  }
 
   const visitJsonMessage = JSON.stringify({
     id: visitRegistration.id,
@@ -330,6 +368,7 @@ export const getVisitMessageData = async (
     endAt: visitRegistration.endsAt,
     visitorId: visitRegistration.userId.toString(),
     proposal: JSON.parse(proposalPayload),
+    registrationAnswers,
   });
 
   return visitJsonMessage;


### PR DESCRIPTION
Adds visit registration questionary answers to visit message payloads using question natural keys.

New payload format:
```
{
  "id": "visit-registration-id",
  "startAt": "2026-08-24T08:00:00.000Z",
  "endAt": "2026-08-24T16:00:00.000Z",
  "visitorId": "123",
  "proposal": {...},
  "registrationAnswers": [
    {
      "questionNaturalKey": "request_daily_allowance",
      "value": true
    },
    ...
  ]
}
```