### PR TITLE
fix: cannot submit fap reviews as chair or sec

### DIFF
--- a/apps/frontend/src/components/review/ReviewSummary.tsx
+++ b/apps/frontend/src/components/review/ReviewSummary.tsx
@@ -35,7 +35,11 @@ function ReviewSummary({ confirm }: ReviewSummaryProps) {
 
   const { api } = useDataApiWithFeedback();
   const isUserOfficer = useCheckAccess([UserRole.USER_OFFICER]);
-  const isFapReviewer = useCheckAccess([UserRole.FAP_REVIEWER]);
+  const isFapReviewer = useCheckAccess([
+    UserRole.FAP_REVIEWER,
+    UserRole.FAP_CHAIR,
+    UserRole.FAP_SECRETARY,
+  ]);
   const { isInternalUser } = useContext(UserContext);
   const { user } = useContext(UserContext);
   const callHasEnded = isCallEnded(


### PR DESCRIPTION
Closes UserOfficeProject/issue-tracker#1573

## Description
This PR fixes the issue of FAP Chairs and Secretaries not being able to submit FAP reviews.

## Motivation and Context
The application restricted the submission of FAP reviews to FAP reviewers only. This change is necessary to allow FAP Chairs and Secretaries to perform this action, as required by their roles.

## Changes
- The access check now includes the `UserRole.FAP_CHAIR` and `UserRole.FAP_SECRETARY` roles, allowing users with these roles to submit FAP reviews.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/](https://jira.ess.eu//browse/)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated