### PR TITLE
feat: remove base64 encoded img tags from logs to prevent flood

### DIFF
--- a/apps/backend/src/eventHandlers/logging.ts
+++ b/apps/backend/src/eventHandlers/logging.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { logger } from '@user-office-software/duo-logger';
+import sanitizeHtml from 'sanitize-html';
 import { container } from 'tsyringe';
 
 import { Tokens } from '../config/Tokens';
@@ -35,7 +36,16 @@ export default function createLoggingHandler() {
 
   // Handler that logs every mutation wrapped with the event bus event to logger and event_logs table.
   return async function loggingHandler(event: ApplicationEvent) {
-    const json = JSON.stringify(event);
+    // remove base64 encoded img tags from event to prevent message flood in event_logs table and standard output
+    const json =
+      event.type == Event.TOPIC_ANSWERED
+        ? sanitizeHtml(JSON.stringify(event), {
+            allowedTags: sanitizeHtml.defaults.allowedTags.filter(
+              (tag: string) => tag !== 'img'
+            ),
+          })
+        : JSON.stringify(event);
+
     logger.logInfo('An event was triggered', { json });
 
     // NOTE: If the event is rejection than log that in the database as well. Later we will be able to see all errors that happened.


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Remove base64 encoded images from logs;

## Motivation and Context

Prevent flood of console output and event_logs table. 

## How Has This Been Tested

Manual tests. 

## Fixes

Sanitize html and remove img tags.

## Changes

See above. 

## Depends on

N/A


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
