### PR TITLE
fix: remove redundant mapping

### DIFF
--- a/apps/backend/src/config/dependencyConfigESS.ts
+++ b/apps/backend/src/config/dependencyConfigESS.ts
@@ -128,8 +128,6 @@ mapClass(Tokens.DataAccessUsersAuthorization, DataAccessUsersAuthorization);
 
 mapClass(Tokens.AssetRegistrar, EAMAssetRegistrar);
 
-mapClass(Tokens.MailService, SparkPostMailService);
-
 if (isDevelopment) {
   mapValue(Tokens.MailService, new SMTPMailService());
 } else {


### PR DESCRIPTION
## Description
This pull request removes a redundant mapping in the dependency configuration.

## Motivation and Context
This mapping is redundant as right after it the conditional mapping occurs

## Changes
- Removed the mapping for the `SparkPostMailService` from the `dependencyConfigESS.ts` file, as it was superfluous.
- The SMTPMailService is now the default mail service, eliminating the need for the SparkPostMailService mapping. 

These changes improve the efficiency of the code and make it easier for other developers to understand the mailing service's configuration.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/SWAP-5725](https://jira.ess.eu//browse/SWAP-5725)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated