### PR TITLE
fix: guard visit and feedback read rights against agents without a user id

### DIFF
--- a/apps/backend/src/auth/FeedbackAuthorization.ts
+++ b/apps/backend/src/auth/FeedbackAuthorization.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from 'tsyringe';
 
+import { UserAuthorization } from './UserAuthorization';
 import { Tokens } from '../config/Tokens';
 import { FeedbackDataSource } from '../datasources/FeedbackDataSource';
 import { Feedback } from '../models/Feedback';
 import { UserWithRole } from '../models/User';
 import { VisitDataSource } from './../datasources/VisitDataSource';
-import { UserAuthorization } from './UserAuthorization';
 
 @injectable()
 export class FeedbackAuthorization {
@@ -53,9 +53,13 @@ export class FeedbackAuthorization {
       return true;
     }
 
+    if (this.userAuth.isApiToken(agent)) {
+      return true;
+    }
+
     const feedback = await this.resolveFeedback(feedbackOrFeedbackId);
 
-    if (!feedback) {
+    if (!feedback || !agent.id) {
       return false;
     }
 

--- a/apps/backend/src/auth/VisitAuthorization.ts
+++ b/apps/backend/src/auth/VisitAuthorization.ts
@@ -49,9 +49,13 @@ export class VisitAuthorization {
       return true;
     }
 
+    if (this.userAuth.isApiToken(agent)) {
+      return true;
+    }
+
     const visit = await this.resolveVisit(visitOrVisitId);
 
-    if (!visit) {
+    if (!visit || !agent.id) {
       return false;
     }
 


### PR DESCRIPTION
## Description
This pull request provides a fix to visit and feedback authorizers when used with API token.

## Motivation and Context
Previously, the system did not check for if the request came with API token. Querying the `visit` field of an `experiment` with an API access token failed with a 500:

```
Undefined binding(s) detected when compiling SELECT. Undefined column(s): [visits_has_users.user_id]
```

This is because the authorizer expect `agent` object to have an `user_id`. But API tokens do not have user_id. 
This PR is a patch, similar to what we have in other places

## Changes
The main changes are as follows:
1. Added a condition to check if the agent is an API token, if true, it returns true.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes Jira Issue

[https://jira.ess.eu//browse/SWAP-5747](https://jira.ess.eu//browse/SWAP-5747)

## Depends On

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated