### PR TITLE
feat: implement OAuth client management functionality

### DIFF
--- a/apps/backend/db_patches/0215_AddOAuthClients.sql
+++ b/apps/backend/db_patches/0215_AddOAuthClients.sql
@@ -1,0 +1,18 @@
+DO
+$$
+BEGIN
+	IF register_patch('AddOAuthClients.sql', 'jekabskarklins', 'OAuth clients registered in an external identity provider, with the endpoints each client is allowed to call', '2026-09-03') THEN
+	  BEGIN
+			CREATE TABLE IF NOT EXISTS oauth_clients (
+				client_id VARCHAR(255) PRIMARY KEY NOT NULL,
+				name VARCHAR(100) NOT NULL,
+				description VARCHAR(500),
+				access_permissions jsonb,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+				updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			);
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -18,6 +18,7 @@ import apolloServer from './src/middlewares/graphql';
 import healthCheck from './src/middlewares/healthCheck';
 import jwtErrorHandler from './src/middlewares/jwtErrorHandler';
 import metrics from './src/middlewares/metrics/metrics';
+import oauthClientAuthorization from './src/middlewares/oauthClientAuthorization';
 import readinessCheck from './src/middlewares/readinessCheck';
 
 async function bootstrap() {
@@ -27,6 +28,7 @@ async function bootstrap() {
   app.use(express.urlencoded({ extended: false }));
   app
     .use(metrics(app))
+    .use(oauthClientAuthorization())
     .use(authorization())
     .use(jwtErrorHandler)
     .use(files())

--- a/apps/backend/src/customTypes/index.d.ts
+++ b/apps/backend/src/customTypes/index.d.ts
@@ -1,3 +1,4 @@
+import { OAuthClient } from '../models/OAuthClient';
 import { AuthJwtPayload, AuthJwtApiTokenPayload } from '../models/User';
 
 type AuthJwtPayloadUnionType = AuthJwtPayload & AuthJwtApiTokenPayload;
@@ -5,6 +6,10 @@ type AuthJwtPayloadUnionType = AuthJwtPayload & AuthJwtApiTokenPayload;
 declare global {
   namespace Express {
     interface User extends AuthJwtPayloadUnionType {}
+
+    interface Request {
+      oauthClient?: OAuthClient;
+    }
   }
 }
 

--- a/apps/backend/src/datasources/AdminDataSource.ts
+++ b/apps/backend/src/datasources/AdminDataSource.ts
@@ -3,14 +3,17 @@ import { Country } from '../models/Country';
 import { Entry } from '../models/Entry';
 import { Feature, FeatureId } from '../models/Feature';
 import { Institution } from '../models/Institution';
+import { OAuthClient } from '../models/OAuthClient';
 import { Permissions } from '../models/Permissions';
 import { Settings, SettingsId } from '../models/Settings';
 import { BasicUserDetails } from '../models/User';
 import { CreateApiAccessTokenInput } from '../resolvers/mutations/CreateApiAccessTokenMutation';
+import { CreateOAuthClientInput } from '../resolvers/mutations/CreateOAuthClientMutation';
 import { MergeInstitutionsInput } from '../resolvers/mutations/MergeInstitutionsMutation';
 import { UpdateFeaturesInput } from '../resolvers/mutations/settings/UpdateFeaturesMutation';
 import { UpdateSettingsInput } from '../resolvers/mutations/settings/UpdateSettingMutation';
 import { UpdateApiAccessTokenInput } from '../resolvers/mutations/UpdateApiAccessTokenMutation';
+import { UpdateOAuthClientInput } from '../resolvers/mutations/UpdateOAuthClientMutation';
 import { InstitutionsFilter } from './../resolvers/queries/InstitutionsQuery';
 
 export interface AdminDataSource {
@@ -52,6 +55,11 @@ export interface AdminDataSource {
   getTokenAndPermissionsById(accessTokenId: string): Promise<Permissions>;
   getAllTokensAndPermissions(): Promise<Permissions[]>;
   deleteApiAccessToken(accessTokenId: string): Promise<boolean>;
+  createOAuthClient(args: CreateOAuthClientInput): Promise<OAuthClient>;
+  updateOAuthClient(args: UpdateOAuthClientInput): Promise<OAuthClient>;
+  deleteOAuthClient(clientId: string): Promise<boolean>;
+  getOAuthClient(clientId: string): Promise<OAuthClient | null>;
+  getAllOAuthClients(): Promise<OAuthClient[]>;
   waitForDBUpgrade(): Promise<void>;
   updateRole(
     role: string,

--- a/apps/backend/src/datasources/mockups/AdminDataSource.ts
+++ b/apps/backend/src/datasources/mockups/AdminDataSource.ts
@@ -3,13 +3,16 @@ import { Country } from '../../models/Country';
 import { Entry } from '../../models/Entry';
 import { Feature, FeatureId, FeatureUpdateAction } from '../../models/Feature';
 import { Institution } from '../../models/Institution';
+import { OAuthClient } from '../../models/OAuthClient';
 import { Permissions } from '../../models/Permissions';
 import { Settings, SettingsId } from '../../models/Settings';
 import { CreateApiAccessTokenInput } from '../../resolvers/mutations/CreateApiAccessTokenMutation';
+import { CreateOAuthClientInput } from '../../resolvers/mutations/CreateOAuthClientMutation';
 import { MergeInstitutionsInput } from '../../resolvers/mutations/MergeInstitutionsMutation';
 import { UpdateFeaturesInput } from '../../resolvers/mutations/settings/UpdateFeaturesMutation';
 import { UpdateSettingsInput } from '../../resolvers/mutations/settings/UpdateSettingMutation';
 import { UpdateApiAccessTokenInput } from '../../resolvers/mutations/UpdateApiAccessTokenMutation';
+import { UpdateOAuthClientInput } from '../../resolvers/mutations/UpdateOAuthClientMutation';
 import { AdminDataSource } from '../AdminDataSource';
 
 export const dummyInstitution = new Institution(1, 'ESS', 1);
@@ -22,6 +25,17 @@ export const dummyApiAccessToken = new Permissions(
 );
 
 export const dummyApiAccessTokens = [dummyApiAccessToken];
+
+export const dummyOAuthClient = new OAuthClient(
+  'nitis-integration-client',
+  'NITIS integration client',
+  'Machine client registered in the external identity provider',
+  '{"ProposalQueries.getAll": true}',
+  new Date('2026-09-03T00:00:00.000Z'),
+  new Date('2026-09-03T00:00:00.000Z')
+);
+
+export const dummyOAuthClients = [dummyOAuthClient];
 
 export const dummyFeature = new Feature(
   FeatureId.SHIPPING,
@@ -216,6 +230,45 @@ export class AdminDataSourceMock implements AdminDataSource {
 
   async deleteApiAccessToken(accessTokenId: string): Promise<boolean> {
     return true;
+  }
+
+  async createOAuthClient(args: CreateOAuthClientInput): Promise<OAuthClient> {
+    return new OAuthClient(
+      args.clientId,
+      args.name,
+      args.description,
+      args.accessPermissions,
+      new Date(),
+      new Date()
+    );
+  }
+
+  async updateOAuthClient(args: UpdateOAuthClientInput): Promise<OAuthClient> {
+    const oauthClient = dummyOAuthClients.find(
+      (client) => client.id === args.clientId
+    );
+
+    if (!oauthClient) {
+      throw new Error(`OAuth client with id ${args.clientId} not found`);
+    }
+
+    oauthClient.name = args.name;
+    oauthClient.description = args.description;
+    oauthClient.accessPermissions = args.accessPermissions;
+
+    return oauthClient;
+  }
+
+  async deleteOAuthClient(clientId: string): Promise<boolean> {
+    return true;
+  }
+
+  async getOAuthClient(clientId: string): Promise<OAuthClient | null> {
+    return dummyOAuthClients.find((client) => client.id === clientId) ?? null;
+  }
+
+  async getAllOAuthClients(): Promise<OAuthClient[]> {
+    return dummyOAuthClients;
   }
 
   async mergeInstitutions(

--- a/apps/backend/src/datasources/postgres/AdminDataSource.ts
+++ b/apps/backend/src/datasources/postgres/AdminDataSource.ts
@@ -10,14 +10,17 @@ import { Page } from '../../models/Admin';
 import { Country } from '../../models/Country';
 import { Feature, FeatureUpdateAction } from '../../models/Feature';
 import { Institution } from '../../models/Institution';
+import { OAuthClient } from '../../models/OAuthClient';
 import { Permissions } from '../../models/Permissions';
 import { Settings } from '../../models/Settings';
 import { BasicUserDetails } from '../../models/User';
 import { CreateApiAccessTokenInput } from '../../resolvers/mutations/CreateApiAccessTokenMutation';
+import { CreateOAuthClientInput } from '../../resolvers/mutations/CreateOAuthClientMutation';
 import { MergeInstitutionsInput } from '../../resolvers/mutations/MergeInstitutionsMutation';
 import { UpdateFeaturesInput } from '../../resolvers/mutations/settings/UpdateFeaturesMutation';
 import { UpdateSettingsInput } from '../../resolvers/mutations/settings/UpdateSettingMutation';
 import { UpdateApiAccessTokenInput } from '../../resolvers/mutations/UpdateApiAccessTokenMutation';
+import { UpdateOAuthClientInput } from '../../resolvers/mutations/UpdateOAuthClientMutation';
 import { AdminDataSource } from '../AdminDataSource';
 import { Entry } from './../../models/Entry';
 import { FeatureId } from './../../models/Feature';
@@ -30,10 +33,12 @@ import {
   createCountryObject,
   createFeatureObject,
   createInstitutionObject,
+  createOAuthClientObject,
   createPageObject,
   createSettingsObject,
   FeatureRecord,
   InstitutionRecord,
+  OAuthClientRecord,
   PageTextRecord,
   SettingsRecord,
   TokensAndPermissionsRecord,
@@ -590,6 +595,87 @@ export default class PostgresAdminDataSource implements AdminDataSource {
     }
 
     return true;
+  }
+
+  async createOAuthClient(args: CreateOAuthClientInput): Promise<OAuthClient> {
+    const [oauthClientRecord]: OAuthClientRecord[] = await database
+      .insert({
+        client_id: args.clientId,
+        name: args.name,
+        description: args.description,
+        access_permissions: args.accessPermissions,
+      })
+      .into('oauth_clients')
+      .returning('*');
+
+    if (!oauthClientRecord) {
+      throw new GraphQLError(
+        `Could not insert oauth client with client id: ${args.clientId}`
+      );
+    }
+
+    return createOAuthClientObject(oauthClientRecord);
+  }
+
+  async updateOAuthClient(args: UpdateOAuthClientInput): Promise<OAuthClient> {
+    const [oauthClientRecord]: OAuthClientRecord[] = await database(
+      'oauth_clients'
+    )
+      .update({
+        name: args.name,
+        description: args.description,
+        access_permissions: args.accessPermissions,
+        updated_at: database.fn.now(),
+      })
+      .where('client_id', args.clientId)
+      .returning('*');
+
+    if (!oauthClientRecord) {
+      throw new GraphQLError(
+        `Could not update oauth client with client id: ${args.clientId}`
+      );
+    }
+
+    return createOAuthClientObject(oauthClientRecord);
+  }
+
+  async deleteOAuthClient(clientId: string): Promise<boolean> {
+    const [oauthClientRecord]: OAuthClientRecord[] = await database(
+      'oauth_clients'
+    )
+      .del()
+      .where('client_id', clientId)
+      .returning('*');
+
+    if (!oauthClientRecord) {
+      throw new GraphQLError(
+        `Could not delete oauth client with client id: ${clientId}`
+      );
+    }
+
+    return true;
+  }
+
+  async getOAuthClient(clientId: string): Promise<OAuthClient | null> {
+    const [oauthClientRecord]: OAuthClientRecord[] = await database
+      .select()
+      .from('oauth_clients')
+      .where('client_id', clientId);
+
+    if (!oauthClientRecord) {
+      return null;
+    }
+
+    return createOAuthClientObject(oauthClientRecord);
+  }
+
+  async getAllOAuthClients(): Promise<OAuthClient[]> {
+    const oauthClientRecords: OAuthClientRecord[] = await database
+      .select()
+      .from('oauth_clients')
+      .orderBy('name', 'asc');
+
+    return oauthClientRecords.map(createOAuthClientObject);
   }
 
   async mergeInstitutions(

--- a/apps/backend/src/datasources/postgres/records.ts
+++ b/apps/backend/src/datasources/postgres/records.ts
@@ -26,6 +26,7 @@ import { GenericTemplate } from '../../models/GenericTemplate';
 import { Institution } from '../../models/Institution';
 import { Instrument } from '../../models/Instrument';
 import { Invite } from '../../models/Invite';
+import { OAuthClient } from '../../models/OAuthClient';
 import { PredefinedMessage } from '../../models/PredefinedMessage';
 import {
   InvitedProposal,
@@ -671,6 +672,15 @@ export interface TokensAndPermissionsRecord {
   readonly access_permissions: string;
 }
 
+export interface OAuthClientRecord {
+  readonly client_id: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly access_permissions: string | null;
+  readonly created_at: Date;
+  readonly updated_at: Date;
+}
+
 export interface VisitRecord {
   readonly visit_id: number;
   readonly proposal_pk: number;
@@ -1124,6 +1134,19 @@ export const createSettingsObject = (record: SettingsRecord) => {
     record.settings_id as SettingsId,
     record.settings_value,
     record.description
+  );
+};
+
+export const createOAuthClientObject = (record: OAuthClientRecord) => {
+  return new OAuthClient(
+    record.client_id,
+    record.name,
+    record.description,
+    record.access_permissions
+      ? JSON.stringify(record.access_permissions)
+      : null,
+    record.created_at,
+    record.updated_at
   );
 };
 

--- a/apps/backend/src/middlewares/authorization.ts
+++ b/apps/backend/src/middlewares/authorization.ts
@@ -1,14 +1,26 @@
+import { NextFunction, Request, Response } from 'express';
 import jwt from 'express-jwt';
 
 import { JwtAlg } from '../utils/jwt';
 
 const secret = process.env.JWT_SECRET as string;
 
-const authorization = () =>
-  jwt({
+const authorization = () => {
+  const jwtMiddleware = jwt({
     credentialsRequired: false,
     secret,
     algorithms: [JwtAlg],
   });
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    // The request was already authorized as an OAuth client of the external
+    // identity provider, whose token this middleware cannot verify.
+    if (req.oauthClient) {
+      return next();
+    }
+
+    return jwtMiddleware(req, res, next);
+  };
+};
 
 export default authorization;

--- a/apps/backend/src/middlewares/factory.ts
+++ b/apps/backend/src/middlewares/factory.ts
@@ -6,6 +6,7 @@ import { UserAuthorization } from '../auth/UserAuthorization';
 import baseContext from '../buildContext';
 import { Tokens } from '../config/Tokens';
 import { DownloadType } from '../factory/service';
+import { OAuthClient } from '../models/OAuthClient';
 import { AuthJwtPayload, UserWithRole } from '../models/User';
 import pdfDownload from './factory/pdf/download';
 import pdfPreview from './factory/pdf/preview';
@@ -48,7 +49,27 @@ const getUserWithRoleFromAccessTokenId = async (
     isApiAccessToken: true,
   } as UserWithRole;
 };
+const getUserWithRoleFromOAuthClient = (
+  oauthClient: OAuthClient
+): UserWithRole =>
+  ({
+    accessPermissions: oauthClient.accessPermissions
+      ? JSON.parse(oauthClient.accessPermissions)
+      : null,
+    isApiAccessToken: true,
+  }) as UserWithRole;
+
 const getLogContextFromRequest = (req: Request) => {
+  if (req?.oauthClient) {
+    return {
+      originalUrl: req.originalUrl,
+      user: {
+        clientId: req.oauthClient.id,
+        isApiAccessToken: true,
+      },
+    };
+  }
+
   if (req?.user) {
     const userReq = req.user?.accessTokenId
       ? {
@@ -132,6 +153,21 @@ export default function factory() {
   ) => {
     const accessTokenId = req.user?.accessTokenId;
     const decodedUser = req.user;
+
+    // A request authorized as an OAuth client of the external identity
+    // provider carries its permissions on the client rather than on a token.
+    if (req.oauthClient) {
+      const userWithRole = getUserWithRoleFromOAuthClient(req.oauthClient);
+
+      if (!userWithRole.accessPermissions) {
+        return res.status(401).send('INSUFFICIENT_PERMISSIONS');
+      }
+
+      res.locals.agent = userWithRole;
+
+      return next();
+    }
+
     if (decodedUser) {
       if (accessTokenId) {
         await getUserWithRoleFromAccessTokenId(accessTokenId)

--- a/apps/backend/src/middlewares/graphql.ts
+++ b/apps/backend/src/middlewares/graphql.ts
@@ -41,11 +41,19 @@ export const context: ContextFunction<
   let user = null;
   const userId = req.user?.user?.id as number;
   const accessTokenId = req.user?.accessTokenId;
+  const oauthClient = req.oauthClient;
   const userAuthorization = container.resolve<UserAuthorization>(
     Tokens.UserAuthorization
   );
 
-  if (req.user) {
+  if (oauthClient) {
+    user = {
+      accessPermissions: oauthClient.accessPermissions
+        ? JSON.parse(oauthClient.accessPermissions)
+        : null,
+      isApiAccessToken: true,
+    } as UserWithRole;
+  } else if (req.user) {
     if (accessTokenId) {
       const { accessPermissions } =
         await baseContext.queries.admin.getPermissionsByToken(accessTokenId);

--- a/apps/backend/src/middlewares/oauthClientAuthorization.spec.ts
+++ b/apps/backend/src/middlewares/oauthClientAuthorization.spec.ts
@@ -1,0 +1,180 @@
+const mockIntrospect = jest.fn();
+
+const mockOpenIdClient = {
+  hasConfig: jest.fn().mockReturnValue(true),
+  getInstance: jest.fn().mockResolvedValue({
+    introspect: mockIntrospect,
+  }),
+};
+
+jest.mock('@user-office-software/openid', () => {
+  return {
+    OpenIdClient: mockOpenIdClient,
+  };
+});
+
+const mockGetOAuthClientById = jest.fn();
+
+jest.mock('../buildContext', () => ({
+  __esModule: true,
+  default: {
+    queries: {
+      admin: {
+        getOAuthClientById: (clientId: string) =>
+          mockGetOAuthClientById(clientId),
+      },
+    },
+  },
+}));
+
+import 'reflect-metadata';
+import { NextFunction, Request, Response } from 'express';
+
+import oauthClientAuthorization from './oauthClientAuthorization';
+import { dummyOAuthClient } from '../datasources/mockups/AdminDataSource';
+import { signToken } from '../utils/jwt';
+
+const buildRequest = (authorization?: string) =>
+  ({ headers: authorization ? { authorization } : {} }) as Request;
+
+describe('oauthClientAuthorization', () => {
+  const response = {} as Response;
+  let next: NextFunction;
+
+  // An access token as an external identity provider would issue it: signed
+  // with something other than the User Office HS256 secret. Successful
+  // introspections are cached per token, so every test mints its own.
+  let tokenCounter = 0;
+  const externalTokenFor = (subject: string) =>
+    [
+      Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString(
+        'base64url'
+      ),
+      Buffer.from(
+        JSON.stringify({ sub: `${subject}-${++tokenCounter}` })
+      ).toString('base64url'),
+      'signature',
+    ].join('.');
+
+  let externalToken: string;
+
+  beforeEach(() => {
+    externalToken = externalTokenFor('a-client');
+    jest.clearAllMocks();
+    mockOpenIdClient.hasConfig.mockReturnValue(true);
+    next = jest.fn();
+  });
+
+  it('passes through when there is no OpenId configuration', async () => {
+    mockOpenIdClient.hasConfig.mockReturnValue(false);
+    const request = buildRequest(`Bearer ${externalToken}`);
+
+    await oauthClientAuthorization()(request, response, next);
+
+    expect(mockIntrospect).not.toHaveBeenCalled();
+    expect(request.oauthClient).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('passes through when there is no bearer token', async () => {
+    const request = buildRequest();
+
+    await oauthClientAuthorization()(request, response, next);
+
+    expect(mockIntrospect).not.toHaveBeenCalled();
+    expect(request.oauthClient).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not introspect tokens issued by User Office itself', async () => {
+    const userOfficeToken = signToken({ user: { id: 1 } });
+    const request = buildRequest(`Bearer ${userOfficeToken}`);
+
+    await oauthClientAuthorization()(request, response, next);
+
+    expect(mockIntrospect).not.toHaveBeenCalled();
+    expect(request.oauthClient).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('attaches the registered client for an active external token', async () => {
+    mockIntrospect.mockResolvedValue({
+      active: true,
+      client_id: dummyOAuthClient.id,
+    });
+    mockGetOAuthClientById.mockResolvedValue(dummyOAuthClient);
+    const request = buildRequest(`Bearer ${externalToken}`);
+
+    await oauthClientAuthorization()(request, response, next);
+
+    expect(mockIntrospect).toHaveBeenCalledWith(externalToken, 'access_token');
+    expect(mockGetOAuthClientById).toHaveBeenCalledWith(dummyOAuthClient.id);
+    expect(request.oauthClient).toEqual(dummyOAuthClient);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not attach a client when the token is not active', async () => {
+    mockIntrospect.mockResolvedValue({ active: false });
+    const request = buildRequest(`Bearer ${externalToken}`);
+
+    await oauthClientAuthorization()(request, response, next);
+
+    expect(mockGetOAuthClientById).not.toHaveBeenCalled();
+    expect(request.oauthClient).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not attach a client that is not registered in User Office', async () => {
+    mockIntrospect.mockResolvedValue({
+      active: true,
+      client_id: 'unregistered-client',
+    });
+    mockGetOAuthClientById.mockResolvedValue(null);
+    const request = buildRequest(`Bearer ${externalToken}`);
+
+    await oauthClientAuthorization()(request, response, next);
+
+    expect(request.oauthClient).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('passes through when introspection fails', async () => {
+    mockIntrospect.mockRejectedValue(new Error('introspection unavailable'));
+    const request = buildRequest(`Bearer ${externalToken}`);
+
+    await oauthClientAuthorization()(request, response, next);
+
+    expect(request.oauthClient).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('caches a successful introspection for repeated requests', async () => {
+    mockIntrospect.mockResolvedValue({
+      active: true,
+      client_id: dummyOAuthClient.id,
+    });
+    mockGetOAuthClientById.mockResolvedValue(dummyOAuthClient);
+    const middleware = oauthClientAuthorization();
+
+    await middleware(buildRequest(`Bearer ${externalToken}`), response, next);
+    await middleware(buildRequest(`Bearer ${externalToken}`), response, next);
+
+    expect(mockIntrospect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a token that has already expired', async () => {
+    const expiredToken = externalTokenFor('expiring-client');
+    mockIntrospect.mockResolvedValue({
+      active: true,
+      client_id: dummyOAuthClient.id,
+      exp: Math.floor(Date.now() / 1000) - 60,
+    });
+    mockGetOAuthClientById.mockResolvedValue(dummyOAuthClient);
+    const middleware = oauthClientAuthorization();
+
+    await middleware(buildRequest(`Bearer ${expiredToken}`), response, next);
+    await middleware(buildRequest(`Bearer ${expiredToken}`), response, next);
+
+    expect(mockIntrospect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/middlewares/oauthClientAuthorization.ts
+++ b/apps/backend/src/middlewares/oauthClientAuthorization.ts
@@ -1,0 +1,147 @@
+import { logger } from '@user-office-software/duo-logger';
+import { OpenIdClient } from '@user-office-software/openid';
+import { NextFunction, Request, Response } from 'express';
+import jsonwebtoken from 'jsonwebtoken';
+
+import baseContext from '../buildContext';
+import { JwtAlg } from '../utils/jwt';
+
+// Introspecting the identity provider on every single request would add a
+// network round trip to each call, so successful introspections are cached for
+// a short while. The entry never outlives the token it was created from.
+const INTROSPECTION_CACHE_TTL_MS = 60 * 1000;
+
+type CacheEntry = { clientId: string; expiresAt: number };
+
+const introspectionCache = new Map<string, CacheEntry>();
+
+const getCachedClientId = (token: string): string | null => {
+  const entry = introspectionCache.get(token);
+
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.expiresAt <= Date.now()) {
+    introspectionCache.delete(token);
+
+    return null;
+  }
+
+  return entry.clientId;
+};
+
+const cacheClientId = (token: string, clientId: string, exp?: number) => {
+  const tokenExpiresAt = exp ? exp * 1000 : Infinity;
+  const expiresAt = Math.min(
+    Date.now() + INTROSPECTION_CACHE_TTL_MS,
+    tokenExpiresAt
+  );
+
+  if (expiresAt > Date.now()) {
+    introspectionCache.set(token, { clientId, expiresAt });
+  }
+};
+
+const getBearerToken = (req: Request): string | null => {
+  const authorizationHeader = req.headers.authorization;
+
+  if (!authorizationHeader) {
+    return null;
+  }
+
+  const [scheme, credentials] = authorizationHeader.split(' ');
+
+  if (!/^Bearer$/i.test(scheme) || !credentials) {
+    return null;
+  }
+
+  return credentials;
+};
+
+/**
+ * User Office issues its own tokens as HS256 JWTs. Anything else that arrives
+ * as a bearer token is a candidate for being an access token issued by the
+ * external identity provider, and is worth introspecting.
+ */
+const isUserOfficeIssuedToken = (token: string): boolean => {
+  try {
+    const decoded = jsonwebtoken.decode(token, { complete: true });
+
+    return decoded?.header?.alg === JwtAlg;
+  } catch {
+    return false;
+  }
+};
+
+const resolveClientId = async (token: string): Promise<string | null> => {
+  const cachedClientId = getCachedClientId(token);
+
+  if (cachedClientId) {
+    return cachedClientId;
+  }
+
+  const client = await OpenIdClient.getInstance();
+  const introspection = await client.introspect(token, 'access_token');
+
+  if (!introspection.active || !introspection.client_id) {
+    return null;
+  }
+
+  cacheClientId(token, introspection.client_id, introspection.exp);
+
+  return introspection.client_id;
+};
+
+/**
+ * Resolves bearer tokens issued by the external identity provider to an OAuth
+ * client registered in User Office. When the token belongs to a registered
+ * client, the client is attached to the request and the regular JWT
+ * authorization middleware is skipped.
+ *
+ * Anything this middleware does not recognise is passed through untouched, so
+ * an unregistered or invalid token is still rejected further down the chain.
+ */
+const oauthClientAuthorization =
+  () => async (req: Request, res: Response, next: NextFunction) => {
+    if (!OpenIdClient.hasConfig()) {
+      return next();
+    }
+
+    const token = getBearerToken(req);
+
+    if (!token || isUserOfficeIssuedToken(token)) {
+      return next();
+    }
+
+    try {
+      const clientId = await resolveClientId(token);
+
+      if (!clientId) {
+        return next();
+      }
+
+      const oauthClient =
+        await baseContext.queries.admin.getOAuthClientById(clientId);
+
+      if (!oauthClient) {
+        logger.logWarn('Access token presented by an unregistered client', {
+          clientId,
+        });
+
+        return next();
+      }
+
+      req.oauthClient = oauthClient;
+
+      return next();
+    } catch (error) {
+      logger.logWarn('Could not resolve the access token to an OAuth client', {
+        message: (error as Error)?.message,
+      });
+
+      return next();
+    }
+  };
+
+export default oauthClientAuthorization;

--- a/apps/backend/src/models/OAuthClient.ts
+++ b/apps/backend/src/models/OAuthClient.ts
@@ -1,0 +1,11 @@
+export class OAuthClient {
+  constructor(
+    /** The client id as it is registered in the external identity provider */
+    public id: string,
+    public name: string,
+    public description: string | null,
+    public accessPermissions: string | null,
+    public createdAt: Date,
+    public updatedAt: Date
+  ) {}
+}

--- a/apps/backend/src/mutations/AdminMutations.ts
+++ b/apps/backend/src/mutations/AdminMutations.ts
@@ -3,6 +3,8 @@ import {
   setPageTextValidationSchema,
   createApiAccessTokenValidationSchema,
   updateApiAccessTokenValidationSchema,
+  createOAuthClientValidationSchema,
+  updateOAuthClientValidationSchema,
 } from '@user-office-software/duo-validation';
 import { container, inject, injectable } from 'tsyringe';
 
@@ -17,12 +19,15 @@ import { Roles } from '../models/Role';
 import { Settings } from '../models/Settings';
 import { UserWithRole } from '../models/User';
 import { CreateApiAccessTokenInput } from '../resolvers/mutations/CreateApiAccessTokenMutation';
+import { CreateOAuthClientInput } from '../resolvers/mutations/CreateOAuthClientMutation';
 import { DeleteApiAccessTokenInput } from '../resolvers/mutations/DeleteApiAccessTokenMutation';
+import { DeleteOAuthClientInput } from '../resolvers/mutations/DeleteOAuthClientMutation';
 import { MergeInstitutionsInput } from '../resolvers/mutations/MergeInstitutionsMutation';
 import { UpdateFeaturesInput } from '../resolvers/mutations/settings/UpdateFeaturesMutation';
 import { UpdateSettingsInput } from '../resolvers/mutations/settings/UpdateSettingMutation';
 import { UpdateApiAccessTokenInput } from '../resolvers/mutations/UpdateApiAccessTokenMutation';
 import { UpdateInstitutionsArgs } from '../resolvers/mutations/UpdateInstitutionsMutation';
+import { UpdateOAuthClientInput } from '../resolvers/mutations/UpdateOAuthClientMutation';
 import { generateUniqueId, isProduction } from '../utils/helperFunctions';
 import { signToken } from '../utils/jwt';
 import { ApolloServerErrorCodeExtended } from '../utils/utilTypes';
@@ -180,6 +185,54 @@ export default class AdminMutations {
         { agent, args },
         error
       );
+    }
+  }
+
+  @ValidateArgs(createOAuthClientValidationSchema(IS_BACKEND_VALIDATION))
+  @Authorized([Roles.USER_OFFICER])
+  async createOAuthClient(
+    agent: UserWithRole | null,
+    args: CreateOAuthClientInput
+  ) {
+    try {
+      const accessPermissions = JSON.parse(args.accessPermissions);
+
+      return await this.dataSource.createOAuthClient({
+        ...args,
+        accessPermissions,
+      });
+    } catch (error) {
+      return rejection('Could not create oauth client', { agent, args }, error);
+    }
+  }
+
+  @ValidateArgs(updateOAuthClientValidationSchema(IS_BACKEND_VALIDATION))
+  @Authorized([Roles.USER_OFFICER])
+  async updateOAuthClient(
+    agent: UserWithRole | null,
+    args: UpdateOAuthClientInput
+  ) {
+    try {
+      const accessPermissions = JSON.parse(args.accessPermissions);
+
+      return await this.dataSource.updateOAuthClient({
+        ...args,
+        accessPermissions,
+      });
+    } catch (error) {
+      return rejection('Could not update oauth client', { agent, args }, error);
+    }
+  }
+
+  @Authorized([Roles.USER_OFFICER])
+  async deleteOAuthClient(
+    agent: UserWithRole | null,
+    args: DeleteOAuthClientInput
+  ) {
+    try {
+      return await this.dataSource.deleteOAuthClient(args.clientId);
+    } catch (error) {
+      return rejection('Could not remove oauth client', { agent, args }, error);
     }
   }
 

--- a/apps/backend/src/queries/AdminQueries.ts
+++ b/apps/backend/src/queries/AdminQueries.ts
@@ -61,6 +61,15 @@ export default class AdminQueries {
     return await this.dataSource.getAllTokensAndPermissions();
   }
 
+  async getOAuthClientById(clientId: string) {
+    return await this.dataSource.getOAuthClient(clientId);
+  }
+
+  @Authorized([Roles.USER_OFFICER])
+  async getAllOAuthClients(agent: UserWithRole | null) {
+    return await this.dataSource.getAllOAuthClients();
+  }
+
   @Authorized([Roles.USER_OFFICER])
   async getAllQueryMutationAndServicesMethods(
     agent: UserWithRole | null,

--- a/apps/backend/src/resolvers/mutations/CreateOAuthClientMutation.ts
+++ b/apps/backend/src/resolvers/mutations/CreateOAuthClientMutation.ts
@@ -1,0 +1,34 @@
+import { Arg, Ctx, Field, InputType, Mutation, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { OAuthClient } from '../types/OAuthClient';
+
+@InputType()
+export class CreateOAuthClientInput {
+  @Field(() => String)
+  public clientId: string;
+
+  @Field(() => String)
+  public name: string;
+
+  @Field(() => String, { nullable: true })
+  public description: string | null;
+
+  @Field(() => String)
+  public accessPermissions: string;
+}
+
+@Resolver()
+export class CreateOAuthClientMutation {
+  @Mutation(() => OAuthClient)
+  createOAuthClient(
+    @Arg('createOAuthClientInput')
+    createOAuthClientInput: CreateOAuthClientInput,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.mutations.admin.createOAuthClient(
+      context.user,
+      createOAuthClientInput
+    );
+  }
+}

--- a/apps/backend/src/resolvers/mutations/DeleteOAuthClientMutation.ts
+++ b/apps/backend/src/resolvers/mutations/DeleteOAuthClientMutation.ts
@@ -1,0 +1,24 @@
+import { Arg, Ctx, Field, InputType, Mutation, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+
+@InputType()
+export class DeleteOAuthClientInput {
+  @Field(() => String)
+  public clientId: string;
+}
+
+@Resolver()
+export class DeleteOAuthClientMutation {
+  @Mutation(() => Boolean)
+  deleteOAuthClient(
+    @Arg('deleteOAuthClientInput')
+    deleteOAuthClientInput: DeleteOAuthClientInput,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.mutations.admin.deleteOAuthClient(
+      context.user,
+      deleteOAuthClientInput
+    );
+  }
+}

--- a/apps/backend/src/resolvers/mutations/UpdateOAuthClientMutation.ts
+++ b/apps/backend/src/resolvers/mutations/UpdateOAuthClientMutation.ts
@@ -1,0 +1,34 @@
+import { Arg, Ctx, Field, InputType, Mutation, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { OAuthClient } from '../types/OAuthClient';
+
+@InputType()
+export class UpdateOAuthClientInput {
+  @Field(() => String)
+  public clientId: string;
+
+  @Field(() => String)
+  public name: string;
+
+  @Field(() => String, { nullable: true })
+  public description: string | null;
+
+  @Field(() => String)
+  public accessPermissions: string;
+}
+
+@Resolver()
+export class UpdateOAuthClientMutation {
+  @Mutation(() => OAuthClient)
+  updateOAuthClient(
+    @Arg('updateOAuthClientInput')
+    updateOAuthClientInput: UpdateOAuthClientInput,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.mutations.admin.updateOAuthClient(
+      context.user,
+      updateOAuthClientInput
+    );
+  }
+}

--- a/apps/backend/src/resolvers/queries/GetAllOAuthClientsQuery.ts
+++ b/apps/backend/src/resolvers/queries/GetAllOAuthClientsQuery.ts
@@ -1,0 +1,12 @@
+import { Ctx, Query, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { OAuthClient } from '../types/OAuthClient';
+
+@Resolver()
+export class GetAllOAuthClientsQuery {
+  @Query(() => [OAuthClient], { nullable: true })
+  allOAuthClients(@Ctx() context: ResolverContext) {
+    return context.queries.admin.getAllOAuthClients(context.user);
+  }
+}

--- a/apps/backend/src/resolvers/types/OAuthClient.ts
+++ b/apps/backend/src/resolvers/types/OAuthClient.ts
@@ -1,0 +1,24 @@
+import { ObjectType, Field } from 'type-graphql';
+
+import { OAuthClient as OAuthClientOrigin } from '../../models/OAuthClient';
+
+@ObjectType()
+export class OAuthClient implements Partial<OAuthClientOrigin> {
+  @Field()
+  public id: string;
+
+  @Field()
+  public name: string;
+
+  @Field(() => String, { nullable: true })
+  public description: string | null;
+
+  @Field(() => String, { nullable: true })
+  public accessPermissions: string | null;
+
+  @Field()
+  public createdAt: Date;
+
+  @Field()
+  public updatedAt: Date;
+}

--- a/apps/frontend/src/components/AppRoutes.tsx
+++ b/apps/frontend/src/components/AppRoutes.tsx
@@ -51,6 +51,9 @@ const ExperimentSafetyReviewPage = lazy(
 const ApiAccessTokensPage = lazy(
   () => import('./settings/apiAccessTokens/ApiAccessTokensPage')
 );
+const OAuthClientsPage = lazy(
+  () => import('./settings/oauthClients/OAuthClientsPage')
+);
 const AppSettingsPage = lazy(
   () => import('./settings/appSettings/AppSettingsPage')
 );
@@ -610,6 +613,17 @@ const AppRoutes = () => {
               }
             />
           )}
+        {isUserOfficer && (
+          <Route
+            path="/OAuthClients"
+            element={
+              <TitledRoute
+                title="OAuth Clients"
+                element={<OAuthClientsPage />}
+              />
+            }
+          />
+        )}
         {isUserOfficer && (
           <Route
             path="/ApiAccessTokens"

--- a/apps/frontend/src/components/menu/SettingsMenuListItem.tsx
+++ b/apps/frontend/src/components/menu/SettingsMenuListItem.tsx
@@ -8,6 +8,7 @@ import Settings from '@mui/icons-material/Settings';
 import SettingsApplications from '@mui/icons-material/SettingsApplications';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import VpnKey from '@mui/icons-material/VpnKey';
+import VpnLock from '@mui/icons-material/VpnLock';
 import { ListItemButton } from '@mui/material';
 import Collapse from '@mui/material/Collapse';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -26,6 +27,7 @@ const menuMap = {
   ProposalStatuses: '/ProposalStatuses',
   ExperimentWorkflows: '/ExperimentWorkflows',
   ApiAccessTokens: '/ApiAccessTokens',
+  OAuthClients: '/OAuthClients',
   Features: '/Features',
   Settings: '/Settings',
   RoleManagement: '/admin/roles',
@@ -126,6 +128,14 @@ const SettingsMenuListItem = () => {
               <VpnKey />
             </ListItemIcon>
             <ListItemText primary="API access tokens" />
+          </ListItemButton>
+        </Tooltip>
+        <Tooltip title="OAuth clients">
+          <ListItemButton component={NavLink} to={menuMap['OAuthClients']}>
+            <ListItemIcon>
+              <VpnLock />
+            </ListItemIcon>
+            <ListItemText primary="OAuth clients" />
           </ListItemButton>
         </Tooltip>
         <Tooltip title="Role management">

--- a/apps/frontend/src/components/settings/oauthClients/CreateUpdateOAuthClient.tsx
+++ b/apps/frontend/src/components/settings/oauthClients/CreateUpdateOAuthClient.tsx
@@ -1,0 +1,334 @@
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import FormLabel from '@mui/material/FormLabel';
+import Grid from '@mui/material/Grid';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import {
+  createOAuthClientValidationSchema,
+  updateOAuthClientValidationSchema,
+} from '@user-office-software/duo-validation/lib/Admin';
+import { Field, FieldArray, FieldArrayRenderProps, Form, Formik } from 'formik';
+import React from 'react';
+
+import ErrorMessage from 'components/common/ErrorMessage';
+import TextField from 'components/common/FormikUITextField';
+import SimpleTabs from 'components/common/SimpleTabs';
+import UOLoader from 'components/common/UOLoader';
+import { OAuthClient, QueryMutationAndServicesGroup } from 'generated/sdk';
+import { useQueriesMutationsAndServicesData } from 'hooks/admin/useQueriesMutationsAndServicesData';
+import { StyledPaper } from 'styles/StyledComponents';
+import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
+
+type FormOAuthClient = {
+  clientId: string;
+  name: string;
+  description: string;
+  accessPermissions: string[];
+};
+
+type CreateUpdateOAuthClientProps = {
+  close: (oauthClientAdded: OAuthClient | null) => void;
+  oauthClient: OAuthClient | null;
+};
+
+const CreateUpdateOAuthClient = ({
+  close,
+  oauthClient,
+}: CreateUpdateOAuthClientProps) => {
+  const { api, isExecutingCall } = useDataApiWithFeedback();
+  const { queriesMutationsAndServices, loadingQueriesMutationsAndServices } =
+    useQueriesMutationsAndServicesData();
+
+  const normalizeAccessPermissions = (data: string | null | undefined) => {
+    const permissionsArray: string[] = [];
+
+    if (data) {
+      const parsedPermissions = JSON.parse(data);
+
+      Object.keys(parsedPermissions).forEach((key) => {
+        permissionsArray.push(key);
+      });
+    }
+
+    return permissionsArray;
+  };
+
+  const initialValues: FormOAuthClient = oauthClient
+    ? {
+        clientId: oauthClient.id,
+        name: oauthClient.name,
+        description: oauthClient.description ?? '',
+        accessPermissions: normalizeAccessPermissions(
+          oauthClient.accessPermissions
+        ),
+      }
+    : {
+        clientId: '',
+        name: '',
+        description: '',
+        accessPermissions: [],
+      };
+
+  const allAccessPermissions = (
+    groups: QueryMutationAndServicesGroup[],
+    title: string,
+    formValues: FormOAuthClient,
+    fieldArrayHelpers: FieldArrayRenderProps
+  ) => (
+    <>
+      {groups.map((group, index) => {
+        const allSelected = group.items.every((item) =>
+          formValues.accessPermissions.includes(item)
+        );
+
+        return (
+          <FormControl
+            component="fieldset"
+            variant="standard"
+            key={index}
+            sx={(theme) => ({
+              border: `1px solid ${theme.palette.grey[200]}`,
+              padding: theme.spacing(0, 1),
+              width: '100%',
+
+              '& legend': {
+                textTransform: 'capitalize',
+              },
+            })}
+          >
+            <FormLabel component="legend">
+              {group.groupName} {title} (
+              <Link
+                component="button"
+                type="button"
+                onClick={() => {
+                  if (allSelected) {
+                    const indicesToRemove = group.items
+                      .map((item) => formValues.accessPermissions.indexOf(item))
+                      .filter((index) => index !== -1)
+                      .sort((a, b) => b - a); //sort in descending order to avoid index shifting
+                    indicesToRemove.forEach((index) =>
+                      fieldArrayHelpers.remove(index)
+                    );
+                  } else {
+                    group.items.forEach((item) => {
+                      if (!formValues.accessPermissions.includes(item)) {
+                        fieldArrayHelpers.push(item);
+                      }
+                    });
+                  }
+                }}
+              >
+                {allSelected ? 'Unselect all' : 'Select all'}
+              </Link>
+              )
+            </FormLabel>
+            <FormGroup>
+              <Grid container spacing={1}>
+                {group.items.map((item, index) => (
+                  <Grid
+                    item
+                    md={6}
+                    xs={12}
+                    key={index}
+                    sx={{
+                      '& label': {
+                        width: '100%',
+
+                        '& .MuiFormControlLabel-label': {
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        },
+                      },
+                    }}
+                  >
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          id={item}
+                          name="accessPermissions"
+                          value={item}
+                          checked={formValues.accessPermissions.includes(item)}
+                          data-cy={`permission-${title.toLowerCase()}`}
+                          onChange={(e) => {
+                            if (e.target.checked) {
+                              fieldArrayHelpers.push(item);
+                            } else {
+                              const idx =
+                                formValues.accessPermissions.indexOf(item);
+                              fieldArrayHelpers.remove(idx);
+                            }
+                          }}
+                          inputProps={{
+                            'aria-label': 'primary checkbox',
+                          }}
+                        />
+                      }
+                      label={item}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            </FormGroup>
+          </FormControl>
+        );
+      })}
+    </>
+  );
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={async (values): Promise<void> => {
+        const accessPermissions: { [key: string]: boolean } = {};
+
+        values.accessPermissions.forEach((element) => {
+          if (element) {
+            accessPermissions[element] = true;
+          }
+        });
+
+        if (oauthClient) {
+          try {
+            const { updateOAuthClient } = await api({
+              toastSuccessMessage: 'OAuth client updated successfully!',
+            }).updateOAuthClient({
+              clientId: oauthClient.id,
+              name: values.name,
+              description: values.description,
+              accessPermissions: JSON.stringify(accessPermissions),
+            });
+
+            close(updateOAuthClient);
+          } catch {
+            close(null);
+          }
+        } else {
+          try {
+            const { createOAuthClient } = await api({
+              toastSuccessMessage: 'OAuth client created successfully!',
+            }).createOAuthClient({
+              clientId: values.clientId,
+              name: values.name,
+              description: values.description,
+              accessPermissions: JSON.stringify(accessPermissions),
+            });
+
+            close(createOAuthClient);
+          } catch {
+            close(null);
+          }
+        }
+      }}
+      validationSchema={
+        oauthClient
+          ? updateOAuthClientValidationSchema
+          : createOAuthClientValidationSchema
+      }
+    >
+      {({ isSubmitting, values }) => (
+        <Form>
+          <Typography variant="h6" component="h1">
+            {oauthClient ? 'Update' : 'Create new'} OAuth client
+          </Typography>
+          <Field
+            name="clientId"
+            id="clientId"
+            label="Client ID"
+            type="text"
+            component={TextField}
+            fullWidth
+            data-cy="clientId"
+            helperText="The client id as it is registered in the identity provider"
+            disabled={isExecutingCall || !!oauthClient}
+            required
+          />
+          <Field
+            name="name"
+            id="name"
+            label="Name"
+            type="text"
+            component={TextField}
+            fullWidth
+            data-cy="name"
+            disabled={isExecutingCall}
+            required
+          />
+          <Field
+            name="description"
+            id="description"
+            label="Description"
+            type="text"
+            component={TextField}
+            fullWidth
+            multiline
+            data-cy="description"
+            disabled={isExecutingCall}
+          />
+
+          {loadingQueriesMutationsAndServices ? (
+            <UOLoader style={{ marginLeft: '50%', marginTop: '100px' }} />
+          ) : (
+            <FieldArray
+              name="accessPermissions"
+              render={(arrayHelpers) => (
+                <StyledPaper margin={[0]} padding={[0]}>
+                  <SimpleTabs tabNames={['Queries', 'Mutations', 'Services']}>
+                    {allAccessPermissions(
+                      queriesMutationsAndServices.queries,
+                      'Queries',
+                      values,
+                      arrayHelpers
+                    )}
+                    {allAccessPermissions(
+                      queriesMutationsAndServices.mutations,
+                      'Mutations',
+                      values,
+                      arrayHelpers
+                    )}
+                    {allAccessPermissions(
+                      queriesMutationsAndServices.services,
+                      'Services',
+                      values,
+                      arrayHelpers
+                    )}
+                  </SimpleTabs>
+                </StyledPaper>
+              )}
+            />
+          )}
+
+          <Grid
+            container
+            justifyContent="flex-end"
+            sx={(theme) => ({ margin: theme.spacing(2, 0, 2) })}
+          >
+            <Grid item>
+              <ErrorMessage name="accessPermissions" />
+
+              <Button
+                type="submit"
+                disabled={
+                  isSubmitting ||
+                  loadingQueriesMutationsAndServices ||
+                  isExecutingCall
+                }
+                data-cy="submit"
+              >
+                {isExecutingCall && <UOLoader size={14} />}
+                {oauthClient ? 'Update' : 'Create'}
+              </Button>
+            </Grid>
+          </Grid>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default CreateUpdateOAuthClient;

--- a/apps/frontend/src/components/settings/oauthClients/OAuthClientsPage.tsx
+++ b/apps/frontend/src/components/settings/oauthClients/OAuthClientsPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { StyledContainer, StyledPaper } from 'styles/StyledComponents';
+
+import OAuthClientsTable from './OAuthClientsTable';
+
+const OAuthClientsPage = () => {
+  return (
+    <StyledContainer maxWidth={false}>
+      <StyledPaper>
+        <OAuthClientsTable />
+      </StyledPaper>
+    </StyledContainer>
+  );
+};
+
+export default OAuthClientsPage;

--- a/apps/frontend/src/components/settings/oauthClients/OAuthClientsTable.tsx
+++ b/apps/frontend/src/components/settings/oauthClients/OAuthClientsTable.tsx
@@ -1,0 +1,87 @@
+import { Typography } from '@mui/material';
+import React from 'react';
+
+import SuperMaterialTable from 'components/common/SuperMaterialTable';
+import { OAuthClient, UserRole } from 'generated/sdk';
+import { useOAuthClientsData } from 'hooks/admin/useOAuthClientsData';
+import { useCheckAccess } from 'hooks/common/useCheckAccess';
+import { tableIcons } from 'utils/materialIcons';
+import useDataApiWithFeedback from 'utils/useDataApiWithFeedback';
+import { FunctionType } from 'utils/utilTypes';
+
+import CreateUpdateOAuthClient from './CreateUpdateOAuthClient';
+
+const columns = [
+  { title: 'Name', field: 'name' },
+  { title: 'Client ID', field: 'clientId' },
+  { title: 'Description', field: 'description' },
+];
+
+const OAuthClientsTable = () => {
+  const { api } = useDataApiWithFeedback();
+  const {
+    loadingOAuthClients,
+    oauthClients,
+    setOAuthClientsWithLoading: setOAuthClients,
+  } = useOAuthClientsData();
+  const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
+
+  const createModal = (
+    onUpdate: FunctionType<void, [OAuthClient | null]>,
+    onCreate: FunctionType<void, [OAuthClient | null]>,
+    editOAuthClient: OAuthClient | null
+  ) => (
+    <CreateUpdateOAuthClient
+      oauthClient={editOAuthClient}
+      close={(oauthClient: OAuthClient | null) =>
+        !!editOAuthClient ? onUpdate(oauthClient) : onCreate(oauthClient)
+      }
+    />
+  );
+
+  const deleteOAuthClient = async (id: string | number) => {
+    try {
+      await api({
+        toastSuccessMessage: 'OAuth client deleted successfully',
+      }).deleteOAuthClient({
+        clientId: id as string,
+      });
+
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  return (
+    <div data-cy="oauth-clients-table">
+      <SuperMaterialTable
+        delete={deleteOAuthClient}
+        createModal={createModal}
+        createModalSize="lg"
+        hasAccess={{
+          update: isUserOfficer,
+          create: isUserOfficer,
+          remove: isUserOfficer,
+        }}
+        setData={setOAuthClients}
+        icons={tableIcons}
+        title={
+          <Typography variant="h6" component="h2">
+            OAuth Clients
+          </Typography>
+        }
+        columns={columns}
+        data={oauthClients}
+        isLoading={loadingOAuthClients}
+        options={{
+          search: true,
+          debounceInterval: 400,
+        }}
+        persistUrlQueryParams={true}
+      />
+    </div>
+  );
+};
+
+export default OAuthClientsTable;

--- a/apps/frontend/src/graphql/admin/createOAuthClient.graphql
+++ b/apps/frontend/src/graphql/admin/createOAuthClient.graphql
@@ -1,0 +1,22 @@
+mutation createOAuthClient(
+  $clientId: String!
+  $name: String!
+  $description: String
+  $accessPermissions: String!
+) {
+  createOAuthClient(
+    createOAuthClientInput: {
+      clientId: $clientId
+      name: $name
+      description: $description
+      accessPermissions: $accessPermissions
+    }
+  ) {
+    id
+    name
+    description
+    accessPermissions
+    createdAt
+    updatedAt
+  }
+}

--- a/apps/frontend/src/graphql/admin/deleteOAuthClient.graphql
+++ b/apps/frontend/src/graphql/admin/deleteOAuthClient.graphql
@@ -1,0 +1,3 @@
+mutation deleteOAuthClient($clientId: String!) {
+  deleteOAuthClient(deleteOAuthClientInput: { clientId: $clientId })
+}

--- a/apps/frontend/src/graphql/admin/getAllOAuthClients.graphql
+++ b/apps/frontend/src/graphql/admin/getAllOAuthClients.graphql
@@ -1,0 +1,10 @@
+query getAllOAuthClients {
+  allOAuthClients {
+    id
+    name
+    description
+    accessPermissions
+    createdAt
+    updatedAt
+  }
+}

--- a/apps/frontend/src/graphql/admin/updateOAuthClient.graphql
+++ b/apps/frontend/src/graphql/admin/updateOAuthClient.graphql
@@ -1,0 +1,22 @@
+mutation updateOAuthClient(
+  $clientId: String!
+  $name: String!
+  $description: String
+  $accessPermissions: String!
+) {
+  updateOAuthClient(
+    updateOAuthClientInput: {
+      clientId: $clientId
+      name: $name
+      description: $description
+      accessPermissions: $accessPermissions
+    }
+  ) {
+    id
+    name
+    description
+    accessPermissions
+    createdAt
+    updatedAt
+  }
+}

--- a/apps/frontend/src/hooks/admin/useOAuthClientsData.ts
+++ b/apps/frontend/src/hooks/admin/useOAuthClientsData.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState, SetStateAction, Dispatch } from 'react';
+
+import { OAuthClient } from 'generated/sdk';
+import { useDataApi } from 'hooks/common/useDataApi';
+
+export function useOAuthClientsData(): {
+  loadingOAuthClients: boolean;
+  oauthClients: OAuthClient[];
+  setOAuthClientsWithLoading: Dispatch<SetStateAction<OAuthClient[]>>;
+} {
+  const [oauthClients, setOAuthClients] = useState<OAuthClient[]>([]);
+  const [loadingOAuthClients, setLoadingOAuthClients] = useState(true);
+
+  const api = useDataApi();
+
+  const setOAuthClientsWithLoading = (data: SetStateAction<OAuthClient[]>) => {
+    setLoadingOAuthClients(true);
+    setOAuthClients(data);
+    setLoadingOAuthClients(false);
+  };
+
+  useEffect(() => {
+    let unmounted = false;
+
+    setLoadingOAuthClients(true);
+    api()
+      .getAllOAuthClients()
+      .then((data) => {
+        if (unmounted) {
+          return;
+        }
+
+        if (data.allOAuthClients) {
+          setOAuthClients(data.allOAuthClients as OAuthClient[]);
+        }
+        setLoadingOAuthClients(false);
+      });
+
+    return () => {
+      // used to avoid unmounted component state update error
+      unmounted = true;
+    };
+  }, [api]);
+
+  return {
+    loadingOAuthClients,
+    oauthClients,
+    setOAuthClientsWithLoading,
+  };
+}

--- a/validation/src/Admin/index.ts
+++ b/validation/src/Admin/index.ts
@@ -56,3 +56,49 @@ export const updateApiAccessTokenValidationSchema = (
             'You must select at least one query or mutation for access'
           ),
   });
+
+export const createOAuthClientValidationSchema = (
+  isBackendValidation: boolean
+) =>
+  Yup.object().shape({
+    clientId: Yup.string()
+      .required('Client id is required')
+      .max(255, 'Client id must be at most 255 characters'),
+    name: Yup.string()
+      .required('Name is required')
+      .max(100, 'Name must be at most 100 characters'),
+    description: Yup.string()
+      .nullable()
+      .max(500, 'Description must be at most 500 characters'),
+    accessPermissions: isBackendValidation
+      ? Yup.string()
+          .required('You must select at least one query or mutation for access')
+          .test('Is valid object', 'Requires valid JSON', checkValidJson)
+      : Yup.array()
+          .of(Yup.string())
+          .required(
+            'You must select at least one query or mutation for access'
+          ),
+  });
+
+export const updateOAuthClientValidationSchema = (
+  isBackendValidation: boolean
+) =>
+  Yup.object().shape({
+    clientId: Yup.string().required('Client id is required'),
+    name: Yup.string()
+      .required('Name is required')
+      .max(100, 'Name must be at most 100 characters'),
+    description: Yup.string()
+      .nullable()
+      .max(500, 'Description must be at most 500 characters'),
+    accessPermissions: isBackendValidation
+      ? Yup.string()
+          .required('You must select at least one query or mutation for access')
+          .test('Is valid object', 'Requires valid JSON', checkValidJson)
+      : Yup.array()
+          .of(Yup.string())
+          .required(
+            'You must select at least one query or mutation for access'
+          ),
+  });


### PR DESCRIPTION
## Description
This PR introduces OAuth client management functionality into the project.

## Motivation and Context
The need for this change is to allow the system to handle OAuth clients registered in an external identity provider and manage the endpoints each client is allowed to call. This will enhance security and control over access to different parts of the system.

## Changes
1. Added a new table `oauth_clients` to the database to store OAuth clients along with their access permissions.
2. Implemented middleware `oauthClientAuthorization` to handle OAuth client authorization in the system.
3. Created new methods in the `AdminDataSource` interface and its implementations to support creating, updating, deleting and retrieving OAuth clients.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/](https://jira.ess.eu//browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated