### PR TITLE
fix: exclude instrument table search from instrument scientist assignment lookup

### DIFF
--- a/apps/e2e/cypress/e2e/instruments.cy.ts
+++ b/apps/e2e/cypress/e2e/instruments.cy.ts
@@ -321,6 +321,38 @@ context('Instrument tests', () => {
       });
     });
 
+    it('User Officer should be able to assign scientist to instrument after searching in the instruments table', () => {
+      cy.contains('Instruments').click();
+
+      cy.get('[data-cy="instruments-table"] [placeholder="Search"]').type(
+        instrument1.name
+      );
+
+      cy.url().should('contain', 'search=');
+
+      cy.contains(instrument1.name)
+        .parent()
+        .find('[aria-label="Assign scientist"]')
+        .click();
+
+      cy.get('[data-cy="co-proposers"]')
+        .contains(scientist2.lastName)
+        .should('exist');
+
+      cy.get('[data-cy="co-proposers"]')
+        .contains(scientist2.lastName)
+        .parent()
+        .find('input[type="checkbox"]')
+        .check();
+
+      cy.get('.MuiDialog-root [data-cy="assign-selected-users"]').click();
+
+      cy.notification({
+        variant: 'success',
+        text: 'Scientist assigned to instrument',
+      });
+    });
+
     it('User Officer should be able to see who submitted the technical review', function () {
       if (!featureFlags.getEnabledFeatures().get(FeatureId.TECHNICAL_REVIEW)) {
         this.skip();

--- a/apps/frontend/src/components/user/PeopleTable.tsx
+++ b/apps/frontend/src/components/user/PeopleTable.tsx
@@ -191,6 +191,9 @@ const PeopleTable = ({
   }, [data?.length]);
 
   useEffect(() => {
+    if (!persistUrlQueryParams) {
+      return;
+    }
     tableRef.current && tableRef.current.onQueryChange({});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams.get('search')]);
@@ -279,7 +282,9 @@ const PeopleTable = ({
                 : orderBy?.orderDirection == PaginationSortDirection.DESC
                   ? PaginationSortDirection.DESC
                   : undefined,
-            searchText: searchParams.get('search') ?? tableQuery.search,
+            searchText: persistUrlQueryParams
+              ? searchParams.get('search') ?? tableQuery.search
+              : tableQuery.search,
           })
           .then(({ users }) => {
             const filteredData = data


### PR DESCRIPTION
## Description

The Instruments table persists its search text in the `search` URL query parameter (via `persistUrlQueryParams`). The `PeopleTable` component used inside the 'Assign scientist' modal was reading that same `search` URL query parameter unconditionally (regardless of whether it opted in to `persistUrlQueryParams`), so when a search was active on the Instruments table, the modal used to assign an instrument scientist would filter users by that leftover search text and return 0 users.

This PR makes `PeopleTable` only read the `search` query parameter when it explicitly opts in via `persistUrlQueryParams`, matching the pattern already used by `SuperMaterialTable`.

## Motivation and Context

When trying to assign an instrument scientist to an instrument after having searched in the Instruments table, 0 users were shown in the assignment dialog, making it impossible to assign a scientist without first clearing the instrument search.

## How Has This Been Tested

- Added a new e2e test (`apps/e2e/cypress/e2e/instruments.cy.ts`) that searches the Instruments table, then opens the 'Assign scientist' dialog and asserts users are shown and can be assigned. Verified the test fails without the fix (0 users found) and passes with the fix.
- Ran the full `instruments.cy.ts` spec locally (35/35 passing).

## Fixes

Fixes instrument scientist assignment returning 0 users when the Instruments table has an active search.

## Changes

- `apps/frontend/src/components/user/PeopleTable.tsx`: only read the `search` URL query parameter for the remote user search when `persistUrlQueryParams` is enabled.
- `apps/e2e/cypress/e2e/instruments.cy.ts`: added regression e2e test.

## Depends on

None

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
