### PR TITLE
feat: add clear warning to UO when changing instruments on data loss

### DIFF
--- a/apps/frontend/src/components/instrument/AssignProposalsToInstruments.tsx
+++ b/apps/frontend/src/components/instrument/AssignProposalsToInstruments.tsx
@@ -89,6 +89,10 @@ const AssignProposalsToInstruments = ({
                 />
               </Grid>
             </Grid>
+            <Alert severity="error" data-cy="remove-instrument-alert">
+              {`Removing instruments from proposals with technical reviews will permanently delete those reviews. `}
+              <strong>{`This action is irreversible.`}</strong>
+            </Alert>
             {!values.selectedInstrumentIds.length && (
               <Alert severity="warning" data-cy="remove-instrument-alert">
                 {`Be aware that leaving ${i18n.format(


### PR DESCRIPTION
When you remove instruments from a proposal with the technical reviews already filled out, UOP will delete that data. There is currently no warning that this is about to happen. This adds that warning.

<img width="1300" height="850" alt="image" src="https://github.com/user-attachments/assets/34642ebc-09be-4b9a-a362-99b58dfd3138" />


fixes:
https://github.com/UserOfficeProject/issue-tracker/issues/1709
