### PR TITLE
Fix bug in 2 concurrent user editing proposal

### DIFF
--- a/apps/frontend/src/components/questionary/QuestionaryMergeView.tsx
+++ b/apps/frontend/src/components/questionary/QuestionaryMergeView.tsx
@@ -33,10 +33,20 @@ const QuestionaryMergeView: React.FC<QuestionaryMergeViewProps> = ({
   const allAnswers = oldAnswers.map((oldA) => {
     const current = newAnswers.find((a) => a.question.id === oldA.question.id);
 
+    // Need to set the ID of the current answer to one updated in the database so the backend can
+    // recognise it when rendering.
+    const currentAnswerForDisplay = current
+      ? {
+          ...current,
+          answerId: oldA.answerId,
+        }
+      : null;
+
     return {
       questionId: oldA.question.id,
       oldAnswer: oldA,
       currentAnswer: current ?? null,
+      currentAnswerForDisplay,
     };
   });
 
@@ -133,8 +143,10 @@ const QuestionaryMergeView: React.FC<QuestionaryMergeViewProps> = ({
                           Your current Answer
                         </Typography>
                         <Typography variant="body1">
-                          {question.currentAnswer?.value
-                            ? renderers.answerRenderer(question.currentAnswer)
+                          {question.currentAnswerForDisplay?.value
+                            ? renderers.answerRenderer(
+                                question.currentAnswerForDisplay
+                              )
                             : 'No answer'}
                         </Typography>
                         <FormControlLabel


### PR DESCRIPTION
There is a bug in this code where if you edit a instrument picker question when someone else edits it then the answerId gets miss-matched with the backend causing problems on render.

Specifically if you have personA and personB editing the same proposal where the answerId of a question is for example 100. When personA presses save, the backend deletes the entry with 100 in it, and saves a new answer with 101 as the answerId. Then when personB presses save they get a popup showing both answers but the renderer is passed two Ids, 101 and 100 for the new answer and old answer. as 100 no longer exists we get an error saying that it could't find the call from answer id 100. Because 100 no longer exists.

<img width="3099" height="864" alt="image" src="https://github.com/user-attachments/assets/f5ee0065-e917-4368-845e-0b673c7e05a4" />

<img width="1812" height="1662" alt="image" src="https://github.com/user-attachments/assets/d811d855-c45f-47b6-8639-5ede575d897f" />

