### PR TITLE
chore: add dependabot config for backend/frontend dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,21 @@ updates:
     versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 7
+
+  - package-ecosystem: 'docker'
+    directories:
+      - '/apps/backend'
+      - '/apps/frontend'
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'
+      time: '10:00'
+    open-pull-requests-limit: 1
+    pull-request-branch-name:
+      separator: '-'
+    allow:
+      - update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
+    cooldown:
+      default-days: 7

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -23,7 +23,7 @@ COPY apps/frontend/ /app/frontend
 RUN npm run build
 
 # Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
-FROM nginxinc/nginx-unprivileged:alpine3.23
+FROM nginxinc/nginx-unprivileged:1.31.5-alpine
 
 COPY --from=build-stage /app/frontend/build/ /usr/share/nginx/html
 COPY --from=build-stage /app/frontend/build-version.txt /usr/share/nginx/html


### PR DESCRIPTION
This also sets the nginx base image to a fixed version but removes the specific alpine constraint.

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->
Add dependabot config for frontend and backend Dockerfiles. The config broadly matches the existing in terms of schedule. Only minor/patch updates will be made otherwise e.g. it will attempt to update to the latest node major version.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Container base images are only updated manually at the moment.

## How Has This Been Tested

Some manual testing in a different repository.
