### PR TITLE
fix: add icon to rich text answer renderer

### DIFF
--- a/apps/frontend/src/components/questionary/questionaryComponents/RichTextInput/RichTextInputRenderer.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/RichTextInput/RichTextInputRenderer.tsx
@@ -1,4 +1,5 @@
-import { Typography } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { IconButton, Tooltip, Typography } from '@mui/material';
 import Button from '@mui/material/Button';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -29,7 +30,13 @@ export const RichTextInputRendererComponent = ({
 
   return (
     <span>
+      <Tooltip title="View full text">
+        <IconButton onClick={handleClickOpen}>
+          <VisibilityIcon />
+        </IconButton>
+      </Tooltip>
       <Typography
+        component="span"
         variant="body1"
         onClick={handleClickOpen}
         data-cy={`${id}_open`}

--- a/apps/frontend/src/components/questionary/questionaryComponents/RichTextInput/RichTextInputRenderer.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/RichTextInput/RichTextInputRenderer.tsx
@@ -31,7 +31,7 @@ export const RichTextInputRendererComponent = ({
   return (
     <span>
       <Tooltip title="View full text">
-        <IconButton onClick={handleClickOpen}>
+        <IconButton onClick={handleClickOpen} sx={{ 'padding-left': 0 }}>
           <VisibilityIcon />
         </IconButton>
       </Tooltip>


### PR DESCRIPTION
Closes: UserOfficeProject/issue-tracker#1577

## Description
This PR introduces a visibility icon to the rich text answer renderer. 

## Motivation and Context
The change was necessary to enhance the user experience by providing a more intuitive way to view full text answers.

## Changes
1. Imported the `VisibilityIcon` from `@mui/icons-material/Visibility`.
2. Wrapped the `VisibilityIcon` within a `Tooltip` and `IconButton` to provide an interactive and informative UI element.
3. Added the `VisibilityIcon` component to the `RichTextInputRendererComponent` rendering function.

Old:
<img width="2680" height="247" alt="image" src="https://github.com/user-attachments/assets/b6471cad-1ab0-41ee-af03-e0fec8b4f974" />

New:
<img width="2720" height="227" alt="image" src="https://github.com/user-attachments/assets/32eb77a3-6347-47d8-b2f4-890a32af12b6" />


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/](https://jira.ess.eu//browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated